### PR TITLE
remove Type(), Route(), GetSignBytes() (removed from sdk.Msg interface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### API Breaking
 
+* (modules/core) [\#161](https://github.com/cosmos/ibc-go/pull/161) Remove Type(), Route(), GetSignBytes() from 02-client, 03-connection, and 04-channel messages.
 * (modules) [\#140](https://github.com/cosmos/ibc-go/pull/140) IsFrozen() client state interface changed to Status(). gRPC `ClientStatus` route added.
 * (modules/core) [\#109](https://github.com/cosmos/ibc-go/pull/109) Remove connection and channel handshake CLI commands.
 * (modules) [\#107](https://github.com/cosmos/ibc-go/pull/107) Modify OnRecvPacket callback to return an acknowledgement which indicates if it is successful or not. Callback state changes are discarded for unsuccessful acknowledgements only. 

--- a/modules/core/02-client/types/msgs.go
+++ b/modules/core/02-client/types/msgs.go
@@ -51,16 +51,6 @@ func NewMsgCreateClient(
 	}, nil
 }
 
-// Route implements sdk.Msg
-func (msg MsgCreateClient) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgCreateClient) Type() string {
-	return TypeMsgCreateClient
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgCreateClient) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
@@ -88,12 +78,6 @@ func (msg MsgCreateClient) ValidateBasic() error {
 		return sdkerrors.Wrap(err, "client type does not meet naming constraints")
 	}
 	return consensusState.ValidateBasic()
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgCreateClient) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners implements sdk.Msg
@@ -132,16 +116,6 @@ func NewMsgUpdateClient(id string, header exported.Header, signer string) (*MsgU
 	}, nil
 }
 
-// Route implements sdk.Msg
-func (msg MsgUpdateClient) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgUpdateClient) Type() string {
-	return TypeMsgUpdateClient
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgUpdateClient) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
@@ -159,12 +133,6 @@ func (msg MsgUpdateClient) ValidateBasic() error {
 		return sdkerrors.Wrap(ErrInvalidClient, "localhost client is only updated on ABCI BeginBlock")
 	}
 	return host.ClientIdentifierValidator(msg.ClientId)
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgUpdateClient) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners implements sdk.Msg
@@ -205,16 +173,6 @@ func NewMsgUpgradeClient(clientID string, clientState exported.ClientState, cons
 	}, nil
 }
 
-// Route implements sdk.Msg
-func (msg MsgUpgradeClient) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgUpgradeClient) Type() string {
-	return TypeMsgUpgradeClient
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgUpgradeClient) ValidateBasic() error {
 	// will not validate client state as committed client may not form a valid client state.
@@ -245,12 +203,6 @@ func (msg MsgUpgradeClient) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
 	}
 	return host.ClientIdentifierValidator(msg.ClientId)
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgUpgradeClient) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners implements sdk.Msg
@@ -289,14 +241,6 @@ func NewMsgSubmitMisbehaviour(clientID string, misbehaviour exported.Misbehaviou
 	}, nil
 }
 
-// Route returns the MsgSubmitClientMisbehaviour's route.
-func (msg MsgSubmitMisbehaviour) Route() string { return host.RouterKey }
-
-// Type returns the MsgSubmitMisbehaviour's type.
-func (msg MsgSubmitMisbehaviour) Type() string {
-	return TypeMsgSubmitMisbehaviour
-}
-
 // ValidateBasic performs basic (non-state-dependant) validation on a MsgSubmitMisbehaviour.
 func (msg MsgSubmitMisbehaviour) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
@@ -319,12 +263,6 @@ func (msg MsgSubmitMisbehaviour) ValidateBasic() error {
 	}
 
 	return host.ClientIdentifierValidator(msg.ClientId)
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgSubmitMisbehaviour) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners returns the single expected signer for a MsgSubmitMisbehaviour.

