### PR TITLE
fix: correct metric labels

### DIFF
--- a/modules/apps/transfer/keeper/relay.go
+++ b/modules/apps/transfer/keeper/relay.go
@@ -13,6 +13,7 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/modules/core/04-channel/types"
 	host "github.com/cosmos/ibc-go/modules/core/24-host"
+	coretypes "github.com/cosmos/ibc-go/modules/core/types"
 )
 
 // SendTransfer handles transfer sending logic. There are 2 possible cases:
@@ -101,8 +102,8 @@ func (k Keeper) SendTransfer(
 	}
 
 	labels := []metrics.Label{
-		telemetry.NewLabel("destination-port", destinationPort),
-		telemetry.NewLabel("destination-channel", destinationChannel),
+		telemetry.NewLabel(coretypes.LabelDestinationPort, destinationPort),
+		telemetry.NewLabel(coretypes.LabelDestinationChannel, destinationChannel),
 	}
 
 	// NOTE: SendTransfer simply sends the denomination as it exists on its own
@@ -110,7 +111,7 @@ func (k Keeper) SendTransfer(
 	// prefixing as necessary.
 
 	if types.SenderChainIsSource(sourcePort, sourceChannel, fullDenomPath) {
-		labels = append(labels, telemetry.NewLabel("source", "true"))
+		labels = append(labels, telemetry.NewLabel(coretypes.LabelSource, "true"))
 
 		// create the escrow address for the tokens
 		escrowAddress := types.GetEscrowAddress(sourcePort, sourceChannel)
@@ -123,7 +124,7 @@ func (k Keeper) SendTransfer(
 		}
 
 	} else {
-		labels = append(labels, telemetry.NewLabel("source", "false"))
+		labels = append(labels, telemetry.NewLabel(coretypes.LabelSource, "false"))
 
 		// transfer the coins to the module account and burn them
 		if err := k.bankKeeper.SendCoinsFromAccountToModule(
@@ -165,7 +166,7 @@ func (k Keeper) SendTransfer(
 		telemetry.SetGaugeWithLabels(
 			[]string{"tx", "msg", "ibc", "transfer"},
 			float32(token.Amount.Int64()),
-			[]metrics.Label{telemetry.NewLabel("denom", fullDenomPath)},
+			[]metrics.Label{telemetry.NewLabel(coretypes.LabelDenom, fullDenomPath)},
 		)
 
 		telemetry.IncrCounterWithLabels(
@@ -200,8 +201,8 @@ func (k Keeper) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, data t
 	}
 
 	labels := []metrics.Label{
-		telemetry.NewLabel("source-port", packet.GetSourcePort()),
-		telemetry.NewLabel("source-channel", packet.GetSourceChannel()),
+		telemetry.NewLabel(coretypes.LabelSourcePort, packet.GetSourcePort()),
+		telemetry.NewLabel(coretypes.LabelSourceChannel, packet.GetSourceChannel()),
 	}
 
 	// This is the prefix that would have been prefixed to the denomination
@@ -244,14 +245,14 @@ func (k Keeper) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, data t
 			telemetry.SetGaugeWithLabels(
 				[]string{"ibc", types.ModuleName, "packet", "receive"},
 				float32(data.Amount),
-				[]metrics.Label{telemetry.NewLabel("denom", unprefixedDenom)},
+				[]metrics.Label{telemetry.NewLabel(coretypes.LabelDenom, unprefixedDenom)},
 			)
 
 			telemetry.IncrCounterWithLabels(
 				[]string{"ibc", types.ModuleName, "receive"},
 				1,
 				append(
-					labels, telemetry.NewLabel("source", "true"),
+					labels, telemetry.NewLabel(coretypes.LabelSource, "true"),
 				),
 			)
 		}()
@@ -303,14 +304,14 @@ func (k Keeper) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, data t
 		telemetry.SetGaugeWithLabels(
 			[]string{"ibc", types.ModuleName, "packet", "receive"},
 			float32(data.Amount),
-			[]metrics.Label{telemetry.NewLabel("denom", data.Denom)},
+			[]metrics.Label{telemetry.NewLabel(coretypes.LabelDenom, data.Denom)},
 		)
 
 		telemetry.IncrCounterWithLabels(
 			[]string{"ibc", types.ModuleName, "receive"},
 			1,
 			append(
-				labels, telemetry.NewLabel("source", "false"),
+				labels, telemetry.NewLabel(coretypes.LabelSource, "false"),
 			),
 		)
 	}()

--- a/modules/core/02-client/keeper/client.go
+++ b/modules/core/02-client/keeper/client.go
@@ -47,7 +47,7 @@ func (k Keeper) CreateClient(
 		telemetry.IncrCounterWithLabels(
 			[]string{"ibc", "client", "create"},
 			1,
-			[]metrics.Label{telemetry.NewLabel("client-type", clientState.ClientType())},
+			[]metrics.Label{telemetry.NewLabel(types.LabelClientType, clientState.ClientType())},
 		)
 	}()
 
@@ -112,9 +112,9 @@ func (k Keeper) UpdateClient(ctx sdk.Context, clientID string, header exported.H
 				[]string{"ibc", "client", "update"},
 				1,
 				[]metrics.Label{
-					telemetry.NewLabel("client-type", clientState.ClientType()),
-					telemetry.NewLabel("client-id", clientID),
-					telemetry.NewLabel("update-type", "msg"),
+					telemetry.NewLabel(types.LabelClientType, clientState.ClientType()),
+					telemetry.NewLabel(types.LabelClientID, clientID),
+					telemetry.NewLabel(types.LabelUpdateType, "msg"),
 				},
 			)
 		}()
@@ -129,9 +129,9 @@ func (k Keeper) UpdateClient(ctx sdk.Context, clientID string, header exported.H
 				[]string{"ibc", "client", "misbehaviour"},
 				1,
 				[]metrics.Label{
-					telemetry.NewLabel("client-type", clientState.ClientType()),
-					telemetry.NewLabel("client-id", clientID),
-					telemetry.NewLabel("msg-type", "update"),
+					telemetry.NewLabel(types.LabelClientType, clientState.ClientType()),
+					telemetry.NewLabel(types.LabelClientID, clientID),
+					telemetry.NewLabel(types.LabelMsgType, "update"),
 				},
 			)
 		}()
