### PR TITLE
chore: interchain accounts cleanup, cli alias

### DIFF
--- a/modules/apps/27-interchain-accounts/client/cli/query.go
+++ b/modules/apps/27-interchain-accounts/client/cli/query.go
@@ -13,6 +13,7 @@ import (
 func GetQueryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "interchain-accounts",
+		Aliases:                    []string{"ica"},
 		Short:                      "Querying commands for the interchain accounts module",
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,

--- a/modules/apps/27-interchain-accounts/genesis.go
+++ b/modules/apps/27-interchain-accounts/genesis.go
@@ -6,12 +6,15 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ibc-go/modules/apps/27-interchain-accounts/keeper"
 	"github.com/cosmos/ibc-go/modules/apps/27-interchain-accounts/types"
+
+	host "github.com/cosmos/ibc-go/modules/core/24-host"
 )
 
+// InitGenesis initializes the interchain accounts application state from a provided genesis state
 func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, state types.GenesisState) {
 	if !keeper.IsBound(ctx, state.PortId) {
-		err := keeper.BindPort(ctx, state.PortId)
-		if err != nil {
+		cap := keeper.BindPort(ctx, state.PortId)
+		if err := keeper.ClaimCapability(ctx, cap, host.PortPath(state.PortId)); err != nil {
 			panic(fmt.Sprintf("could not claim port capability: %v", err))
 		}
 	}


### PR DESCRIPTION

## Description

Some more interchain-accounts code cleanup / housekeeping

- Adding `ica` alias to CLI
- Updating usage of BindPort / ClaimCapability funcs

closes: #281 #289

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
