### PR TITLE
fix: updating port-id & fixing OnChanOpenInit bug

### DIFF
--- a/modules/apps/27-interchain-accounts/keeper/handshake.go
+++ b/modules/apps/27-interchain-accounts/keeper/handshake.go
@@ -40,9 +40,9 @@ func (k Keeper) OnChanOpenInit(
 		return sdkerrors.Wrapf(channeltypes.ErrInvalidChannelVersion, "channel version must be '%s' (%s != %s)", types.Version, version, types.Version)
 	}
 
-	_, found := k.GetActiveChannel(ctx, portID)
+	existingChannelID, found := k.GetActiveChannel(ctx, portID)
 	if found {
-		return sdkerrors.Wrapf(porttypes.ErrInvalidPort, "existing active channel (%s) for portID (%s)", channelID, portID)
+		return sdkerrors.Wrapf(porttypes.ErrInvalidPort, "existing active channel (%s) for portID (%s)", existingChannelID, portID)
 	}
 
 	// Claim channel capability passed back by IBC module

--- a/modules/apps/27-interchain-accounts/keeper/handshake.go
+++ b/modules/apps/27-interchain-accounts/keeper/handshake.go
@@ -39,7 +39,8 @@ func (k Keeper) OnChanOpenInit(
 	if version != types.Version {
 		return sdkerrors.Wrapf(channeltypes.ErrInvalidChannelVersion, "channel version must be '%s' (%s != %s)", types.Version, version, types.Version)
 	}
-	channelID, found := k.GetActiveChannel(ctx, portID)
+
+	_, found := k.GetActiveChannel(ctx, portID)
 	if found {
 		return sdkerrors.Wrapf(porttypes.ErrInvalidPort, "existing active channel (%s) for portID (%s)", channelID, portID)
 	}

--- a/modules/apps/27-interchain-accounts/types/keys.go
+++ b/modules/apps/27-interchain-accounts/types/keys.go
@@ -10,7 +10,7 @@ const (
 	// module supports
 	Version = "ics27-1"
 
-	PortID = "interchain-account"
+	PortID = "ibcaccount"
 
 	StoreKey  = ModuleName
 	RouterKey = ModuleName


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
At present, the hermes relayer is hardcoded to use `ibcaccount` when listening for packets for interchain accounts. For now lets leave it at `ibcaccount` & I'll make a PR to `ibc-rs` to request an update to `interchain-accounts` sometime next week. 

I have also fixed a small bug in the `OnChanOpenInit` function whereby we were overwriting the `channelID` with an empty string when checking for an active channel.  

closes: #317 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