@@ -181,8 +181,8 @@ func (k Keeper) UpgradeClient(ctx sdk.Context, clientID string, upgradedClient e
 			[]string{"ibc", "client", "upgrade"},
 			1,
 			[]metrics.Label{
-				telemetry.NewLabel("client-type", updatedClientState.ClientType()),
-				telemetry.NewLabel("client-id", clientID),
+				telemetry.NewLabel(types.LabelClientType, updatedClientState.ClientType()),
+				telemetry.NewLabel(types.LabelClientID, clientID),
 			},
 		)
 	}()
@@ -231,8 +231,8 @@ func (k Keeper) CheckMisbehaviourAndUpdateState(ctx sdk.Context, misbehaviour ex
 			[]string{"ibc", "client", "misbehaviour"},
 			1,
 			[]metrics.Label{
-				telemetry.NewLabel("client-type", misbehaviour.ClientType()),
-				telemetry.NewLabel("client-id", misbehaviour.GetClientID()),
+				telemetry.NewLabel(types.LabelClientType, misbehaviour.ClientType()),
+				telemetry.NewLabel(types.LabelClientID, misbehaviour.GetClientID()),
 			},
 		)
 	}()

--- a/modules/core/02-client/keeper/proposal.go
+++ b/modules/core/02-client/keeper/proposal.go
@@ -62,9 +62,9 @@ func (k Keeper) ClientUpdateProposal(ctx sdk.Context, p *types.ClientUpdatePropo
 			[]string{"ibc", "client", "update"},
 			1,
 			[]metrics.Label{
-				telemetry.NewLabel("client-type", clientState.ClientType()),
-				telemetry.NewLabel("client-id", p.SubjectClientId),
-				telemetry.NewLabel("update-type", "proposal"),
+				telemetry.NewLabel(types.LabelClientType, clientState.ClientType()),
+				telemetry.NewLabel(types.LabelClientID, p.SubjectClientId),
+				telemetry.NewLabel(types.LabelUpdateType, "proposal"),
 			},
 		)
 	}()

--- a/modules/core/02-client/types/metrics.go
+++ b/modules/core/02-client/types/metrics.go
@@ -1,0 +1,9 @@
+package types
+
+// Prometheus metric labels.
+const (
+	LabelClientType = "client_type"
+	LabelClientID   = "client_id"
+	LabelUpdateType = "update_type"
+	LabelMsgType    = "msg_type"
+)

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosmos/ibc-go/modules/core/04-channel/types"
 	channeltypes "github.com/cosmos/ibc-go/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/modules/core/05-port/types"
+	coretypes "github.com/cosmos/ibc-go/modules/core/types"
 )
 
 var _ clienttypes.MsgServer = Keeper{}
