### PR TITLE
remove CounterpartyHops function, add GetChannelConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (core) [\#629](https://github.com/cosmos/ibc-go/pull/629) Removes the GetProofSpecs from the ClientState interface. This function was previously unused by core IBC.
 * (transfer) [\#517](https://github.com/cosmos/ibc-go/pull/517) Separates the ICS 26 callback functions from `AppModule` into a new type `IBCModule` for ICS 20 transfer.
 * (modules/core/02-client) [\#536](https://github.com/cosmos/ibc-go/pull/536) GetSelfConsensusState return type changed from bool to error.
+* (channel) [\#644](https://github.com/cosmos/ibc-go/pull/644) Removes `CounterpartyHops` function from the ChannelKeeper.
 
 ### State Machine Breaking
 
@@ -52,6 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [\#383](https://github.com/cosmos/ibc-go/pull/383) Adds helper functions for merging and splitting middleware versions from the underlying app version.
 * (modules/core/05-port) [\#288](https://github.com/cosmos/ibc-go/issues/288) Making the 05-port keeper function IsBound public. The IsBound function checks if the provided portID is already binded to a module.
+* (channel) [\#644](https://github.com/cosmos/ibc-go/pull/644) Adds `GetChannelConnection` to the ChannelKeeper. This function returns the connectionID and connection state associated with a channel. 
 
 ### Features
 

--- a/modules/apps/27-interchain-accounts/controller/keeper/handshake.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/handshake.go
@@ -105,24 +105,19 @@ func (k Keeper) OnChanCloseConfirm(
 // validateControllerPortParams asserts the provided connection sequence and counterparty connection sequence
 // match that of the associated connection stored in state
 func (k Keeper) validateControllerPortParams(ctx sdk.Context, channelID, portID string, connectionSeq, counterpartyConnectionSeq uint64) error {
-	channel, found := k.channelKeeper.GetChannel(ctx, portID, channelID)
-	if !found {
-		return sdkerrors.Wrapf(channeltypes.ErrChannelNotFound, "port ID %s channel ID %s", portID, channelID)
-	}
-
-	counterpartyHops, found := k.channelKeeper.CounterpartyHops(ctx, channel)
-	if !found {
-		return sdkerrors.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
-	}
-
-	connSeq, err := connectiontypes.ParseConnectionSequence(channel.ConnectionHops[0])
+	connectionID, connection, err := k.channelKeeper.GetChannelConnection(ctx, portID, channelID)
 	if err != nil {
-		return sdkerrors.Wrapf(err, "failed to parse connection sequence %s", channel.ConnectionHops[0])
+		return err
 	}
 
-	counterpartyConnSeq, err := connectiontypes.ParseConnectionSequence(counterpartyHops[0])
+	connSeq, err := connectiontypes.ParseConnectionSequence(connectionID)
 	if err != nil {
-		return sdkerrors.Wrapf(err, "failed to parse counterparty connection sequence %s", counterpartyHops[0])
+		return sdkerrors.Wrapf(err, "failed to parse connection sequence %s", connectionID)
+	}
+
+	counterpartyConnSeq, err := connectiontypes.ParseConnectionSequence(connection.GetCounterparty().GetConnectionID())
+	if err != nil {
+		return sdkerrors.Wrapf(err, "failed to parse counterparty connection sequence %s", connection.GetCounterparty().GetConnectionID())
 	}
 
 	if connSeq != connectionSeq {

--- a/modules/apps/27-interchain-accounts/host/keeper/handshake.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/handshake.go
@@ -105,24 +105,19 @@ func (k Keeper) OnChanCloseConfirm(
 // validateControllerPortParams asserts the provided connection sequence and counterparty connection sequence
 // match that of the associated connection stored in state
 func (k Keeper) validateControllerPortParams(ctx sdk.Context, channelID, portID string, connectionSeq, counterpartyConnectionSeq uint64) error {
-	channel, found := k.channelKeeper.GetChannel(ctx, portID, channelID)
-	if !found {
-		return sdkerrors.Wrapf(channeltypes.ErrChannelNotFound, "port ID %s channel ID %s", portID, channelID)
-	}
-
-	counterpartyHops, found := k.channelKeeper.CounterpartyHops(ctx, channel)
-	if !found {
-		return sdkerrors.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
-	}
-
-	connSeq, err := connectiontypes.ParseConnectionSequence(channel.ConnectionHops[0])
+	connectionID, connection, err := k.channelKeeper.GetChannelConnection(ctx, portID, channelID)
 	if err != nil {
-		return sdkerrors.Wrapf(err, "failed to parse connection sequence %s", channel.ConnectionHops[0])
+		return err
 	}
 
-	counterpartyConnSeq, err := connectiontypes.ParseConnectionSequence(counterpartyHops[0])
+	connSeq, err := connectiontypes.ParseConnectionSequence(connectionID)
 	if err != nil {
-		return sdkerrors.Wrapf(err, "failed to parse counterparty connection sequence %s", counterpartyHops[0])
+		return sdkerrors.Wrapf(err, "failed to parse connection sequence %s", connectionID)
+	}
+
+	counterpartyConnSeq, err := connectiontypes.ParseConnectionSequence(connection.GetCounterparty().GetConnectionID())
+	if err != nil {
+		return sdkerrors.Wrapf(err, "failed to parse counterparty connection sequence %s", connection.GetCounterparty().GetConnectionID())
 	}
 
 	if connSeq != connectionSeq {

--- a/modules/apps/27-interchain-accounts/types/expected_keepers.go
+++ b/modules/apps/27-interchain-accounts/types/expected_keepers.go
@@ -27,7 +27,7 @@ type ICS4Wrapper interface {
 type ChannelKeeper interface {
 	GetChannel(ctx sdk.Context, srcPort, srcChan string) (channel channeltypes.Channel, found bool)
 	GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool)
-	CounterpartyHops(ctx sdk.Context, channel channeltypes.Channel) ([]string, bool)
+	GetChannelConnection(ctx sdk.Context, portID, channelID string) (string, ibcexported.ConnectionI, error)
 }
 
 // PortKeeper defines the expected IBC port keeper

--- a/modules/core/04-channel/keeper/keeper.go
+++ b/modules/core/04-channel/keeper/keeper.go
@@ -403,6 +403,23 @@ func (k Keeper) GetChannelClientState(ctx sdk.Context, portID, channelID string)
 	return connection.ClientId, clientState, nil
 }
 
+// GetChannelConnection returns the connection ID and state associated with the given port and channel identifier.
+func (k Keeper) GetChannelConnection(ctx sdk.Context, portID, channelID string) (string, exported.ConnectionI, error) {
+	channel, found := k.GetChannel(ctx, portID, channelID)
+	if !found {
+		return "", nil, sdkerrors.Wrapf(types.ErrChannelNotFound, "port-id: %s, channel-id: %s", portID, channelID)
+	}
+
+	connectionID := channel.ConnectionHops[0]
+
+	connection, found := k.connectionKeeper.GetConnection(ctx, connectionID)
+	if !found {
+		return "", nil, sdkerrors.Wrapf(connectiontypes.ErrConnectionNotFound, "connection-id: %s", connectionID)
+	}
+
+	return connectionID, connection, nil
+}
+
 // LookupModuleByChannel will return the IBCModule along with the capability associated with a given channel defined by its portID and channelID
 func (k Keeper) LookupModuleByChannel(ctx sdk.Context, portID, channelID string) (string, *capabilitytypes.Capability, error) {
 	modules, cap, err := k.scopedKeeper.LookupModules(ctx, host.ChannelCapabilityPath(portID, channelID))

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -227,11 +227,7 @@ func (k Keeper) TimeoutOnClose(
 		return sdkerrors.Wrapf(types.ErrInvalidPacket, "packet commitment bytes are not equal: got (%v), expected (%v)", commitment, packetCommitment)
 	}
 
-	counterpartyHops, found := k.CounterpartyHops(ctx, channel)
-	if !found {
-		// Should not reach here, connectionEnd was able to be retrieved above
-		panic("cannot find connection")
-	}
+	counterpartyHops := []string{connectionEnd.GetCounterparty().GetConnectionID()}
 
 	counterparty := types.NewCounterparty(packet.GetSourcePort(), packet.GetSourceChannel())
 	expectedChannel := types.NewChannel(


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

In order complete 640, `ChanOpenTry` needs to remove setting of the channel. This will occur after the application callback in the message server. `CounterpartyHops` takes in the channel as an argument, but this is unnecessary. In general the `CounterpartyHops` function was unnecessary, so I removed it and replaced it with direct calls to the counterparty connection ID. 

ICS27 needs access to both connection IDs and it was using `CounterpartyHops` so I added a function which returns the connection ID and connection state associated with a channel. I'm surprised we didn't have this function before

ref: #640 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
