### PR TITLE
chore: moving stateless GenerateAddress func to types

### DIFF
--- a/modules/apps/27-interchain-accounts/keeper/account.go
+++ b/modules/apps/27-interchain-accounts/keeper/account.go
@@ -4,7 +4,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/tendermint/tendermint/crypto/tmhash"
 
 	"github.com/cosmos/ibc-go/modules/apps/27-interchain-accounts/types"
 	channeltypes "github.com/cosmos/ibc-go/modules/core/04-channel/types"
@@ -45,9 +44,9 @@ func (k Keeper) InitInterchainAccount(ctx sdk.Context, connectionID, counterpart
 
 // Register interchain account if it has not already been created
 func (k Keeper) RegisterInterchainAccount(ctx sdk.Context, portId string) {
-	address := k.GenerateAddress(portId)
-	account := k.accountKeeper.GetAccount(ctx, address)
+	address := types.GenerateAddress(portId)
 
+	account := k.accountKeeper.GetAccount(ctx, address)
 	if account != nil {
 		// account already created, return no-op
 		return
@@ -57,11 +56,10 @@ func (k Keeper) RegisterInterchainAccount(ctx sdk.Context, portId string) {
 		authtypes.NewBaseAccountWithAddress(address),
 		portId,
 	)
+
 	k.accountKeeper.NewAccount(ctx, interchainAccount)
 	k.accountKeeper.SetAccount(ctx, interchainAccount)
 	_ = k.SetInterchainAccountAddress(ctx, portId, interchainAccount.Address)
-
-	return
 }
 
 func (k Keeper) SetInterchainAccountAddress(ctx sdk.Context, portId string, address string) string {
@@ -80,11 +78,6 @@ func (k Keeper) GetInterchainAccountAddress(ctx sdk.Context, portId string) (str
 
 	interchainAccountAddr := string(store.Get(key))
 	return interchainAccountAddr, nil
-}
-
-// Determine account's address that will be created.
-func (k Keeper) GenerateAddress(identifier string) []byte {
-	return tmhash.SumTruncated(append([]byte(identifier)))
 }
 
 func (k Keeper) GetInterchainAccount(ctx sdk.Context, addr sdk.AccAddress) (types.InterchainAccount, error) {

--- a/modules/apps/27-interchain-accounts/types/account.go
+++ b/modules/apps/27-interchain-accounts/types/account.go
@@ -11,6 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/tendermint/tendermint/crypto/tmhash"
 
 	connectiontypes "github.com/cosmos/ibc-go/modules/core/03-connection/types"
 )
@@ -18,6 +19,11 @@ import (
 const (
 	ICAPrefix string = "ics-27"
 )
+
+// GenerateAddress returns a truncated SHA256 hash using the provided port string
+func GenerateAddress(port string) []byte {
+	return tmhash.SumTruncated([]byte(port))
+}
 
 // GeneratePortID generates the portID for a specific owner
 // on the controller chain in the format:


### PR DESCRIPTION

## Description

General housekeeping for interchain-accounts branch

closes: #302 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
