### PR TITLE
fix: adding connectionID to portID generator fn

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/ibc_module_test.go
+++ b/modules/apps/27-interchain-accounts/controller/ibc_module_test.go
@@ -28,7 +28,7 @@ var (
 	TestOwnerAddress = "cosmos17dtl0mjt3t77kpuhg2edqzjpszulwhgzuj9ljs"
 
 	// TestPortID defines a resuable port identifier for testing purposes
-	TestPortID, _ = icatypes.NewControllerPortID(TestOwnerAddress)
+	TestPortID, _ = icatypes.NewControllerPortID(TestOwnerAddress, ibctesting.FirstConnectionID)
 
 	// TestVersion defines a resuable interchainaccounts version string for testing purposes
 	TestVersion = string(icatypes.ModuleCdc.MustMarshalJSON(&icatypes.Metadata{
@@ -71,7 +71,7 @@ func NewICAPath(chainA, chainB *ibctesting.TestChain) *ibctesting.Path {
 }
 
 func InitInterchainAccount(endpoint *ibctesting.Endpoint, owner string) error {
-	portID, err := icatypes.NewControllerPortID(owner)
+	portID, err := icatypes.NewControllerPortID(owner, ibctesting.FirstConnectionID)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func (suite *InterchainAccountsTestSuite) TestOnChanOpenInit() {
 			suite.coordinator.SetupConnections(path)
 
 			// mock init interchain account
-			portID, err := icatypes.NewControllerPortID(TestOwnerAddress)
+			portID, err := icatypes.NewControllerPortID(TestOwnerAddress, ibctesting.FirstConnectionID)
 			suite.Require().NoError(err)
 
 			portCap := suite.chainA.GetSimApp().IBCKeeper.PortKeeper.BindPort(suite.chainA.GetContext(), portID)

--- a/modules/apps/27-interchain-accounts/controller/keeper/account.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/account.go
@@ -16,7 +16,7 @@ import (
 // already in use. Gaining access to interchain accounts whose channels have closed
 // cannot be done with this function. A regular MsgChanOpenInit must be used.
 func (k Keeper) InitInterchainAccount(ctx sdk.Context, connectionID, owner string) error {
-	portID, err := icatypes.NewControllerPortID(owner)
+	portID, err := icatypes.NewControllerPortID(owner, connectionID)
 	if err != nil {
 		return err
 	}

--- a/modules/apps/27-interchain-accounts/controller/keeper/account_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/account_test.go
@@ -38,7 +38,7 @@ func (suite *KeeperTestSuite) TestInitInterchainAccount() {
 		{
 			"MsgChanOpenInit fails - channel is already active & in state OPEN",
 			func() {
-				portID, err := icatypes.NewControllerPortID(TestOwnerAddress)
+				portID, err := icatypes.NewControllerPortID(TestOwnerAddress, ibctesting.FirstConnectionID)
 				suite.Require().NoError(err)
 
 				suite.chainA.GetSimApp().ICAControllerKeeper.SetActiveChannelID(suite.chainA.GetContext(), portID, path.EndpointA.ChannelID)

--- a/modules/apps/27-interchain-accounts/controller/keeper/handshake_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/handshake_test.go
@@ -136,7 +136,7 @@ func (suite *KeeperTestSuite) TestOnChanOpenInit() {
 			suite.coordinator.SetupConnections(path)
 
 			// mock init interchain account
-			portID, err := icatypes.NewControllerPortID(TestOwnerAddress)
+			portID, err := icatypes.NewControllerPortID(TestOwnerAddress, ibctesting.FirstConnectionID)
 			suite.Require().NoError(err)
 
 			portCap := suite.chainA.GetSimApp().IBCKeeper.PortKeeper.BindPort(suite.chainA.GetContext(), portID)

--- a/modules/apps/27-interchain-accounts/controller/keeper/keeper_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/keeper_test.go
@@ -24,7 +24,7 @@ var (
 	TestOwnerAddress = "cosmos17dtl0mjt3t77kpuhg2edqzjpszulwhgzuj9ljs"
 
 	// TestPortID defines a resuable port identifier for testing purposes
-	TestPortID, _ = icatypes.NewControllerPortID(TestOwnerAddress)
+	TestPortID, _ = icatypes.NewControllerPortID(TestOwnerAddress, ibctesting.FirstConnectionID)
 
 	// TestVersion defines a resuable interchainaccounts version string for testing purposes
 	TestVersion = string(icatypes.ModuleCdc.MustMarshalJSON(&icatypes.Metadata{
@@ -87,7 +87,7 @@ func SetupICAPath(path *ibctesting.Path, owner string) error {
 
 // InitInterchainAccount is a helper function for starting the channel handshake
 func InitInterchainAccount(endpoint *ibctesting.Endpoint, owner string) error {
-	portID, err := icatypes.NewControllerPortID(owner)
+	portID, err := icatypes.NewControllerPortID(owner, ibctesting.FirstConnectionID)
 	if err != nil {
 		return err
 	}

--- a/modules/apps/27-interchain-accounts/host/ibc_module_test.go
+++ b/modules/apps/27-interchain-accounts/host/ibc_module_test.go
@@ -30,7 +30,7 @@ var (
 	TestOwnerAddress = "cosmos17dtl0mjt3t77kpuhg2edqzjpszulwhgzuj9ljs"
 
 	// TestPortID defines a resuable port identifier for testing purposes
-	TestPortID, _ = icatypes.NewControllerPortID(TestOwnerAddress)
+	TestPortID, _ = icatypes.NewControllerPortID(TestOwnerAddress, ibctesting.FirstConnectionID)
 
 	// TestVersion defines a resuable interchainaccounts version string for testing purposes
 	TestVersion = string(icatypes.ModuleCdc.MustMarshalJSON(&icatypes.Metadata{
@@ -73,7 +73,7 @@ func NewICAPath(chainA, chainB *ibctesting.TestChain) *ibctesting.Path {
 }
 
 func InitInterchainAccount(endpoint *ibctesting.Endpoint, owner string) error {
-	portID, err := icatypes.NewControllerPortID(owner)
+	portID, err := icatypes.NewControllerPortID(owner, ibctesting.FirstConnectionID)
 	if err != nil {
 		return err
 	}

--- a/modules/apps/27-interchain-accounts/host/keeper/account_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/account_test.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
+	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 )
 
 func (suite *KeeperTestSuite) TestRegisterInterchainAccount() {
@@ -16,7 +17,7 @@ func (suite *KeeperTestSuite) TestRegisterInterchainAccount() {
 	err := SetupICAPath(path, TestOwnerAddress)
 	suite.Require().NoError(err)
 
-	portID, err := icatypes.NewControllerPortID(TestOwnerAddress)
+	portID, err := icatypes.NewControllerPortID(TestOwnerAddress, ibctesting.FirstConnectionID)
 	suite.Require().NoError(err)
 
 	// Get the address of the interchain account stored in state during handshake step

--- a/modules/apps/27-interchain-accounts/host/keeper/keeper_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/keeper_test.go
@@ -24,7 +24,7 @@ var (
 	TestOwnerAddress = "cosmos17dtl0mjt3t77kpuhg2edqzjpszulwhgzuj9ljs"
 
 	// TestPortID defines a resuable port identifier for testing purposes
-	TestPortID, _ = icatypes.NewControllerPortID(TestOwnerAddress)
+	TestPortID, _ = icatypes.NewControllerPortID(TestOwnerAddress, ibctesting.FirstConnectionID)
 
 	// TestVersion defines a resuable interchainaccounts version string for testing purposes
 	TestVersion = string(icatypes.ModuleCdc.MustMarshalJSON(&icatypes.Metadata{
@@ -87,7 +87,7 @@ func SetupICAPath(path *ibctesting.Path, owner string) error {
 
 // InitInterchainAccount is a helper function for starting the channel handshake
 func InitInterchainAccount(endpoint *ibctesting.Endpoint, owner string) error {
-	portID, err := icatypes.NewControllerPortID(owner)
+	portID, err := icatypes.NewControllerPortID(owner, ibctesting.FirstConnectionID)
 	if err != nil {
 		return err
 	}

--- a/modules/apps/27-interchain-accounts/host/keeper/relay_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/relay_test.go
@@ -395,7 +395,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			err := SetupICAPath(path, TestOwnerAddress)
 			suite.Require().NoError(err)
 
-			portID, err := icatypes.NewControllerPortID(TestOwnerAddress)
+			portID, err := icatypes.NewControllerPortID(TestOwnerAddress, ibctesting.FirstConnectionID)
 			suite.Require().NoError(err)
 
 			// Get the address of the interchain account stored in state during handshake step

--- a/modules/apps/27-interchain-accounts/types/account_test.go
+++ b/modules/apps/27-interchain-accounts/types/account_test.go
@@ -19,7 +19,7 @@ var (
 	TestOwnerAddress = "cosmos17dtl0mjt3t77kpuhg2edqzjpszulwhgzuj9ljs"
 
 	// TestPortID defines a resuable port identifier for testing purposes
-	TestPortID, _ = types.NewControllerPortID(TestOwnerAddress)
+	TestPortID, _ = types.NewControllerPortID(TestOwnerAddress, ibctesting.FirstConnectionID)
 )
 
 type TypesTestSuite struct {

--- a/modules/apps/27-interchain-accounts/types/port.go
+++ b/modules/apps/27-interchain-accounts/types/port.go
@@ -7,11 +7,14 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-// NewControllerPortID creates and returns a new prefixed controller port identifier using the provided owner string
+// NewControllerPortID creates and returns a new prefixed controller port identifier using the provided owner string and a connection sequence
 func NewControllerPortID(owner, connectionSeq string) (string, error) {
 	if strings.TrimSpace(owner) == "" {
 		return "", sdkerrors.Wrap(ErrInvalidAccountAddress, "owner address cannot be empty")
 	}
 
-	return fmt.Sprint(PortPrefix, owner, strings.TrimSpace(connectionSeq)), nil
+	// parse only the connection number from the connection sequence string
+	seq := strings.Split(connectionSeq, "-")[1]
+
+	return fmt.Sprint(PortPrefix, owner, "-", seq), nil
 }

--- a/modules/apps/27-interchain-accounts/types/port.go
+++ b/modules/apps/27-interchain-accounts/types/port.go
@@ -8,10 +8,10 @@ import (
 )
 
 // NewControllerPortID creates and returns a new prefixed controller port identifier using the provided owner string
-func NewControllerPortID(owner string) (string, error) {
+func NewControllerPortID(owner, connectionSeq string) (string, error) {
 	if strings.TrimSpace(owner) == "" {
 		return "", sdkerrors.Wrap(ErrInvalidAccountAddress, "owner address cannot be empty")
 	}
 
-	return fmt.Sprint(PortPrefix, owner), nil
+	return fmt.Sprint(PortPrefix, owner, strings.TrimSpace(connectionSeq)), nil
 }

--- a/modules/apps/27-interchain-accounts/types/port_test.go
+++ b/modules/apps/27-interchain-accounts/types/port_test.go
@@ -22,7 +22,7 @@ func (suite *TypesTestSuite) TestNewControllerPortID() {
 		{
 			"success",
 			func() {},
-			fmt.Sprint(types.PortPrefix, TestOwnerAddress, ibctesting.FirstConnectionID),
+			fmt.Sprint(types.PortPrefix, TestOwnerAddress, "-", 0),
 			true,
 		},
 		{

--- a/modules/apps/27-interchain-accounts/types/port_test.go
+++ b/modules/apps/27-interchain-accounts/types/port_test.go
@@ -22,7 +22,7 @@ func (suite *TypesTestSuite) TestNewControllerPortID() {
 		{
 			"success",
 			func() {},
-			fmt.Sprint(types.PortPrefix, TestOwnerAddress),
+			fmt.Sprint(types.PortPrefix, TestOwnerAddress, ibctesting.FirstConnectionID),
 			true,
 		},
 		{
@@ -45,7 +45,7 @@ func (suite *TypesTestSuite) TestNewControllerPortID() {
 
 			tc.malleate() // malleate mutates test data
 
-			portID, err := types.NewControllerPortID(owner)
+			portID, err := types.NewControllerPortID(owner, ibctesting.FirstConnectionID)
 
 			if tc.expPass {
 				suite.Require().NoError(err, tc.name)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adding the connection sequence to the `NewControllerPortID` helper fn. 

This change makes it possible for the API to be used in a way whereby a dev using `InitInterchainAccount` can use the same owner address for multiple host chains (represented by connection). 
 
Alternatively, we could not make this change and ask the ica-auth module dev to create a unique owner-id per account and manage this whichever way they choose. In that case we simply need to update documentation and provide an example. 

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
