### PR TITLE
use local clock time as reference time for timeout timestamp if later than consensus state timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [\#383](https://github.com/cosmos/ibc-go/pull/383) Adds helper functions for merging and splitting middleware versions from the underlying app version.
 * (modules/core/05-port) [\#288](https://github.com/cosmos/ibc-go/issues/288) Making the 05-port keeper function IsBound public. The IsBound function checks if the provided portID is already binded to a module.
+* (02-client) [\#568](https://github.com/cosmos/ibc-go/pull/568) In IBC `transfer` cli command use local clock time as reference for relative timestamp timeout if greater than the block timestamp queried from the latest consensus state corresponding to the counterparty channel.
 
 ### Features
 

--- a/modules/apps/transfer/client/cli/tx.go
+++ b/modules/apps/transfer/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -104,8 +105,7 @@ corresponding to the counterparty channel. Any timeout set to 0 is disabled.`),
 							timeoutTimestamp = consensusStateTimestamp + timeoutTimestamp
 						}
 					} else {
-						// rare case: if local clock time is equal to or earlier than Jan 1st, 1970 12:00 AM
-						timeoutTimestamp = consensusStateTimestamp + timeoutTimestamp
+						return errors.New("local clock time is not greater than Jan 1st, 1970 12:00 AM")
 					}
 				}
 			}

--- a/modules/apps/transfer/client/cli/tx.go
+++ b/modules/apps/transfer/client/cli/tx.go
@@ -103,6 +103,7 @@ to the counterparty channel. Any timeout set to 0 is disabled.`),
 							timeoutTimestamp = consensusStateTimestamp + timeoutTimestamp
 						}
 					} else {
+						// rare case: if local clock time is equal to or earlier than Jan 1st, 1970 12:00 AM
 						timeoutTimestamp = consensusStateTimestamp + timeoutTimestamp
 					}
 				}

--- a/modules/apps/transfer/client/cli/tx.go
+++ b/modules/apps/transfer/client/cli/tx.go
@@ -30,9 +30,10 @@ func NewTransferTxCmd() *cobra.Command {
 		Short: "Transfer a fungible token through IBC",
 		Long: strings.TrimSpace(`Transfer a fungible token through IBC. Timeouts can be specified
 as absolute or relative using the "absolute-timeouts" flag. Timeout height can be set by passing in the height string
-in the form {revision}-{height} using the "packet-timeout-height" flag. Relative timeouts are added to
-the block height and block timestamp queried from the latest consensus state corresponding
-to the counterparty channel. Any timeout set to 0 is disabled.`),
+in the form {revision}-{height} using the "packet-timeout-height" flag. Relative timeout height is added to the block
+height queried from the latest consensus state corresponding to the counterparty channel. Relative timeout timestamp 
+is added to the greater value of the local clock time and the block timestamp queried from the latest consensus state 
+corresponding to the counterparty channel. Any timeout set to 0 is disabled.`),
 		Example: fmt.Sprintf("%s tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount]", version.AppName),
 		Args:    cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

In the IBC transfer cli command use the local clock time as reference time to calculate the timeout timestamp on the counter party chain if it is later than the consensus state timestamp of the counter party chain, otherwise still use consensus state timestamp as reference.

closes: #508

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
