### PR TITLE
feat: adding InitChannel util function

### DIFF
--- a/modules/apps/27-interchain-accounts/keeper/account.go
+++ b/modules/apps/27-interchain-accounts/keeper/account.go
@@ -56,3 +56,16 @@ func (k Keeper) RegisterInterchainAccount(ctx sdk.Context, accAddr sdk.AccAddres
 	k.accountKeeper.SetAccount(ctx, interchainAccount)
 	k.SetInterchainAccountAddress(ctx, controllerPortID, interchainAccount.Address)
 }
+
+// Opens a new channel on a particular port given a connection
+// This is a helper function to open a new channel
+// in case of a channel closing and the controller chain needs to regain access to an interchain account on the host chain
+func (k Keeper) InitChannel(ctx sdk.Context, portID, connectionID string) error {
+	msg := channeltypes.NewMsgChannelOpenInit(portID, types.VersionPrefix, channeltypes.ORDERED, []string{connectionID}, types.PortID, types.ModuleName)
+	handler := k.msgRouter.Handler(msg)
+	if _, err := handler(ctx, msg); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/modules/apps/27-interchain-accounts/keeper/account_test.go
+++ b/modules/apps/27-interchain-accounts/keeper/account_test.go
@@ -2,6 +2,8 @@ package keeper_test
 
 import (
 	"github.com/cosmos/ibc-go/v2/modules/apps/27-interchain-accounts/types"
+	channeltypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
+	host "github.com/cosmos/ibc-go/v2/modules/core/24-host"
 	ibctesting "github.com/cosmos/ibc-go/v2/testing"
 )
 
@@ -53,7 +55,6 @@ func (suite *KeeperTestSuite) TestInitInterchainAccount() {
 			owner = TestOwnerAddress // must be explicitly changed
 			path = NewICAPath(suite.chainA, suite.chainB)
 			suite.coordinator.SetupConnections(path)
-
 			tc.malleate() // explicitly change fields in channel and testChannel
 
 			err = suite.chainA.GetSimApp().ICAKeeper.InitInterchainAccount(suite.chainA.GetContext(), path.EndpointA.ConnectionID, path.EndpointB.ConnectionID, owner)
@@ -64,6 +65,77 @@ func (suite *KeeperTestSuite) TestInitInterchainAccount() {
 				suite.Require().Error(err)
 			}
 
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestInitChannel() {
+	var (
+		path   *ibctesting.Path
+		portID string
+	)
+
+	testCases := []struct {
+		name     string
+		malleate func()
+		expPass  bool
+	}{
+		{
+			"success", func() {}, true,
+		},
+		{
+			"port is not bound", func() {
+				portID = "invalid-portID"
+			}, false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		suite.Run(tc.name, func() {
+			suite.SetupTest() // reset
+			path = NewICAPath(suite.chainA, suite.chainB)
+			suite.coordinator.SetupConnections(path)
+			portID, _ = types.GeneratePortID(TestOwnerAddress, path.EndpointA.ConnectionID, path.EndpointA.Counterparty.ConnectionID)
+
+			// bind port and claim capability
+			cap := suite.chainA.GetSimApp().ICAKeeper.BindPort(suite.chainA.GetContext(), portID)
+			err := suite.chainA.GetSimApp().ICAKeeper.ClaimCapability(suite.chainA.GetContext(), cap, host.PortPath(portID))
+			suite.Require().NoError(err)
+
+			tc.malleate() // explicitly change fields in channel and testChannel
+
+			// get next channel seq
+			channelSequence := path.EndpointA.Chain.App.GetIBCKeeper().ChannelKeeper.GetNextChannelSequence(path.EndpointA.Chain.GetContext())
+
+			// Init new channel
+			err = suite.chainA.GetSimApp().ICAKeeper.InitChannel(suite.chainA.GetContext(), portID, path.EndpointA.ConnectionID)
+
+			if tc.expPass {
+				suite.Require().NoError(err)
+
+				// finish the channel handshake
+
+				// commit state changes for proof verification
+				path.EndpointA.Chain.App.Commit()
+				path.EndpointA.Chain.NextBlock()
+
+				// update port/channel ids
+				path.EndpointA.ChannelID = channeltypes.FormatChannelIdentifier(channelSequence)
+				path.EndpointA.ChannelConfig.PortID = portID
+
+				// finish channel handshake
+				err = path.EndpointB.ChanOpenTry()
+				suite.Require().NoError(err)
+				err = path.EndpointA.ChanOpenAck()
+				suite.Require().NoError(err)
+				err = path.EndpointB.ChanOpenConfirm()
+				suite.Require().NoError(err)
+
+			} else {
+				suite.Require().Error(err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
Adding a helper function to open a new channel in the case that a channel closes. This is necessary so that a controller chain can regain access to an ICA. 

closes: #509 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
