### PR TITLE
test: adding test for RegisterInterchainAccount & adding check to rel…

### DIFF
--- a/modules/apps/27-interchain-accounts/host/keeper/account.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/account.go
@@ -1,0 +1,26 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/cosmos/ibc-go/v2/modules/apps/27-interchain-accounts/types"
+)
+
+// RegisterInterchainAccount attempts to create a new account using the provided address and stores it in state keyed by the provided port identifier
+// If an account for the provided address already exists this function returns early (no-op)
+func (k Keeper) RegisterInterchainAccount(ctx sdk.Context, accAddr sdk.AccAddress, controllerPortID string) {
+	if acc := k.accountKeeper.GetAccount(ctx, accAddr); acc != nil {
+		return
+	}
+
+	interchainAccount := types.NewInterchainAccount(
+		authtypes.NewBaseAccountWithAddress(accAddr),
+		controllerPortID,
+	)
+
+	k.accountKeeper.NewAccount(ctx, interchainAccount)
+	k.accountKeeper.SetAccount(ctx, interchainAccount)
+
+	k.SetInterchainAccountAddress(ctx, controllerPortID, interchainAccount.Address)
+}

--- a/modules/apps/27-interchain-accounts/host/keeper/account_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/account_test.go
@@ -21,7 +21,7 @@ func (suite *KeeperTestSuite) TestRegisterInterchainAccount() {
 	suite.Require().NoError(err)
 
 	// Get the address of the interchain account stored in state during handshake step
-	storedAddr, found := suite.chainB.GetSimApp().ICAHostKeeper.GetInterchainAccountAddress(suite.chainB.GetContext(), portId)
+	storedAddr, found := suite.chainB.GetSimApp().ICAHostKeeper.GetInterchainAccountAddress(suite.chainB.GetContext(), portID)
 	suite.Require().True(found)
 
 	icaAddr, err := sdk.AccAddressFromBech32(storedAddr)

--- a/modules/apps/27-interchain-accounts/host/keeper/account_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/account_test.go
@@ -1,0 +1,33 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/ibc-go/v2/modules/apps/27-interchain-accounts/types"
+	ibctesting "github.com/cosmos/ibc-go/v2/testing"
+)
+
+func (suite *KeeperTestSuite) TestRegisterInterchainAccount() {
+	suite.SetupTest()
+
+	path := NewICAPath(suite.chainA, suite.chainB)
+	suite.coordinator.SetupConnections(path)
+
+	// InitInterchainAccount
+	err := SetupICAPath(path, TestOwnerAddress)
+	suite.Require().NoError(err)
+
+	portId, err := types.GeneratePortID(TestOwnerAddress, ibctesting.FirstConnectionID, ibctesting.FirstConnectionID)
+	suite.Require().NoError(err)
+
+	// Get the address of the interchain account stored in state during handshake step
+	storedAddr, found := suite.chainB.GetSimApp().ICAHostKeeper.GetInterchainAccountAddress(suite.chainB.GetContext(), portId)
+	suite.Require().True(found)
+
+	icaAddr, err := sdk.AccAddressFromBech32(storedAddr)
+	suite.Require().NoError(err)
+
+	// Check if account is created
+	interchainAccount := suite.chainB.GetSimApp().AccountKeeper.GetAccount(suite.chainB.GetContext(), icaAddr)
+	suite.Require().Equal(interchainAccount.GetAddress().String(), storedAddr)
+}

--- a/modules/apps/27-interchain-accounts/host/keeper/account_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/account_test.go
@@ -17,7 +17,7 @@ func (suite *KeeperTestSuite) TestRegisterInterchainAccount() {
 	err := SetupICAPath(path, TestOwnerAddress)
 	suite.Require().NoError(err)
 
-	portId, err := types.GeneratePortID(TestOwnerAddress, ibctesting.FirstConnectionID, ibctesting.FirstConnectionID)
+	portID, err := types.GeneratePortID(TestOwnerAddress, ibctesting.FirstConnectionID, ibctesting.FirstConnectionID)
 	suite.Require().NoError(err)
 
 	// Get the address of the interchain account stored in state during handshake step

--- a/modules/apps/27-interchain-accounts/host/keeper/handshake_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/handshake_test.go
@@ -168,7 +168,6 @@ func (suite *KeeperTestSuite) TestOnChanOpenTry() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }

