### PR TITLE
chore: rename checkHeader to VerifyClientMessage

### DIFF
--- a/modules/light-clients/06-solomachine/types/misbehaviour.go
+++ b/modules/light-clients/06-solomachine/types/misbehaviour.go
@@ -22,6 +22,12 @@ func (misbehaviour Misbehaviour) Type() string {
 	return exported.TypeClientMisbehaviour
 }
 
+// TODO: Remove GetHeight() when new interface type ClientMessage is introduced
+// GetHeight implements the exported.Header interface
+func (misbehaviour Misbehaviour) GetHeight() exported.Height {
+	return nil
+}
+
 // ValidateBasic implements Misbehaviour interface.
 func (misbehaviour Misbehaviour) ValidateBasic() error {
 	if err := host.ClientIdentifierValidator(misbehaviour.ClientId); err != nil {

--- a/modules/light-clients/06-solomachine/types/update_test.go
+++ b/modules/light-clients/06-solomachine/types/update_test.go
@@ -180,3 +180,354 @@ func (suite *SoloMachineTestSuite) TestCheckHeaderAndUpdateState() {
 		}
 	}
 }
+
+func (suite *SoloMachineTestSuite) TestVerifyClientMessage() {
+	var (
+		clientState *types.ClientState
+		clientMsg   exported.Header // TODO: Update to ClientMessage interface
+	)
+
+	// test singlesig and multisig public keys
+	for _, solomachine := range []*ibctesting.Solomachine{suite.solomachine, suite.solomachineMulti} {
+
+		testCases := []struct {
+			name    string
+			setup   func()
+			expPass bool
+		}{
+			{
+				"successful header",
+				func() {
+					clientState = solomachine.ClientState()
+					clientMsg = solomachine.CreateHeader()
+				},
+				true,
+			},
+			{
+				"successful misbehaviour",
+				func() {
+					clientState = solomachine.ClientState()
+					clientMsg = solomachine.CreateMisbehaviour()
+				},
+				true,
+			},
+			{
+				"invalid client message type",
+				func() {
+					clientState = solomachine.ClientState()
+					clientMsg = &ibctmtypes.Header{}
+				},
+				false,
+			},
+			{
+				"wrong sequence in header",
+				func() {
+					clientState = solomachine.ClientState()
+					// store in temp before assigning to interface type
+					h := solomachine.CreateHeader()
+					h.Sequence++
+					clientMsg = h
+				},
+				false,
+			},
+			{
+				"invalid header Signature",
+				func() {
+					clientState = solomachine.ClientState()
+					h := solomachine.CreateHeader()
+					h.Signature = suite.GetInvalidProof()
+					clientMsg = h
+				}, false,
+			},
+			{
+				"invalid timestamp in header",
+				func() {
+					clientState = solomachine.ClientState()
+					h := solomachine.CreateHeader()
+					h.Timestamp--
+					clientMsg = h
+				}, false,
+			},
+			{
+				"signature uses wrong sequence",
+				func() {
+					clientState = solomachine.ClientState()
+					solomachine.Sequence++
+					clientMsg = solomachine.CreateHeader()
+				},
+				false,
+			},
+			{
+				"signature uses new pubkey to sign",
+				func() {
+					// store in temp before assinging to interface type
+					cs := solomachine.ClientState()
+					h := solomachine.CreateHeader()
+
+					publicKey, err := codectypes.NewAnyWithValue(solomachine.PublicKey)
+					suite.NoError(err)
+
+					data := &types.HeaderData{
+						NewPubKey:      publicKey,
+						NewDiversifier: h.NewDiversifier,
+					}
+
+					dataBz, err := suite.chainA.Codec.Marshal(data)
+					suite.Require().NoError(err)
+
+					// generate invalid signature
+					signBytes := &types.SignBytes{
+						Sequence:    cs.Sequence,
+						Timestamp:   solomachine.Time,
+						Diversifier: solomachine.Diversifier,
+						DataType:    types.CLIENT,
+						Data:        dataBz,
+					}
+
+					signBz, err := suite.chainA.Codec.Marshal(signBytes)
+					suite.Require().NoError(err)
+
+					sig := solomachine.GenerateSignature(signBz)
+					suite.Require().NoError(err)
+					h.Signature = sig
+
+					clientState = cs
+					clientMsg = h
+
+				},
+				false,
+			},
+			{
+				"signature signs over old pubkey",
+				func() {
+					// store in temp before assinging to interface type
+					cs := solomachine.ClientState()
+					oldPubKey := solomachine.PublicKey
+					h := solomachine.CreateHeader()
+
+					// generate invalid signature
+					data := append(sdk.Uint64ToBigEndian(cs.Sequence), oldPubKey.Bytes()...)
+					sig := solomachine.GenerateSignature(data)
+					h.Signature = sig
+
+					clientState = cs
+					clientMsg = h
+				},
+				false,
+			},
+			{
+				"consensus state public key is nil",
+				func() {
+					cs := solomachine.ClientState()
+					cs.ConsensusState.PublicKey = nil
+					clientState = cs
+					clientMsg = solomachine.CreateHeader()
+				},
+				false,
+			},
+			{
+				"invalid SignatureOne SignatureData",
+				func() {
+					clientState = solomachine.ClientState()
+					m := solomachine.CreateMisbehaviour()
+
+					m.SignatureOne.Signature = suite.GetInvalidProof()
+					clientMsg = m
+				}, false,
+			},
+			{
+				"invalid SignatureTwo SignatureData",
+				func() {
+					clientState = solomachine.ClientState()
+					m := solomachine.CreateMisbehaviour()
+
+					m.SignatureTwo.Signature = suite.GetInvalidProof()
+					clientMsg = m
+				}, false,
+			},
+			{
+				"invalid SignatureOne timestamp",
+				func() {
+					clientState = solomachine.ClientState()
+					m := solomachine.CreateMisbehaviour()
+
+					m.SignatureOne.Timestamp = 1000000000000
+					clientMsg = m
+				}, false,
+			},
+			{
+				"invalid SignatureTwo timestamp",
+				func() {
+					clientState = solomachine.ClientState()
+					m := solomachine.CreateMisbehaviour()
+
+					m.SignatureTwo.Timestamp = 1000000000000
+					clientMsg = m
+				}, false,
+			},
+			{
+				"invalid first signature data",
+				func() {
+					clientState = solomachine.ClientState()
+
+					// store in temp before assigning to interface type
+					m := solomachine.CreateMisbehaviour()
+
+					msg := []byte("DATA ONE")
+					signBytes := &types.SignBytes{
+						Sequence:    solomachine.Sequence + 1,
+						Timestamp:   solomachine.Time,
+						Diversifier: solomachine.Diversifier,
+						DataType:    types.CLIENT,
+						Data:        msg,
+					}
+
+					data, err := suite.chainA.Codec.Marshal(signBytes)
+					suite.Require().NoError(err)
+
+					sig := solomachine.GenerateSignature(data)
+
+					m.SignatureOne.Signature = sig
+					m.SignatureOne.Data = msg
+					clientMsg = m
+				},
+				false,
+			},
+			{
+				"invalid second signature data",
+				func() {
+					clientState = solomachine.ClientState()
+
+					// store in temp before assigning to interface type
+					m := solomachine.CreateMisbehaviour()
+
+					msg := []byte("DATA TWO")
+					signBytes := &types.SignBytes{
+						Sequence:    solomachine.Sequence + 1,
+						Timestamp:   solomachine.Time,
+						Diversifier: solomachine.Diversifier,
+						DataType:    types.CLIENT,
+						Data:        msg,
+					}
+
+					data, err := suite.chainA.Codec.Marshal(signBytes)
+					suite.Require().NoError(err)
+
+					sig := solomachine.GenerateSignature(data)
+
+					m.SignatureTwo.Signature = sig
+					m.SignatureTwo.Data = msg
+					clientMsg = m
+				},
+				false,
+			},
+			{
+				"wrong pubkey generates first signature",
+				func() {
+					clientState = solomachine.ClientState()
+					badMisbehaviour := solomachine.CreateMisbehaviour()
+
+					// update public key to a new one
+					solomachine.CreateHeader()
+					m := solomachine.CreateMisbehaviour()
+
+					// set SignatureOne to use the wrong signature
+					m.SignatureOne = badMisbehaviour.SignatureOne
+					clientMsg = m
+				}, false,
+			},
+			{
+				"wrong pubkey generates second signature",
+				func() {
+					clientState = solomachine.ClientState()
+					badMisbehaviour := solomachine.CreateMisbehaviour()
+
+					// update public key to a new one
+					solomachine.CreateHeader()
+					m := solomachine.CreateMisbehaviour()
+
+					// set SignatureTwo to use the wrong signature
+					m.SignatureTwo = badMisbehaviour.SignatureTwo
+					clientMsg = m
+				}, false,
+			},
+			{
+				"signatures sign over different sequence",
+				func() {
+					clientState = solomachine.ClientState()
+
+					// store in temp before assigning to interface type
+					m := solomachine.CreateMisbehaviour()
+
+					// Signature One
+					msg := []byte("DATA ONE")
+					// sequence used is plus 1
+					signBytes := &types.SignBytes{
+						Sequence:    solomachine.Sequence + 1,
+						Timestamp:   solomachine.Time,
+						Diversifier: solomachine.Diversifier,
+						DataType:    types.CLIENT,
+						Data:        msg,
+					}
+
+					data, err := suite.chainA.Codec.Marshal(signBytes)
+					suite.Require().NoError(err)
+
+					sig := solomachine.GenerateSignature(data)
+
+					m.SignatureOne.Signature = sig
+					m.SignatureOne.Data = msg
+
+					// Signature Two
+					msg = []byte("DATA TWO")
+					// sequence used is minus 1
+
+					signBytes = &types.SignBytes{
+						Sequence:    solomachine.Sequence - 1,
+						Timestamp:   solomachine.Time,
+						Diversifier: solomachine.Diversifier,
+						DataType:    types.CLIENT,
+						Data:        msg,
+					}
+					data, err = suite.chainA.Codec.Marshal(signBytes)
+					suite.Require().NoError(err)
+
+					sig = solomachine.GenerateSignature(data)
+
+					m.SignatureTwo.Signature = sig
+					m.SignatureTwo.Data = msg
+
+					clientMsg = m
+				},
+				false,
+			},
+			{
+				"consensus state pubkey is nil",
+				func() {
+					cs := solomachine.ClientState()
+					cs.ConsensusState.PublicKey = nil
+					clientState = cs
+					clientMsg = solomachine.CreateMisbehaviour()
+				},
+				false,
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+
+			suite.Run(tc.name, func() {
+				// setup test
+				tc.setup()
+
+				err := clientState.VerifyClientMessage(suite.chainA.Codec, clientMsg)
+
+				if tc.expPass {
+					suite.Require().NoError(err)
+				} else {
+					suite.Require().Error(err)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Renames `checkHeader` to `VerifyClientMessage`
- Requires new interface type `ClientMessage` to remove temporary `GetHeight` from 06-solomachine `Misbehaviour`

ref: #878 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
