### PR TITLE
chore: CheckSubstituteAndUpdateState stores client state in lightclients impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 * [\#1186](https://github.com/cosmos/ibc-go/pull/1186/files) Removing `GetRoot` function from ConsensusState interface in `02-client`. `GetRoot` is unused by core IBC. 
 * (modules/core/02-client) [\#1196](https://github.com/cosmos/ibc-go/pull/1196) Adding VerifyClientMessage to ClientState interface. 
+* (modules/core/02-client) [\#1170](https://github.com/cosmos/ibc-go/pull/1170) Updating `ClientUpdateProposal` to set client state in lightclient implementations `CheckSubstituteAndUpdateState` methods.
 
 ### Features
 

--- a/modules/core/02-client/keeper/proposal.go
+++ b/modules/core/02-client/keeper/proposal.go
@@ -53,7 +53,6 @@ func (k Keeper) ClientUpdateProposal(ctx sdk.Context, p *types.ClientUpdatePropo
 	if err != nil {
 		return err
 	}
-	k.SetClientState(ctx, p.SubjectClientId, clientState)
 
 	k.Logger(ctx).Info("client updated after governance proposal passed", "client-id", p.SubjectClientId, "height", clientState.GetLatestHeight().String())
 

--- a/modules/light-clients/06-solomachine/types/proposal_handle.go
+++ b/modules/light-clients/06-solomachine/types/proposal_handle.go
@@ -60,5 +60,7 @@ func (cs ClientState) CheckSubstituteAndUpdateState(
 	clientState.ConsensusState = substituteClientState.ConsensusState
 	clientState.IsFrozen = false
 
+	setClientState(subjectClientStore, cdc, clientState)
+
 	return clientState, nil
 }

--- a/modules/light-clients/06-solomachine/types/proposal_handle_test.go
+++ b/modules/light-clients/06-solomachine/types/proposal_handle_test.go
@@ -1,6 +1,8 @@
 package types_test
 
 import (
+	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
+	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 	"github.com/cosmos/ibc-go/v3/modules/core/exported"
 	"github.com/cosmos/ibc-go/v3/modules/light-clients/06-solomachine/types"
 	ibctmtypes "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
@@ -78,6 +80,10 @@ func (suite *SoloMachineTestSuite) TestCheckSubstituteAndUpdateState() {
 					suite.Require().Equal(substituteClientState.(*types.ClientState).ConsensusState, updatedClient.(*types.ClientState).ConsensusState)
 					suite.Require().Equal(substituteClientState.(*types.ClientState).Sequence, updatedClient.(*types.ClientState).Sequence)
 					suite.Require().Equal(false, updatedClient.(*types.ClientState).IsFrozen)
+
+					// ensure updated client state is set in store
+					bz := subjectClientStore.Get(host.ClientStateKey())
+					suite.Require().Equal(clienttypes.MustMarshalClientState(suite.chainA.Codec, updatedClient), bz)
 				} else {
 					suite.Require().Error(err)
 					suite.Require().Nil(updatedClient)

--- a/modules/light-clients/07-tendermint/types/proposal_handle.go
+++ b/modules/light-clients/07-tendermint/types/proposal_handle.go
@@ -87,6 +87,7 @@ func (cs ClientState) CheckSubstituteAndUpdateState(
 
 	// no validation is necessary since the substitute is verified to be Active
 	// in 02-client.
+	setClientState(subjectClientStore, cdc, &cs)
 
 	return &cs, nil
 }

--- a/modules/light-clients/07-tendermint/types/proposal_handle_test.go
+++ b/modules/light-clients/07-tendermint/types/proposal_handle_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
+	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 	"github.com/cosmos/ibc-go/v3/modules/core/exported"
 	"github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
@@ -299,6 +300,10 @@ func (suite *TendermintTestSuite) TestCheckSubstituteAndUpdateState() {
 				suite.Require().Equal(expectedIterationKey, subjectIterationKey)
 
 				suite.Require().Equal(newChainID, updatedClient.(*types.ClientState).ChainId)
+
+				// ensure updated client state is set in store
+				bz := subjectClientStore.Get(host.ClientStateKey())
+				suite.Require().Equal(clienttypes.MustMarshalClientState(suite.chainA.Codec, updatedClient), bz)
 			} else {
 				suite.Require().Error(err)
 				suite.Require().Nil(updatedClient)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Set ClientState in store within `CheckSubstituteAndUpdateState`

closes: #599 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