--- a/modules/apps/27-interchain-accounts/host/keeper/keeper.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/keeper.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	"github.com/tendermint/tendermint/libs/log"
@@ -57,23 +56,6 @@ func NewKeeper(
 // Logger returns the application logger, scoped to the associated module
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s-%s", host.ModuleName, types.ModuleName))
-}
-
-// RegisterInterchainAccount attempts to create a new account using the provided address and stores it in state keyed by the provided port identifier
-// If an account for the provided address already exists this function returns early (no-op)
-func (k Keeper) RegisterInterchainAccount(ctx sdk.Context, accAddr sdk.AccAddress, controllerPortID string) {
-	if acc := k.accountKeeper.GetAccount(ctx, accAddr); acc != nil {
-		return
-	}
-
-	interchainAccount := types.NewInterchainAccount(
-		authtypes.NewBaseAccountWithAddress(accAddr),
-		controllerPortID,
-	)
-
-	k.accountKeeper.NewAccount(ctx, interchainAccount)
-	k.accountKeeper.SetAccount(ctx, interchainAccount)
-	k.SetInterchainAccountAddress(ctx, controllerPortID, interchainAccount.Address)
 }
 
 // BindPort stores the provided portID and binds to it, returning the associated capability

--- a/modules/apps/27-interchain-accounts/host/keeper/relay_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/relay_test.go
@@ -344,7 +344,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			err := SetupICAPath(path, TestOwnerAddress)
 			suite.Require().NoError(err)
 
-			portId, err := types.GeneratePortID(TestOwnerAddress, ibctesting.FirstConnectionID, ibctesting.FirstConnectionID)
+			portID, err := types.GeneratePortID(TestOwnerAddress, ibctesting.FirstConnectionID, ibctesting.FirstConnectionID)
 			suite.Require().NoError(err)
 
 			// Get the address of the interchain account stored in state during handshake step

--- a/modules/apps/27-interchain-accounts/host/keeper/relay_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/relay_test.go
@@ -348,7 +348,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			suite.Require().NoError(err)
 
 			// Get the address of the interchain account stored in state during handshake step
-			storedAddr, found := suite.chainB.GetSimApp().ICAHostKeeper.GetInterchainAccountAddress(suite.chainB.GetContext(), portId)
+			storedAddr, found := suite.chainB.GetSimApp().ICAHostKeeper.GetInterchainAccountAddress(suite.chainB.GetContext(), portID)
 			suite.Require().True(found)
 
 			icaAddr, err := sdk.AccAddressFromBech32(storedAddr)

--- a/modules/apps/27-interchain-accounts/host/keeper/relay_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/relay_test.go
@@ -344,6 +344,20 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			err := SetupICAPath(path, TestOwnerAddress)
 			suite.Require().NoError(err)
 
+			portId, err := types.GeneratePortID(TestOwnerAddress, ibctesting.FirstConnectionID, ibctesting.FirstConnectionID)
+			suite.Require().NoError(err)
+
+			// Get the address of the interchain account stored in state during handshake step
+			storedAddr, found := suite.chainB.GetSimApp().ICAHostKeeper.GetInterchainAccountAddress(suite.chainB.GetContext(), portId)
+			suite.Require().True(found)
+
+			icaAddr, err := sdk.AccAddressFromBech32(storedAddr)
+			suite.Require().NoError(err)
+
+			// Check if account is created
+			interchainAccount := suite.chainB.GetSimApp().AccountKeeper.GetAccount(suite.chainB.GetContext(), icaAddr)
+			suite.Require().Equal(interchainAccount.GetAddress().String(), storedAddr)
+
 			suite.fundICAWallet(suite.chainB.GetContext(), path.EndpointA.ChannelConfig.PortID, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10000))))
 
 			tc.malleate() // malleate mutates test data


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

@andrey-kuprianov raised an issue earlier noting that when we remove the [following lines](https://github.com/cosmos/ibc-go/blob/interchain-accounts/modules/apps/27-interchain-accounts/host/keeper/keeper.go#L74-L75) from `RegisterInterchainAccount` all of our tests still pass.

```
k.accountKeeper.NewAccount(ctx, interchainAccount)
k.accountKeeper.SetAccount(ctx, interchainAccount)
```

 In order to verify that the interchain account is getting set as we expect (and to remove the false positive from the tests) I have added an explicit test for `RegisterInterchainAccount` and have added a check to `relay_test.go` that will return an error if the account has not been created. 

The issue stems from the fact that we are [funding the interchain account address before executing any messages](https://github.com/cosmos/ibc-go/blob/interchain-accounts/modules/apps/27-interchain-accounts/host/keeper/relay_test.go#L347) (which will create an account with the address of the receiving address) in all of the tests. 

With this update when we remove the accountKeeper lines in `RegisterAccount` the tests will fail, as is expected. 

Additionally, I added back the `account.go` file. If everyone agrees I would much prefer to have this structure as I found it awkward looking for `RegisterInterchainAccount` in `keeper.go`. 


closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
