### PR TITLE
fix: remove go mod tidy from proto-gen script

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -32,8 +32,6 @@ buf protoc \
     --doc_out=./docs/ibc \
     --doc_opt=./docs/protodoc-markdown.tmpl,proto-docs.md \
     $(find "$(pwd)/proto" -maxdepth 5 -name '*.proto')
-go mod tidy
-
 
 # move proto files to the right places
 cp -r github.com/cosmos/ibc-go/v*/modules/* modules/


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This has really been annoying me lately. Every time we run 

`make proto-all` or specifically `make proto-gen` 

The `go.mod` file gets screwed up and requires another `make install` before it's usable (I know we'll be running make install most of the time anyway but it bothers me nonetheless). I'm not entirely sure what the root cause is but removing the go mod tidy here relieves us of this problem. 

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