--- a/modules/core/03-connection/types/events.go
+++ b/modules/core/03-connection/types/events.go
@@ -16,10 +16,10 @@ const (
 
 // IBC connection events vars
 var (
-	EventTypeConnectionOpenInit    = MsgConnectionOpenInit{}.Type()
-	EventTypeConnectionOpenTry     = MsgConnectionOpenTry{}.Type()
-	EventTypeConnectionOpenAck     = MsgConnectionOpenAck{}.Type()
-	EventTypeConnectionOpenConfirm = MsgConnectionOpenConfirm{}.Type()
+	EventTypeConnectionOpenInit    = "connection_open_init"
+	EventTypeConnectionOpenTry     = "connection_open_try"
+	EventTypeConnectionOpenAck     = "connection_open_ack"
+	EventTypeConnectionOpenConfirm = "connection_open_confirm"
 
 	AttributeValueCategory = fmt.Sprintf("%s_%s", host.ModuleName, SubModuleName)
 )

--- a/modules/core/03-connection/types/msgs.go
+++ b/modules/core/03-connection/types/msgs.go
@@ -39,16 +39,6 @@ func NewMsgConnectionOpenInit(
 	}
 }
 
-// Route implements sdk.Msg
-func (msg MsgConnectionOpenInit) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgConnectionOpenInit) Type() string {
-	return "connection_open_init"
-}
-
 // ValidateBasic implements sdk.Msg.
 func (msg MsgConnectionOpenInit) ValidateBasic() error {
 	if err := host.ClientIdentifierValidator(msg.ClientId); err != nil {
@@ -69,12 +59,6 @@ func (msg MsgConnectionOpenInit) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
 	}
 	return msg.Counterparty.ValidateBasic()
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgConnectionOpenInit) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners implements sdk.Msg
@@ -112,16 +96,6 @@ func NewMsgConnectionOpenTry(
 		ConsensusHeight:      consensusHeight,
 		Signer:               signer,
 	}
-}
-
-// Route implements sdk.Msg
-func (msg MsgConnectionOpenTry) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgConnectionOpenTry) Type() string {
-	return "connection_open_try"
 }
 
 // ValidateBasic implements sdk.Msg
@@ -184,12 +158,6 @@ func (msg MsgConnectionOpenTry) UnpackInterfaces(unpacker codectypes.AnyUnpacker
 	return unpacker.UnpackAny(msg.ClientState, new(exported.ClientState))
 }
 
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgConnectionOpenTry) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
-}
-
 // GetSigners implements sdk.Msg
 func (msg MsgConnectionOpenTry) GetSigners() []sdk.AccAddress {
 	accAddr, err := sdk.AccAddressFromBech32(msg.Signer)
@@ -226,16 +194,6 @@ func NewMsgConnectionOpenAck(
 // UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
 func (msg MsgConnectionOpenAck) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
 	return unpacker.UnpackAny(msg.ClientState, new(exported.ClientState))
-}
-
-// Route implements sdk.Msg
-func (msg MsgConnectionOpenAck) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgConnectionOpenAck) Type() string {
-	return "connection_open_ack"
 }
 
 // ValidateBasic implements sdk.Msg
@@ -281,12 +239,6 @@ func (msg MsgConnectionOpenAck) ValidateBasic() error {
 	return nil
 }
 
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgConnectionOpenAck) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
-}
-
 // GetSigners implements sdk.Msg
 func (msg MsgConnectionOpenAck) GetSigners() []sdk.AccAddress {
 	accAddr, err := sdk.AccAddressFromBech32(msg.Signer)
@@ -310,16 +262,6 @@ func NewMsgConnectionOpenConfirm(
 	}
 }
 
-// Route implements sdk.Msg
-func (msg MsgConnectionOpenConfirm) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgConnectionOpenConfirm) Type() string {
-	return "connection_open_confirm"
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgConnectionOpenConfirm) ValidateBasic() error {
 	if !IsValidConnectionID(msg.ConnectionId) {
@@ -336,12 +278,6 @@ func (msg MsgConnectionOpenConfirm) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
 	}
 	return nil
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgConnectionOpenConfirm) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners implements sdk.Msg