@@ -518,10 +519,10 @@ func (k Keeper) RecvPacket(goCtx context.Context, msg *channeltypes.MsgRecvPacke
 			[]string{"tx", "msg", "ibc", channeltypes.EventTypeRecvPacket},
 			1,
 			[]metrics.Label{
-				telemetry.NewLabel("source-port", msg.Packet.SourcePort),
-				telemetry.NewLabel("source-channel", msg.Packet.SourceChannel),
-				telemetry.NewLabel("destination-port", msg.Packet.DestinationPort),
-				telemetry.NewLabel("destination-channel", msg.Packet.DestinationChannel),
+				telemetry.NewLabel(coretypes.LabelSourcePort, msg.Packet.SourcePort),
+				telemetry.NewLabel(coretypes.LabelSourceChannel, msg.Packet.SourceChannel),
+				telemetry.NewLabel(coretypes.LabelDestinationPort, msg.Packet.DestinationPort),
+				telemetry.NewLabel(coretypes.LabelDestinationChannel, msg.Packet.DestinationChannel),
 			},
 		)
 	}()
@@ -571,11 +572,11 @@ func (k Keeper) Timeout(goCtx context.Context, msg *channeltypes.MsgTimeout) (*c
 			[]string{"ibc", "timeout", "packet"},
 			1,
 			[]metrics.Label{
-				telemetry.NewLabel("source-port", msg.Packet.SourcePort),
-				telemetry.NewLabel("source-channel", msg.Packet.SourceChannel),
-				telemetry.NewLabel("destination-port", msg.Packet.DestinationPort),
-				telemetry.NewLabel("destination-channel", msg.Packet.DestinationChannel),
-				telemetry.NewLabel("timeout-type", "height"),
+				telemetry.NewLabel(coretypes.LabelSourcePort, msg.Packet.SourcePort),
+				telemetry.NewLabel(coretypes.LabelSourceChannel, msg.Packet.SourceChannel),
+				telemetry.NewLabel(coretypes.LabelDestinationPort, msg.Packet.DestinationPort),
+				telemetry.NewLabel(coretypes.LabelDestinationChannel, msg.Packet.DestinationChannel),
+				telemetry.NewLabel(coretypes.LabelTimeoutType, "height"),
 			},
 		)
 	}()
@@ -627,11 +628,11 @@ func (k Keeper) TimeoutOnClose(goCtx context.Context, msg *channeltypes.MsgTimeo
 			[]string{"ibc", "timeout", "packet"},
 			1,
 			[]metrics.Label{
-				telemetry.NewLabel("source-port", msg.Packet.SourcePort),
-				telemetry.NewLabel("source-channel", msg.Packet.SourceChannel),
-				telemetry.NewLabel("destination-port", msg.Packet.DestinationPort),
-				telemetry.NewLabel("destination-channel", msg.Packet.DestinationChannel),
-				telemetry.NewLabel("timeout-type", "channel-closed"),
+				telemetry.NewLabel(coretypes.LabelSourcePort, msg.Packet.SourcePort),
+				telemetry.NewLabel(coretypes.LabelSourceChannel, msg.Packet.SourceChannel),
+				telemetry.NewLabel(coretypes.LabelDestinationPort, msg.Packet.DestinationPort),
+				telemetry.NewLabel(coretypes.LabelDestinationChannel, msg.Packet.DestinationChannel),
+				telemetry.NewLabel(coretypes.LabelTimeoutType, "channel-closed"),
 			},
 		)
 	}()
@@ -676,10 +677,10 @@ func (k Keeper) Acknowledgement(goCtx context.Context, msg *channeltypes.MsgAckn
 			[]string{"tx", "msg", "ibc", channeltypes.EventTypeAcknowledgePacket},
 			1,
 			[]metrics.Label{
-				telemetry.NewLabel("source-port", msg.Packet.SourcePort),
-				telemetry.NewLabel("source-channel", msg.Packet.SourceChannel),
-				telemetry.NewLabel("destination-port", msg.Packet.DestinationPort),
-				telemetry.NewLabel("destination-channel", msg.Packet.DestinationChannel),
+				telemetry.NewLabel(coretypes.LabelSourcePort, msg.Packet.SourcePort),
+				telemetry.NewLabel(coretypes.LabelSourceChannel, msg.Packet.SourceChannel),
+				telemetry.NewLabel(coretypes.LabelDestinationPort, msg.Packet.DestinationPort),
+				telemetry.NewLabel(coretypes.LabelDestinationChannel, msg.Packet.DestinationChannel),
 			},
 		)
 	}()

--- a/modules/core/types/metrics.go
+++ b/modules/core/types/metrics.go
@@ -1,0 +1,12 @@
+package types
+
+// Prometheus metric labels.
+const (
+	LabelSourcePort         = "source_port"
+	LabelSourceChannel      = "source_channel"
+	LabelDestinationPort    = "destination_port"
+	LabelDestinationChannel = "destination_channel"
+	LabelTimeoutType        = "timeout_type"
+	LabelDenom              = "denom"
+	LabelSource             = "source"
+)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Move metric labels to types package and use correct Prometheus format (`s/-/_`).

closes: #222

**This should be included in the next SDK/Gaia point release.**

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
