### PR TITLE
chore: ctrl port connection id validation

### DIFF
--- a/modules/apps/27-interchain-accounts/keeper/handshake_test.go
+++ b/modules/apps/27-interchain-accounts/keeper/handshake_test.go
@@ -75,7 +75,10 @@ func (suite *KeeperTestSuite) TestOnChanOpenInit() {
 		{
 			"invalid connection sequence",
 			func() {
-				path.EndpointA.ChannelConfig.PortID, _ = types.GeneratePortID(TestOwnerAddress, "connection-1", "connection-0")
+				portID, err := types.GeneratePortID(TestOwnerAddress, "connection-1", "connection-0")
+				suite.Require().NoError(err)
+
+				path.EndpointA.ChannelConfig.PortID = portID
 				path.EndpointA.SetChannel(*channel)
 			},
 			false,
@@ -83,7 +86,10 @@ func (suite *KeeperTestSuite) TestOnChanOpenInit() {
 		{
 			"invalid counterparty connection sequence",
 			func() {
-				path.EndpointA.ChannelConfig.PortID, _ = types.GeneratePortID(TestOwnerAddress, "connection-0", "connection-1")
+				portID, err := types.GeneratePortID(TestOwnerAddress, "connection-0", "connection-1")
+				suite.Require().NoError(err)
+
+				path.EndpointA.ChannelConfig.PortID = portID
 				path.EndpointA.SetChannel(*channel)
 			},
 			false,
@@ -210,7 +216,10 @@ func (suite *KeeperTestSuite) TestOnChanOpenTry() {
 		{
 			"invalid connection sequence",
 			func() {
-				channel.Counterparty.PortId, _ = types.GeneratePortID(TestOwnerAddress, "connection-0", "connection-1")
+				portID, err := types.GeneratePortID(TestOwnerAddress, "connection-0", "connection-1")
+				suite.Require().NoError(err)
+
+				channel.Counterparty.PortId = portID
 				path.EndpointB.SetChannel(*channel)
 			},
 			false,
@@ -218,7 +227,10 @@ func (suite *KeeperTestSuite) TestOnChanOpenTry() {
 		{
 			"invalid counterparty connection sequence",
 			func() {
-				channel.Counterparty.PortId, _ = types.GeneratePortID(TestOwnerAddress, "connection-1", "connection-0")
+				portID, err := types.GeneratePortID(TestOwnerAddress, "connection-1", "connection-0")
+				suite.Require().NoError(err)
+
+				channel.Counterparty.PortId = portID
 				path.EndpointB.SetChannel(*channel)
 			},
 			false,
@@ -249,8 +261,11 @@ func (suite *KeeperTestSuite) TestOnChanOpenTry() {
 		{
 			"invalid account address",
 			func() {
+				portID, err := types.GeneratePortID("invalid-owner-addr", "connection-0", "connection-0")
+				suite.Require().NoError(err)
+
+				channel.Counterparty.PortId = portID
 				path.EndpointB.SetChannel(*channel)
-				channel.Counterparty.PortId, _ = types.GeneratePortID("invalid-port-id", "connection-0", "connection-0")
 			},
 			false,
 		},

--- a/modules/apps/27-interchain-accounts/keeper/handshake_test.go
+++ b/modules/apps/27-interchain-accounts/keeper/handshake_test.go
@@ -23,33 +23,86 @@ func (suite *KeeperTestSuite) TestOnChanOpenInit() {
 	}{
 
 		{
-			"success", func() {}, true,
+			"success",
+			func() {
+				path.EndpointA.SetChannel(*channel)
+			},
+			true,
 		},
 		{
-			"invalid order - UNORDERED", func() {
+			"invalid order - UNORDERED",
+			func() {
 				channel.Ordering = channeltypes.UNORDERED
-			}, false,
+			},
+			false,
 		},
 		{
-			"invalid counterparty port ID", func() {
-				channel.Counterparty.PortId = ibctesting.MockPort
-			}, false,
+			"invalid port ID",
+			func() {
+				path.EndpointA.ChannelConfig.PortID = "invalid-port-id"
+			},
+			false,
 		},
 		{
-			"invalid version", func() {
+			"invalid counterparty port ID",
+			func() {
+				channel.Counterparty.PortId = "invalid-port-id"
+			},
+			false,
+		},
+		{
+			"invalid version",
+			func() {
 				channel.Version = "version"
-			}, false,
+			},
+			false,
 		},
 		{
-			"channel is already active", func() {
+			"channel not found",
+			func() {
+				path.EndpointA.ChannelID = "invalid-channel-id"
+			},
+			false,
+		},
+		{
+			"connection not found",
+			func() {
+				channel.ConnectionHops = []string{"invalid-connnection-id"}
+				path.EndpointA.SetChannel(*channel)
+			},
+			false,
+		},
+		{
+			"invalid connection sequence",
+			func() {
+				path.EndpointA.ChannelConfig.PortID, _ = types.GeneratePortID(TestOwnerAddress, "connection-1", "connection-0")
+				path.EndpointA.SetChannel(*channel)
+			},
+			false,
+		},
+		{
+			"invalid counterparty connection sequence",
+			func() {
+				path.EndpointA.ChannelConfig.PortID, _ = types.GeneratePortID(TestOwnerAddress, "connection-0", "connection-1")
+				path.EndpointA.SetChannel(*channel)
+			},
+			false,
+		},
+		{
+			"channel is already active",
+			func() {
 				suite.chainA.GetSimApp().ICAKeeper.SetActiveChannel(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-			}, false,
+			},
+			false,
 		},
 		{
-			"capability already claimed", func() {
+			"capability already claimed",
+			func() {
+				path.EndpointA.SetChannel(*channel)
 				err := suite.chainA.GetSimApp().ScopedICAKeeper.ClaimCapability(suite.chainA.GetContext(), chanCap, host.ChannelCapabilityPath(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID))
 				suite.Require().NoError(err)
-			}, false,
+			},
+			false,
 		},
 	}
 
@@ -97,7 +150,6 @@ func (suite *KeeperTestSuite) TestOnChanOpenInit() {
 	}
 }
 
-// ChainA is controller, ChainB is host chain
 func (suite *KeeperTestSuite) TestOnChanOpenTry() {
 	var (
 		channel             *channeltypes.Channel
@@ -113,33 +165,94 @@ func (suite *KeeperTestSuite) TestOnChanOpenTry() {
 	}{
 
 		{
-			"success", func() {}, true,
+			"success",
+			func() {
+				path.EndpointB.SetChannel(*channel)
+			},
+			true,
 		},
 		{
-			"invalid order - UNORDERED", func() {
+			"invalid order - UNORDERED",
+			func() {
 				channel.Ordering = channeltypes.UNORDERED
-			}, false,
+			},
+			false,
 		},
 		{
-			"invalid version", func() {
+			"invalid port",
+			func() {
+				path.EndpointB.ChannelConfig.PortID = "invalid-port-id"
+			},
+			false,
+		},
+		{
+			"invalid counterparty port",
+			func() {
+				channel.Counterparty.PortId = "invalid-port-id"
+			},
+			false,
+		},
+		{
+			"channel not found",
+			func() {
+				path.EndpointB.ChannelID = "invalid-channel-id"
+			},
+			false,
+		},
+		{
+			"connection not found",
+			func() {
+				channel.ConnectionHops = []string{"invalid-connnection-id"}
+				path.EndpointB.SetChannel(*channel)
+			},
+			false,
+		},
+		{
+			"invalid connection sequence",
+			func() {
+				channel.Counterparty.PortId, _ = types.GeneratePortID(TestOwnerAddress, "connection-0", "connection-1")
+				path.EndpointB.SetChannel(*channel)
+			},
+			false,
+		},
+		{
+			"invalid counterparty connection sequence",
+			func() {
+				channel.Counterparty.PortId, _ = types.GeneratePortID(TestOwnerAddress, "connection-1", "connection-0")
+				path.EndpointB.SetChannel(*channel)
+			},
+			false,
+		},
+		{
+			"invalid version",
+			func() {
 				channel.Version = "version"
-			}, false,
+			},
+			false,
 		},
 		{
-			"invalid counterparty version", func() {
+			"invalid counterparty version",
+			func() {
 				counterpartyVersion = "version"
-			}, false,
+			},
+			false,
 		},
 		{
-			"capability already claimed", func() {
+			"capability already claimed",
+			func() {
+				path.EndpointB.SetChannel(*channel)
 				err := suite.chainB.GetSimApp().ScopedICAKeeper.ClaimCapability(suite.chainB.GetContext(), chanCap, host.ChannelCapabilityPath(path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID))
 				suite.Require().NoError(err)
-			}, false,
+			},
+			false,
 		},
 		{
-			"invalid account address", func() {
-				channel.Counterparty.PortId = "invalid-port-id"
-			}, false,
+			"invalid account address",
+			func() {
+				path.EndpointB.SetChannel(*channel)
+				channel.Counterparty.PortId, _ = types.GeneratePortID("invalid-port-id", "connection-0", "connection-0")
+			},
+			false,
 		},
 	}
 
@@ -154,6 +267,10 @@ func (suite *KeeperTestSuite) TestOnChanOpenTry() {
 
 			err := InitInterchainAccount(path.EndpointA, TestOwnerAddress)
 			suite.Require().NoError(err)
+
+			// set the channel id on host
+			channelSequence := path.EndpointB.Chain.App.GetIBCKeeper().ChannelKeeper.GetNextChannelSequence(path.EndpointB.Chain.GetContext())
+			path.EndpointB.ChannelID = channeltypes.FormatChannelIdentifier(channelSequence)
 
 			// default values
 			counterparty := channeltypes.NewCounterparty(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)

--- a/modules/apps/27-interchain-accounts/keeper/keeper_test.go
+++ b/modules/apps/27-interchain-accounts/keeper/keeper_test.go
@@ -21,7 +21,7 @@ var (
 	// TestOwnerAddress defines a reusable bech32 address for testing purposes
 	TestOwnerAddress = "cosmos17dtl0mjt3t77kpuhg2edqzjpszulwhgzuj9ljs"
 	// TestPortID defines a resuable port identifier for testing purposes
-	TestPortID = fmt.Sprintf("%s-0-0-%s", types.VersionPrefix, TestOwnerAddress)
+	TestPortID = fmt.Sprintf("%s|0|0|%s", types.VersionPrefix, TestOwnerAddress)
 	// TestVersion defines a resuable interchainaccounts version string for testing purposes
 	TestVersion = types.NewAppVersion(types.VersionPrefix, TestAccAddress.String())
 )

--- a/modules/apps/27-interchain-accounts/types/account.go
+++ b/modules/apps/27-interchain-accounts/types/account.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"encoding/json"
-	"fmt"
+	fmt "fmt"
 	"strings"
 
 	crypto "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -23,7 +23,7 @@ func GenerateAddress(moduleAccAddr sdk.AccAddress, portID string) sdk.AccAddress
 
 // ParseAddressFromVersion trims the interchainaccounts version prefix and returns the associated account address
 func ParseAddressFromVersion(version string) string {
-	return strings.TrimPrefix(version, fmt.Sprint(VersionPrefix, Delimiter))
+	return strings.Split(version, Delimiter)[1]
 }
 
 // GeneratePortID generates the portID for a specific owner
@@ -47,7 +47,7 @@ func GeneratePortID(owner, connectionID, counterpartyConnectionID string) (strin
 		return "", sdkerrors.Wrap(err, "invalid counterparty connection identifier")
 	}
 
-	return fmt.Sprintf("%s-%d-%d-%s", VersionPrefix, connectionSeq, counterpartyConnectionSeq, owner), nil
+	return fmt.Sprint(VersionPrefix, Delimiter, connectionSeq, Delimiter, counterpartyConnectionSeq, Delimiter, owner), nil
 }
 
 type InterchainAccountI interface {

--- a/modules/apps/27-interchain-accounts/types/account.go
+++ b/modules/apps/27-interchain-accounts/types/account.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"encoding/json"
-	fmt "fmt"
+	"fmt"
 	"strings"
 
 	crypto "github.com/cosmos/cosmos-sdk/crypto/types"

--- a/modules/apps/27-interchain-accounts/types/account_test.go
+++ b/modules/apps/27-interchain-accounts/types/account_test.go
@@ -69,7 +69,7 @@ func (suite *TypesTestSuite) TestGeneratePortID() {
 		{
 			"success",
 			func() {},
-			fmt.Sprintf("%s-0-0-%s", types.VersionPrefix, TestOwnerAddress),
+			fmt.Sprintf("%s|0|0|%s", types.VersionPrefix, TestOwnerAddress),
 			true,
 		},
 		{
@@ -77,7 +77,7 @@ func (suite *TypesTestSuite) TestGeneratePortID() {
 			func() {
 				path.EndpointA.ConnectionID = "connection-1"
 			},
-			fmt.Sprintf("%s-1-0-%s", types.VersionPrefix, TestOwnerAddress),
+			fmt.Sprintf("%s|1|0|%s", types.VersionPrefix, TestOwnerAddress),
 			true,
 		},
 		{

--- a/modules/apps/27-interchain-accounts/types/expected_keepers.go
+++ b/modules/apps/27-interchain-accounts/types/expected_keepers.go
@@ -31,6 +31,7 @@ type ChannelKeeper interface {
 	SendPacket(ctx sdk.Context, channelCap *capabilitytypes.Capability, packet ibcexported.PacketI) error
 	ChanCloseInit(ctx sdk.Context, portID, channelID string, chanCap *capabilitytypes.Capability) error
 	ChanOpenInit(ctx sdk.Context, order channeltypes.Order, connectionHops []string, portID string, portCap *capabilitytypes.Capability, counterparty channeltypes.Counterparty, version string) (string, *capabilitytypes.Capability, error)
+	CounterpartyHops(ctx sdk.Context, channel channeltypes.Channel) ([]string, bool)
 }
 
 // ClientKeeper defines the expected IBC client keeper

--- a/modules/core/24-host/validate.go
+++ b/modules/core/24-host/validate.go
@@ -25,7 +25,7 @@ var DefaultMaxPortCharacterLength = 128
 // - Alphanumeric
 // - `.`, `_`, `+`, `-`, `#`
 // - `[`, `]`, `<`, `>`
-var IsValidID = regexp.MustCompile(`^[a-zA-Z0-9\.\_\+\-\#\[\]\<\>]+$`).MatchString
+var IsValidID = regexp.MustCompile(`^[a-zA-Z0-9\.\_\+\-\#\|\[\]\<\>]+$`).MatchString
 
 // ICS 024 Identifier and Path Validation Implementation
 //


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Updated controller port id delimiter to match version string delimiter of `|`. Allows cleaner parsing for validation
- Adding connection id validation. Ensures connection ids in controller port id match that of the associated channel
- Addressed some minor nits
    - ParseAddressFromVersion uses `strings.Split()` in favour of `strings.TrimPrefix()`
    - Check self port IDs in channel handshake
    - Update error msg for ordered check and counterparty port (OnChanOpenInit/OnChanOpenTry)

closes: #444 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
