### PR TITLE
fix: correctly propagate sdk.Result events to the current ctx

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/keeper/account.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/account.go
@@ -32,9 +32,13 @@ func (k Keeper) InitInterchainAccount(ctx sdk.Context, connectionID, counterpart
 
 	msg := channeltypes.NewMsgChannelOpenInit(portID, icatypes.VersionPrefix, channeltypes.ORDERED, []string{connectionID}, icatypes.PortID, icatypes.ModuleName)
 	handler := k.msgRouter.Handler(msg)
-	if _, err := handler(ctx, msg); err != nil {
+
+	res, err := handler(ctx, msg)
+	if err != nil {
 		return err
 	}
+
+	ctx.EventManager().EmitEvents(res.GetEvents())
 
 	return nil
 }

--- a/modules/apps/27-interchain-accounts/controller/keeper/account.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/account.go
@@ -38,6 +38,7 @@ func (k Keeper) InitInterchainAccount(ctx sdk.Context, connectionID, counterpart
 		return err
 	}
 
+	// NOTE: The sdk msg handler creates a new EventManager, so events must be correctly propagated back to the current context
 	ctx.EventManager().EmitEvents(res.GetEvents())
 
 	return nil

--- a/modules/apps/27-interchain-accounts/host/keeper/relay.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/relay.go
@@ -51,6 +51,7 @@ func (k Keeper) executeTx(ctx sdk.Context, sourcePort, destPort, destChannel str
 		}
 	}
 
+	// NOTE: The context returned by CacheContext() creates a new EventManager, so events must be correctly propagated back to the current context
 	ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 	writeCache()
 
@@ -69,6 +70,7 @@ func (k Keeper) executeMsg(ctx sdk.Context, msg sdk.Msg) error {
 		return err
 	}
 
+	// NOTE: The sdk msg handler creates a new EventManager, so events must be correctly propagated back to the current context
 	ctx.EventManager().EmitEvents(res.GetEvents())
 
 	return nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fixes an issue whereby events would be swallowed into the void due to ignoring of `sdk.Result` fields and more specifically the creation of a new `EventManager` instance within the [`sdk.Msg` router execution](https://github.com/cosmos/cosmos-sdk/blob/v0.44.5/baseapp/msg_service_router.go#L110).

We should also be aware that a new `EventManager` instance is created upon every call to [`ctx.CacheContext`](https://github.com/cosmos/cosmos-sdk/blob/v0.44.5/types/context.go#L258)

Shout out @colin-axner for helping identify the cause of the issue.

I tested the following changes using hermes and the interchain-accounts auth module. Channel handshakes are now correctly picked up by hermes channel workers and completed. 

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
