### PR TITLE
add validation of packet ID in CLI to query packet

### DIFF
--- a/modules/apps/29-fee/client/cli/query.go
+++ b/modules/apps/29-fee/client/cli/query.go
@@ -20,22 +20,23 @@ func GetCmdIncentivizedPacket() *cobra.Command {
 		Short:   "Query for an unrelayed incentivized packet by port-id, channel-id and packet sequence.",
 		Long:    "Query for an unrelayed incentivized packet by port-id, channel-id and packet sequence.",
 		Args:    cobra.ExactArgs(3),
-		Example: fmt.Sprintf("%s query ibc-fee packet-by-id", version.AppName),
+		Example: fmt.Sprintf("%s query ibc-fee packet", version.AppName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
 
+			portID, channelID := args[0], args[1]
 			seq, err := strconv.ParseUint(args[2], 10, 64)
 			if err != nil {
 				return err
 			}
 
-			packetID := channeltypes.PacketId{
-				PortId:    args[0],
-				ChannelId: args[1],
-				Sequence:  seq,
+			packetID := channeltypes.NewPacketId(portID, channelID, seq)
+
+			if err := packetID.Validate(); err != nil {
+				return err
 			}
 
 			req := &types.QueryIncentivizedPacketRequest{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Just to make it consistent with other queries that validate the packet ID (and thus return an error if sequence is 0).

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
