### PR TITLE
feat: CLIs for total ack and timeout queries

### DIFF
--- a/modules/apps/29-fee/client/cli/query.go
+++ b/modules/apps/29-fee/client/cli/query.go
@@ -19,7 +19,7 @@ func GetCmdTotalRecvFees() *cobra.Command {
 		Short:   "Query the total receive fees for a packet",
 		Long:    "Query the total receive fees for a packet",
 		Args:    cobra.ExactArgs(3),
-		Example: fmt.Sprintf("%s query ibc-fee transfer channel-5 100", version.AppName),
+		Example: fmt.Sprintf("%s query ibc-fee total-recv-fees transfer channel-5 100", version.AppName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
@@ -45,6 +45,98 @@ func GetCmdTotalRecvFees() *cobra.Command {
 			}
 
 			res, err := queryClient.TotalRecvFees(cmd.Context(), req)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdTotalAckFees returns the command handler for the Query/TotalAckFees rpc.
+func GetCmdTotalAckFees() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "total-ack-fees [port-id] [channel-id] [sequence]",
+		Short:   "Query the total acknowledgement fees for a packet",
+		Long:    "Query the total acknowledgement fees for a packet",
+		Args:    cobra.ExactArgs(3),
+		Example: fmt.Sprintf("%s query ibc-fee total-ack-fees transfer channel-5 100", version.AppName),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			portID, channelID := args[0], args[1]
+			seq, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				return err
+			}
+
+			packetID := channeltypes.NewPacketId(channelID, portID, seq)
+
+			if err := packetID.Validate(); err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			req := &types.QueryTotalAckFeesRequest{
+				PacketId: packetID,
+			}
+
+			res, err := queryClient.TotalAckFees(cmd.Context(), req)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdTotalTimeoutFees returns the command handler for the Query/TotalTimeoutFees rpc.
+func GetCmdTotalTimeoutFees() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "total-timeout-fees [port-id] [channel-id] [sequence]",
+		Short:   "Query the total timeout fees for a packet",
+		Long:    "Query the total timeout fees for a packet",
+		Args:    cobra.ExactArgs(3),
+		Example: fmt.Sprintf("%s query ibc-fee total-timeout-fees transfer channel-5 100", version.AppName),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			portID, channelID := args[0], args[1]
+			seq, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				return err
+			}
+
+			packetID := channeltypes.NewPacketId(channelID, portID, seq)
+
+			if err := packetID.Validate(); err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			req := &types.QueryTotalTimeoutFeesRequest{
+				PacketId: packetID,
+			}
+
+			res, err := queryClient.TotalTimeoutFees(cmd.Context(), req)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Adding CLI for query total ack fees
- Adding CLI for query total timeout fees

ref: #871 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