--- a/modules/core/04-channel/types/events.go
+++ b/modules/core/04-channel/types/events.go
@@ -14,11 +14,12 @@ const (
 	AttributeCounterpartyPortID    = "counterparty_port_id"
 	AttributeCounterpartyChannelID = "counterparty_channel_id"
 
-	EventTypeSendPacket        = "send_packet"
-	EventTypeRecvPacket        = "recv_packet"
-	EventTypeWriteAck          = "write_acknowledgement"
-	EventTypeAcknowledgePacket = "acknowledge_packet"
-	EventTypeTimeoutPacket     = "timeout_packet"
+	EventTypeSendPacket           = "send_packet"
+	EventTypeRecvPacket           = "recv_packet"
+	EventTypeWriteAck             = "write_acknowledgement"
+	EventTypeAcknowledgePacket    = "acknowledge_packet"
+	EventTypeTimeoutPacket        = "timeout_packet"
+	EventTypeTimeoutPacketOnClose = "timeout_on_close_packet"
 
 	// NOTE: DEPRECATED in favor of AttributeKeyDataHex
 	AttributeKeyData = "packet_data"
@@ -38,12 +39,12 @@ const (
 
 // IBC channel events vars
 var (
-	EventTypeChannelOpenInit     = MsgChannelOpenInit{}.Type()
-	EventTypeChannelOpenTry      = MsgChannelOpenTry{}.Type()
-	EventTypeChannelOpenAck      = MsgChannelOpenAck{}.Type()
-	EventTypeChannelOpenConfirm  = MsgChannelOpenConfirm{}.Type()
-	EventTypeChannelCloseInit    = MsgChannelCloseInit{}.Type()
-	EventTypeChannelCloseConfirm = MsgChannelCloseConfirm{}.Type()
+	EventTypeChannelOpenInit     = "channel_open_init"
+	EventTypeChannelOpenTry      = "channel_open_try"
+	EventTypeChannelOpenAck      = "channel_open_ack"
+	EventTypeChannelOpenConfirm  = "channel_open_confirm"
+	EventTypeChannelCloseInit    = "channel_close_init"
+	EventTypeChannelCloseConfirm = "channel_close_confirm"
 
 	AttributeValueCategory = fmt.Sprintf("%s_%s", host.ModuleName, SubModuleName)
 )

--- a/modules/core/04-channel/types/msgs.go
+++ b/modules/core/04-channel/types/msgs.go
@@ -28,16 +28,6 @@ func NewMsgChannelOpenInit(
 	}
 }
 
-// Route implements sdk.Msg
-func (msg MsgChannelOpenInit) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgChannelOpenInit) Type() string {
-	return "channel_open_init"
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgChannelOpenInit) ValidateBasic() error {
 	if err := host.PortIdentifierValidator(msg.PortId); err != nil {
@@ -57,12 +47,6 @@ func (msg MsgChannelOpenInit) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
 	}
 	return msg.Channel.ValidateBasic()
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgChannelOpenInit) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners implements sdk.Msg
@@ -94,16 +78,6 @@ func NewMsgChannelOpenTry(
 		ProofHeight:         proofHeight,
 		Signer:              signer,
 	}
-}
-
-// Route implements sdk.Msg
-func (msg MsgChannelOpenTry) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgChannelOpenTry) Type() string {
-	return "channel_open_try"
 }
 
 // ValidateBasic implements sdk.Msg
@@ -140,12 +114,6 @@ func (msg MsgChannelOpenTry) ValidateBasic() error {
 	return msg.Channel.ValidateBasic()
 }
 
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgChannelOpenTry) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
-}
-
 // GetSigners implements sdk.Msg
 func (msg MsgChannelOpenTry) GetSigners() []sdk.AccAddress {
 	signer, err := sdk.AccAddressFromBech32(msg.Signer)
@@ -174,16 +142,6 @@ func NewMsgChannelOpenAck(
 	}
 }
 
-// Route implements sdk.Msg
-func (msg MsgChannelOpenAck) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgChannelOpenAck) Type() string {
-	return "channel_open_ack"
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgChannelOpenAck) ValidateBasic() error {
 	if err := host.PortIdentifierValidator(msg.PortId); err != nil {
@@ -206,12 +164,6 @@ func (msg MsgChannelOpenAck) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
 	}
 	return nil
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgChannelOpenAck) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners implements sdk.Msg
@@ -240,16 +192,6 @@ func NewMsgChannelOpenConfirm(
 	}
 }
 
