### PR TITLE
chore: update portkey to include port ID

### DIFF
--- a/modules/apps/27-interchain-accounts/genesis.go
+++ b/modules/apps/27-interchain-accounts/genesis.go
@@ -22,7 +22,7 @@ func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, state types.GenesisState
 
 // ExportGenesis exports transfer module's portID into its geneis state
 func ExportGenesis(ctx sdk.Context, keeper keeper.Keeper) *types.GenesisState {
-	portID := keeper.GetPort(ctx)
+	portID := keeper.GetPort(ctx, types.PortID)
 
 	return &types.GenesisState{
 		PortId: portID,

--- a/modules/apps/27-interchain-accounts/keeper/keeper.go
+++ b/modules/apps/27-interchain-accounts/keeper/keeper.go
@@ -97,15 +97,15 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 }
 
 // GetPort returns the portID for the interchain accounts module. Used in ExportGenesis
-func (k Keeper) GetPort(ctx sdk.Context) string {
+func (k Keeper) GetPort(ctx sdk.Context, portID string) string {
 	store := ctx.KVStore(k.storeKey)
-	return string(store.Get([]byte(types.PortKey)))
+	return string(store.Get(types.KeyPort(portID)))
 }
 
 // BindPort stores the provided portID and binds to it, returning the associated capability
 func (k Keeper) BindPort(ctx sdk.Context, portID string) *capabilitytypes.Capability {
 	store := ctx.KVStore(k.storeKey)
-	store.Set([]byte(types.PortKey), []byte(portID))
+	store.Set(types.KeyPort(portID), []byte(portID))
 
 	return k.portKeeper.BindPort(ctx, portID)
 }

--- a/modules/apps/27-interchain-accounts/keeper/keeper_test.go
+++ b/modules/apps/27-interchain-accounts/keeper/keeper_test.go
@@ -110,7 +110,7 @@ func (suite *KeeperTestSuite) TestIsBound() {
 }
 
 func (suite *KeeperTestSuite) TestGetPort() {
-	port := suite.chainA.GetSimApp().ICAKeeper.GetPort(suite.chainA.GetContext())
+	port := suite.chainA.GetSimApp().ICAKeeper.GetPort(suite.chainA.GetContext(), types.PortID)
 	suite.Require().Equal(types.PortID, port)
 }
 

--- a/modules/apps/27-interchain-accounts/types/keys.go
+++ b/modules/apps/27-interchain-accounts/types/keys.go
@@ -48,7 +48,7 @@ func KeyActiveChannel(portID string) []byte {
 	return []byte(fmt.Sprintf("%s/%s", ActiveChannelKeyPrefix, portID))
 }
 
-// KeyOwnerAccount creates and returns a new key used for owner account store operations
+// KeyOwnerAccount creates and returns a new key used for interchain account store operations
 func KeyOwnerAccount(portID string) []byte {
 	return []byte(fmt.Sprintf("%s/%s", OwnerKeyPrefix, portID))
 }

--- a/modules/apps/27-interchain-accounts/types/keys.go
+++ b/modules/apps/27-interchain-accounts/types/keys.go
@@ -28,8 +28,14 @@ const (
 )
 
 var (
-	// PortKey defines the key to store the port ID in store
-	PortKey = []byte{0x01}
+	// ActiveChannelKeyPrefix defines the key prefix used to store active channels
+	ActiveChannelKeyPrefix = "activeChannel"
+
+	// OwnerKeyPrefix defines the key prefix used to store interchain accounts
+	OwnerKeyPrefix = "owner"
+
+	// PortKeyPrefix defines the key prefix used to store ports
+	PortKeyPrefix = "port"
 )
 
 // NewVersion returns a complete version string in the format: VersionPrefix + Delimter + AccAddress
@@ -39,10 +45,15 @@ func NewAppVersion(versionPrefix, accAddr string) string {
 
 // KeyActiveChannel creates and returns a new key used for active channels store operations
 func KeyActiveChannel(portID string) []byte {
-	return []byte(fmt.Sprintf("activeChannel/%s", portID))
+	return []byte(fmt.Sprintf("%s/%s", ActiveChannelKeyPrefix, portID))
 }
 
 // KeyOwnerAccount creates and returns a new key used for owner account store operations
 func KeyOwnerAccount(portID string) []byte {
-	return []byte(fmt.Sprintf("owner/%s", portID))
+	return []byte(fmt.Sprintf("%s/%s", OwnerKeyPrefix, portID))
+}
+
+// KeyPort creates and returns a new key used for port store operations
+func KeyPort(portID string) []byte {
+	return []byte(fmt.Sprintf("%s/%s", PortKeyPrefix, portID))
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Updating port keys to include port ID
- Separate key prefixes to vars

This was required as a precursor to the issue for implementing `InitGenesis` & `ExportGenesis`.
This should allow range queries using a prefix iterator. It's likely that `GetPort` should be replaced by `GetAllPorts` when tackling the GenesisState work.

closes: #451 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