-// Route implements sdk.Msg
-func (msg MsgChannelOpenConfirm) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgChannelOpenConfirm) Type() string {
-	return "channel_open_confirm"
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgChannelOpenConfirm) ValidateBasic() error {
 	if err := host.PortIdentifierValidator(msg.PortId); err != nil {
@@ -269,12 +211,6 @@ func (msg MsgChannelOpenConfirm) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
 	}
 	return nil
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgChannelOpenConfirm) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners implements sdk.Msg
@@ -300,16 +236,6 @@ func NewMsgChannelCloseInit(
 	}
 }
 
-// Route implements sdk.Msg
-func (msg MsgChannelCloseInit) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgChannelCloseInit) Type() string {
-	return "channel_close_init"
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgChannelCloseInit) ValidateBasic() error {
 	if err := host.PortIdentifierValidator(msg.PortId); err != nil {
@@ -323,12 +249,6 @@ func (msg MsgChannelCloseInit) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
 	}
 	return nil
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgChannelCloseInit) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners implements sdk.Msg
@@ -357,16 +277,6 @@ func NewMsgChannelCloseConfirm(
 	}
 }
 
-// Route implements sdk.Msg
-func (msg MsgChannelCloseConfirm) Route() string {
-	return host.RouterKey
-}
-
-// Type implements sdk.Msg
-func (msg MsgChannelCloseConfirm) Type() string {
-	return "channel_close_confirm"
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgChannelCloseConfirm) ValidateBasic() error {
 	if err := host.PortIdentifierValidator(msg.PortId); err != nil {
@@ -386,12 +296,6 @@ func (msg MsgChannelCloseConfirm) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
 	}
 	return nil
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgChannelCloseConfirm) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetSigners implements sdk.Msg
@@ -419,11 +323,6 @@ func NewMsgRecvPacket(
 	}
 }
 
-// Route implements sdk.Msg
-func (msg MsgRecvPacket) Route() string {
-	return host.RouterKey
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgRecvPacket) ValidateBasic() error {
 	if len(msg.ProofCommitment) == 0 {
@@ -437,12 +336,6 @@ func (msg MsgRecvPacket) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
 	}
 	return msg.Packet.ValidateBasic()
-}
-
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgRecvPacket) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
 }
 
 // GetDataSignBytes returns the base64-encoded bytes used for the
@@ -461,11 +354,6 @@ func (msg MsgRecvPacket) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{signer}
 }
 
-// Type implements sdk.Msg
-func (msg MsgRecvPacket) Type() string {
-	return "recv_packet"
-}
-
 var _ sdk.Msg = &MsgTimeout{}
 
 // NewMsgTimeout constructs new MsgTimeout
@@ -481,11 +369,6 @@ func NewMsgTimeout(
 		ProofHeight:      proofHeight,
 		Signer:           signer,
 	}
-}
-
-// Route implements sdk.Msg
-func (msg MsgTimeout) Route() string {
-	return host.RouterKey
 }
 
 // ValidateBasic implements sdk.Msg
@@ -506,12 +389,6 @@ func (msg MsgTimeout) ValidateBasic() error {
 	return msg.Packet.ValidateBasic()
 }
 
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgTimeout) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
-}
-
 // GetSigners implements sdk.Msg
 func (msg MsgTimeout) GetSigners() []sdk.AccAddress {
 	signer, err := sdk.AccAddressFromBech32(msg.Signer)
@@ -519,11 +396,6 @@ func (msg MsgTimeout) GetSigners() []sdk.AccAddress {
 		panic(err)
 	}
 	return []sdk.AccAddress{signer}
-}
-
-// Type implements sdk.Msg
-func (msg MsgTimeout) Type() string {
-	return "timeout_packet"
 }
 
 // NewMsgTimeoutOnClose constructs new MsgTimeoutOnClose
@@ -541,11 +413,6 @@ func NewMsgTimeoutOnClose(
 		ProofHeight:      proofHeight,
 		Signer:           signer,
 	}
-}
-
-// Route implements sdk.Msg
-func (msg MsgTimeoutOnClose) Route() string {
-	return host.RouterKey
 }
 
 // ValidateBasic implements sdk.Msg
@@ -569,12 +436,6 @@ func (msg MsgTimeoutOnClose) ValidateBasic() error {
 	return msg.Packet.ValidateBasic()
 }
 
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgTimeoutOnClose) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
-}
-
 // GetSigners implements sdk.Msg
 func (msg MsgTimeoutOnClose) GetSigners() []sdk.AccAddress {
 	signer, err := sdk.AccAddressFromBech32(msg.Signer)
@@ -582,11 +443,6 @@ func (msg MsgTimeoutOnClose) GetSigners() []sdk.AccAddress {
 		panic(err)
 	}
 	return []sdk.AccAddress{signer}
-}
-
-// Type implements sdk.Msg
-func (msg MsgTimeoutOnClose) Type() string {
-	return "timeout_on_close_packet"
 }
 
 var _ sdk.Msg = &MsgAcknowledgement{}
@@ -608,11 +464,6 @@ func NewMsgAcknowledgement(
 	}
 }
 
-// Route implements sdk.Msg
-func (msg MsgAcknowledgement) Route() string {
-	return host.RouterKey
-}
-
 // ValidateBasic implements sdk.Msg
 func (msg MsgAcknowledgement) ValidateBasic() error {
 	if len(msg.ProofAcked) == 0 {
@@ -631,12 +482,6 @@ func (msg MsgAcknowledgement) ValidateBasic() error {
 	return msg.Packet.ValidateBasic()
 }
 
-// GetSignBytes implements sdk.Msg. The function will panic since it is used
-// for amino transaction verification which IBC does not support.
-func (msg MsgAcknowledgement) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
-}
-
 // GetSigners implements sdk.Msg
 func (msg MsgAcknowledgement) GetSigners() []sdk.AccAddress {
 	signer, err := sdk.AccAddressFromBech32(msg.Signer)
@@ -644,9 +489,4 @@ func (msg MsgAcknowledgement) GetSigners() []sdk.AccAddress {
 		panic(err)
 	}
 	return []sdk.AccAddress{signer}
-}
-
-// Type implements sdk.Msg
-func (msg MsgAcknowledgement) Type() string {
-	return "acknowledge_packet"
 }

--- a/modules/core/04-channel/types/msgs_test.go
+++ b/modules/core/04-channel/types/msgs_test.go
@@ -315,12 +315,6 @@ func (suite *TypesTestSuite) TestMsgChannelCloseConfirmValidateBasic() {
 	}
 }
 
-func (suite *TypesTestSuite) TestMsgRecvPacketType() {
-	msg := types.NewMsgRecvPacket(packet, suite.proof, height, addr)
-
-	suite.Equal("recv_packet", msg.Type())
-}
-
 func (suite *TypesTestSuite) TestMsgRecvPacketValidateBasic() {
 	testCases := []struct {
 		name    string

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -462,7 +462,7 @@ func (k Keeper) RecvPacket(goCtx context.Context, msg *channeltypes.MsgRecvPacke
 
 	defer func() {
 		telemetry.IncrCounterWithLabels(
-			[]string{"tx", "msg", "ibc", msg.Type()},
+			[]string{"tx", "msg", "ibc", channeltypes.EventTypeRecvPacket},
 			1,
 			[]metrics.Label{
 				telemetry.NewLabel("source-port", msg.Packet.SourcePort),
@@ -604,7 +604,7 @@ func (k Keeper) Acknowledgement(goCtx context.Context, msg *channeltypes.MsgAckn
 
 	defer func() {
 		telemetry.IncrCounterWithLabels(
-			[]string{"tx", "msg", "ibc", msg.Type()},
+			[]string{"tx", "msg", "ibc", channeltypes.EventTypeAcknowledgePacket},
 			1,
 			[]metrics.Label{
 				telemetry.NewLabel("source-port", msg.Packet.SourcePort),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

SDK has removed `Type()` `Route()` and `GetSignBytes()` from the Msg interface. Those functions are still needed for the transfer message which supports amino signing. They would be unused for all other message types.

I figure we might as well remove what we can before 1.0.0 since after that we would need to wait for a major version release to remove old APIs

closes: #159 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
