### PR TITLE
fumpt carlos upgrade branch

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/ibc_module_test.go
+++ b/modules/apps/27-interchain-accounts/controller/ibc_module_test.go
@@ -119,9 +119,7 @@ func SetupICAPath(path *ibctesting.Path, owner string) error {
 }
 
 func (suite *InterchainAccountsTestSuite) TestOnChanOpenInit() {
-	var (
-		channel *channeltypes.Channel
-	)
+	var channel *channeltypes.Channel
 
 	testCases := []struct {
 		name     string
@@ -259,9 +257,7 @@ func (suite *InterchainAccountsTestSuite) TestChanOpenTry() {
 }
 
 func (suite *InterchainAccountsTestSuite) TestOnChanOpenAck() {
-	var (
-		path *ibctesting.Path
-	)
+	var path *ibctesting.Path
 
 	testCases := []struct {
 		name     string
@@ -322,10 +318,8 @@ func (suite *InterchainAccountsTestSuite) TestOnChanOpenAck() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
-
 }
 
 // Test initiating a ChanOpenConfirm using the controller chain instead of the host chain
@@ -375,7 +369,6 @@ func (suite *InterchainAccountsTestSuite) TestChanOpenConfirm() {
 		suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID,
 	)
 	suite.Require().Error(err)
-
 }
 
 // OnChanCloseInit on controller (chainA)
@@ -400,16 +393,13 @@ func (suite *InterchainAccountsTestSuite) TestOnChanCloseInit() {
 }
 
 func (suite *InterchainAccountsTestSuite) TestOnChanCloseConfirm() {
-	var (
-		path *ibctesting.Path
-	)
+	var path *ibctesting.Path
 
 	testCases := []struct {
 		name     string
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success", func() {}, true,
 		},
@@ -440,13 +430,11 @@ func (suite *InterchainAccountsTestSuite) TestOnChanCloseConfirm() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }
 
 func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
-
 	testCases := []struct {
 		name     string
 		malleate func()
@@ -495,9 +483,7 @@ func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 }
 
 func (suite *InterchainAccountsTestSuite) TestOnAcknowledgementPacket() {
-	var (
-		path *ibctesting.Path
-	)
+	var path *ibctesting.Path
 
 	testCases := []struct {
 		msg      string
@@ -566,9 +552,7 @@ func (suite *InterchainAccountsTestSuite) TestOnAcknowledgementPacket() {
 }
 
 func (suite *InterchainAccountsTestSuite) TestOnTimeoutPacket() {
-	var (
-		path *ibctesting.Path
-	)
+	var path *ibctesting.Path
 
 	testCases := []struct {
 		msg      string

--- a/modules/apps/27-interchain-accounts/controller/keeper/genesis_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/genesis_test.go
@@ -41,7 +41,6 @@ func (suite *KeeperTestSuite) TestInitGenesis() {
 	expParams := types.NewParams(false)
 	params := suite.chainA.GetSimApp().ICAControllerKeeper.GetParams(suite.chainA.GetContext())
 	suite.Require().Equal(expParams, params)
-
 }
 
 func (suite *KeeperTestSuite) TestExportGenesis() {

--- a/modules/apps/27-interchain-accounts/controller/keeper/handshake.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/handshake.go
@@ -119,6 +119,5 @@ func (k Keeper) OnChanCloseConfirm(
 	portID,
 	channelID string,
 ) error {
-
 	return nil
 }

--- a/modules/apps/27-interchain-accounts/controller/keeper/handshake_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/handshake_test.go
@@ -22,7 +22,6 @@ func (suite *KeeperTestSuite) TestOnChanOpenInit() {
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success",
 			func() {
@@ -242,7 +241,6 @@ func (suite *KeeperTestSuite) TestOnChanOpenInit() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }
@@ -402,16 +400,13 @@ func (suite *KeeperTestSuite) TestOnChanOpenAck() {
 }
 
 func (suite *KeeperTestSuite) TestOnChanCloseConfirm() {
-	var (
-		path *ibctesting.Path
-	)
+	var path *ibctesting.Path
 
 	testCases := []struct {
 		name     string
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success", func() {}, true,
 		},
@@ -441,7 +436,6 @@ func (suite *KeeperTestSuite) TestOnChanCloseConfirm() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }

--- a/modules/apps/27-interchain-accounts/controller/keeper/keeper.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/keeper.go
@@ -40,7 +40,6 @@ func NewKeeper(
 	ics4Wrapper icatypes.ICS4Wrapper, channelKeeper icatypes.ChannelKeeper, portKeeper icatypes.PortKeeper,
 	scopedKeeper capabilitykeeper.ScopedKeeper, msgRouter *authmiddleware.MsgServiceRouter,
 ) Keeper {
-
 	// set KeyTable if it has not already been set
 	if !paramSpace.HasKeyTable() {
 		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())

--- a/modules/apps/27-interchain-accounts/controller/keeper/relay_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/relay_test.go
@@ -183,9 +183,7 @@ func (suite *KeeperTestSuite) TestSendTx() {
 }
 
 func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
-	var (
-		path *ibctesting.Path
-	)
+	var path *ibctesting.Path
 
 	testCases := []struct {
 		msg      string

--- a/modules/apps/27-interchain-accounts/controller/types/params.go
+++ b/modules/apps/27-interchain-accounts/controller/types/params.go
@@ -11,10 +11,8 @@ const (
 	DefaultControllerEnabled = true
 )
 
-var (
-	// KeyControllerEnabled is the store key for ControllerEnabled Params
-	KeyControllerEnabled = []byte("ControllerEnabled")
-)
+// KeyControllerEnabled is the store key for ControllerEnabled Params
+var KeyControllerEnabled = []byte("ControllerEnabled")
 
 // ParamKeyTable type declaration for parameters
 func ParamKeyTable() paramtypes.KeyTable {

--- a/modules/apps/27-interchain-accounts/host/ibc_module_test.go
+++ b/modules/apps/27-interchain-accounts/host/ibc_module_test.go
@@ -167,7 +167,6 @@ func (suite *InterchainAccountsTestSuite) TestOnChanOpenTry() {
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success", func() {}, true,
 		},
@@ -185,7 +184,6 @@ func (suite *InterchainAccountsTestSuite) TestOnChanOpenTry() {
 				) (string, error) {
 					return "", fmt.Errorf("mock ica auth fails")
 				}
-
 			}, true,
 		},
 		{
@@ -242,10 +240,8 @@ func (suite *InterchainAccountsTestSuite) TestOnChanOpenTry() {
 				suite.Require().Error(err)
 				suite.Require().Equal("", version)
 			}
-
 		})
 	}
-
 }
 
 // Test initiating a ChanOpenAck using the host chain instead of the controller chain
@@ -288,7 +284,6 @@ func (suite *InterchainAccountsTestSuite) TestOnChanOpenConfirm() {
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success", func() {}, true,
 		},
@@ -305,7 +300,6 @@ func (suite *InterchainAccountsTestSuite) TestOnChanOpenConfirm() {
 				) error {
 					return fmt.Errorf("mock ica auth fails")
 				}
-
 			}, true,
 		},
 	}
@@ -342,10 +336,8 @@ func (suite *InterchainAccountsTestSuite) TestOnChanOpenConfirm() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
-
 }
 
 // OnChanCloseInit on host (chainB)
@@ -370,16 +362,13 @@ func (suite *InterchainAccountsTestSuite) TestOnChanCloseInit() {
 }
 
 func (suite *InterchainAccountsTestSuite) TestOnChanCloseConfirm() {
-	var (
-		path *ibctesting.Path
-	)
+	var path *ibctesting.Path
 
 	testCases := []struct {
 		name     string
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success", func() {}, true,
 		},
@@ -410,15 +399,12 @@ func (suite *InterchainAccountsTestSuite) TestOnChanCloseConfirm() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }
 
 func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
-	var (
-		packetData []byte
-	)
+	var packetData []byte
 	testCases := []struct {
 		name          string
 		malleate      func()
@@ -517,14 +503,11 @@ func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 			} else {
 				suite.Require().False(ack.Success())
 			}
-
 		})
 	}
-
 }
 
 func (suite *InterchainAccountsTestSuite) TestOnAcknowledgementPacket() {
-
 	testCases := []struct {
 		name     string
 		malleate func()
@@ -578,7 +561,6 @@ func (suite *InterchainAccountsTestSuite) TestOnAcknowledgementPacket() {
 }
 
 func (suite *InterchainAccountsTestSuite) TestOnTimeoutPacket() {
-
 	testCases := []struct {
 		name     string
 		malleate func()

--- a/modules/apps/27-interchain-accounts/host/keeper/account_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/account_test.go
@@ -13,7 +13,7 @@ func (suite *KeeperTestSuite) TestRegisterInterchainAccount() {
 	path := NewICAPath(suite.chainA, suite.chainB)
 	suite.coordinator.SetupConnections(path)
 
-	//RegisterInterchainAccount 
+	// RegisterInterchainAccount
 	err := SetupICAPath(path, TestOwnerAddress)
 	suite.Require().NoError(err)
 

--- a/modules/apps/27-interchain-accounts/host/keeper/events.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/events.go
@@ -2,9 +2,9 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	
-	"github.com/cosmos/ibc-go/v3/modules/core/exported"
+
 	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
+	"github.com/cosmos/ibc-go/v3/modules/core/exported"
 )
 
 // EmitWriteErrorAcknowledgementEvent emits an event signalling an error acknowledgement and including the error details

--- a/modules/apps/27-interchain-accounts/host/keeper/handshake.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/handshake.go
@@ -110,6 +110,5 @@ func (k Keeper) OnChanCloseConfirm(
 	portID,
 	channelID string,
 ) error {
-
 	return nil
 }

--- a/modules/apps/27-interchain-accounts/host/keeper/handshake_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/handshake_test.go
@@ -22,7 +22,6 @@ func (suite *KeeperTestSuite) TestOnChanOpenTry() {
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success",
 			func() {
@@ -228,16 +227,13 @@ func (suite *KeeperTestSuite) TestOnChanOpenTry() {
 }
 
 func (suite *KeeperTestSuite) TestOnChanOpenConfirm() {
-	var (
-		path *ibctesting.Path
-	)
+	var path *ibctesting.Path
 
 	testCases := []struct {
 		name     string
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success", func() {}, true,
 		},
@@ -279,22 +275,18 @@ func (suite *KeeperTestSuite) TestOnChanOpenConfirm() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) TestOnChanCloseConfirm() {
-	var (
-		path *ibctesting.Path
-	)
+	var path *ibctesting.Path
 
 	testCases := []struct {
 		name     string
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success", func() {}, true,
 		},
@@ -320,7 +312,6 @@ func (suite *KeeperTestSuite) TestOnChanCloseConfirm() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }

--- a/modules/apps/27-interchain-accounts/host/keeper/keeper.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/keeper.go
@@ -5,13 +5,13 @@ import (
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authmiddleware "github.com/cosmos/cosmos-sdk/x/auth/middleware"
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/tendermint/tendermint/libs/log"
-	authmiddleware "github.com/cosmos/cosmos-sdk/x/auth/middleware"
 
 	"github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types"
 	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
@@ -40,7 +40,6 @@ func NewKeeper(
 	channelKeeper icatypes.ChannelKeeper, portKeeper icatypes.PortKeeper,
 	accountKeeper icatypes.AccountKeeper, scopedKeeper capabilitykeeper.ScopedKeeper, msgRouter *authmiddleware.MsgServiceRouter,
 ) Keeper {
-
 	// ensure ibc interchain accounts module account is set
 	if addr := accountKeeper.GetModuleAddress(icatypes.ModuleName); addr == nil {
 		panic("the Interchain Accounts module account has not been set")

--- a/modules/apps/27-interchain-accounts/module_test.go
+++ b/modules/apps/27-interchain-accounts/module_test.go
@@ -125,8 +125,6 @@ func (suite *InterchainAccountsTestSuite) TestInitModule() {
 
 				suite.Require().True(app.IBCKeeper.PortKeeper.IsBound(ctx, types.PortID))
 			}
-
 		})
 	}
-
 }

--- a/modules/apps/27-interchain-accounts/types/account.go
+++ b/modules/apps/27-interchain-accounts/types/account.go
@@ -106,7 +106,6 @@ func (ia InterchainAccount) MarshalYAML() ([]byte, error) {
 		Sequence:      ia.Sequence,
 		AccountOwner:  ia.AccountOwner,
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +127,6 @@ func (ia InterchainAccount) MarshalJSON() ([]byte, error) {
 		Sequence:      ia.Sequence,
 		AccountOwner:  ia.AccountOwner,
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/modules/apps/27-interchain-accounts/types/account.pb.go
+++ b/modules/apps/27-interchain-accounts/types/account.pb.go
@@ -5,10 +5,10 @@ package types
 
 import (
 	fmt "fmt"
+	_ "github.com/cosmos/cosmos-proto"
 	types "github.com/cosmos/cosmos-sdk/x/auth/types"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
-	_ "github.com/cosmos/cosmos-proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"

--- a/modules/apps/27-interchain-accounts/types/codec.go
+++ b/modules/apps/27-interchain-accounts/types/codec.go
@@ -8,14 +8,12 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
-var (
-	// ModuleCdc references the global interchain accounts module codec. Note, the codec
-	// should ONLY be used in certain instances of tests and for JSON encoding.
-	//
-	// The actual codec used for serialization should be provided to interchain accounts and
-	// defined at the application level.
-	ModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
-)
+// ModuleCdc references the global interchain accounts module codec. Note, the codec
+// should ONLY be used in certain instances of tests and for JSON encoding.
+//
+// The actual codec used for serialization should be provided to interchain accounts and
+// defined at the application level.
+var ModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
 
 // RegisterInterfaces registers the concrete InterchainAccount implementation against the associated
 // x/auth AccountI and GenesisAccount interfaces

--- a/modules/apps/27-interchain-accounts/types/codec_test.go
+++ b/modules/apps/27-interchain-accounts/types/codec_test.go
@@ -148,5 +148,4 @@ func (suite *TypesTestSuite) TestDeserializeAndSerializeCosmosTxWithAmino() {
 	bz, err := types.DeserializeCosmosTx(marshaler, []byte{0x10, 0})
 	suite.Require().Error(err)
 	suite.Require().Empty(bz)
-
 }

--- a/modules/apps/27-interchain-accounts/types/genesis_test.go
+++ b/modules/apps/27-interchain-accounts/types/genesis_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 func (suite *TypesTestSuite) TestValidateGenesisState() {
-	var (
-		genesisState types.GenesisState
-	)
+	var genesisState types.GenesisState
 
 	testCases := []struct {
 		name     string
@@ -63,9 +61,7 @@ func (suite *TypesTestSuite) TestValidateGenesisState() {
 }
 
 func (suite *TypesTestSuite) TestValidateControllerGenesisState() {
-	var (
-		genesisState types.ControllerGenesisState
-	)
+	var genesisState types.ControllerGenesisState
 
 	testCases := []struct {
 		name     string
@@ -188,9 +184,7 @@ func (suite *TypesTestSuite) TestValidateControllerGenesisState() {
 }
 
 func (suite *TypesTestSuite) TestValidateHostGenesisState() {
-	var (
-		genesisState types.HostGenesisState
-	)
+	var genesisState types.HostGenesisState
 
 	testCases := []struct {
 		name     string

--- a/modules/apps/27-interchain-accounts/types/metadata_test.go
+++ b/modules/apps/27-interchain-accounts/types/metadata_test.go
@@ -7,7 +7,6 @@ import (
 
 // use TestVersion as metadata being compared against
 func (suite *TypesTestSuite) TestIsPreviousMetadataEqual() {
-
 	var (
 		metadata        types.Metadata
 		previousVersion string
@@ -127,7 +126,6 @@ func (suite *TypesTestSuite) TestIsPreviousMetadataEqual() {
 }
 
 func (suite *TypesTestSuite) TestValidateControllerMetadata() {
-
 	var metadata types.Metadata
 
 	testCases := []struct {
@@ -269,7 +267,6 @@ func (suite *TypesTestSuite) TestValidateControllerMetadata() {
 }
 
 func (suite *TypesTestSuite) TestValidateHostMetadata() {
-
 	var metadata types.Metadata
 
 	testCases := []struct {

--- a/modules/apps/27-interchain-accounts/types/packet_test.go
+++ b/modules/apps/27-interchain-accounts/types/packet_test.go
@@ -33,7 +33,7 @@ func (suite *TypesTestSuite) TestValidateBasic() {
 			"type unspecified",
 			types.InterchainAccountPacketData{
 				Type: types.UNSPECIFIED,
-				Data: []byte("data"), 
+				Data: []byte("data"),
 				Memo: "memo",
 			},
 			false,

--- a/modules/apps/transfer/ibc_module_test.go
+++ b/modules/apps/transfer/ibc_module_test.go
@@ -23,7 +23,6 @@ func (suite *TransferTestSuite) TestOnChanOpenInit() {
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success", func() {}, true,
 		},
@@ -93,7 +92,6 @@ func (suite *TransferTestSuite) TestOnChanOpenInit() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }
@@ -111,7 +109,6 @@ func (suite *TransferTestSuite) TestOnChanOpenTry() {
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success", func() {}, true,
 		},
@@ -185,7 +182,6 @@ func (suite *TransferTestSuite) TestOnChanOpenTry() {
 				suite.Require().Error(err)
 				suite.Require().Equal("", version)
 			}
-
 		})
 	}
 }
@@ -198,7 +194,6 @@ func (suite *TransferTestSuite) TestOnChanOpenAck() {
 		malleate func()
 		expPass  bool
 	}{
-
 		{
 			"success", func() {}, true,
 		},
@@ -235,7 +230,6 @@ func (suite *TransferTestSuite) TestOnChanOpenAck() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }

--- a/modules/apps/transfer/keeper/grpc_query.go
+++ b/modules/apps/transfer/keeper/grpc_query.go
@@ -61,7 +61,6 @@ func (q Keeper) DenomTraces(c context.Context, req *types.QueryDenomTracesReques
 		traces = append(traces, result)
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/modules/apps/transfer/keeper/grpc_query_test.go
+++ b/modules/apps/transfer/keeper/grpc_query_test.go
@@ -143,7 +143,6 @@ func (suite *KeeperTestSuite) TestQueryParams() {
 }
 
 func (suite *KeeperTestSuite) TestQueryDenomHash() {
-
 	reqTrace := types.DenomTrace{
 		Path:      "transfer/channelToA/transfer/channelToB",
 		BaseDenom: "uatom",

--- a/modules/apps/transfer/keeper/keeper.go
+++ b/modules/apps/transfer/keeper/keeper.go
@@ -36,7 +36,6 @@ func NewKeeper(
 	ics4Wrapper types.ICS4Wrapper, channelKeeper types.ChannelKeeper, portKeeper types.PortKeeper,
 	authKeeper types.AccountKeeper, bankKeeper types.BankKeeper, scopedKeeper capabilitykeeper.ScopedKeeper,
 ) Keeper {
-
 	// ensure ibc transfer module account is set
 	if addr := authKeeper.GetModuleAddress(types.ModuleName); addr == nil {
 		panic("the IBC transfer module account has not been set")

--- a/modules/apps/transfer/keeper/mbt_relay_test.go
+++ b/modules/apps/transfer/keeper/mbt_relay_test.go
@@ -280,7 +280,7 @@ func (suite *KeeperTestSuite) TestModelBasedRelay() {
 		panic(fmt.Errorf("Failed to read model-based test files: %w", err))
 	}
 	for _, file_info := range files {
-		var tlaTestCases = []TlaOnRecvPacketTestCase{}
+		tlaTestCases := []TlaOnRecvPacketTestCase{}
 		if !strings.HasSuffix(file_info.Name(), ".json") {
 			continue
 		}

--- a/modules/apps/transfer/keeper/relay.go
+++ b/modules/apps/transfer/keeper/relay.go
@@ -58,7 +58,6 @@ func (k Keeper) SendTransfer(
 	timeoutHeight clienttypes.Height,
 	timeoutTimestamp uint64,
 ) error {
-
 	if !k.GetSendEnabled(ctx) {
 		return types.ErrSendDisabled
 	}

--- a/modules/apps/transfer/keeper/relay_test.go
+++ b/modules/apps/transfer/keeper/relay_test.go
@@ -28,25 +28,32 @@ func (suite *KeeperTestSuite) TestSendTransfer() {
 		sendFromSource bool
 		expPass        bool
 	}{
-		{"successful transfer from source chain",
+		{
+			"successful transfer from source chain",
 			func() {
 				suite.coordinator.CreateTransferChannels(path)
 				amount = sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100))
-			}, true, true},
-		{"successful transfer with coin from counterparty chain",
+			}, true, true,
+		},
+		{
+			"successful transfer with coin from counterparty chain",
 			func() {
 				// send coin from chainA back to chainB
 				suite.coordinator.CreateTransferChannels(path)
 				amount = types.GetTransferCoin(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, sdk.DefaultBondDenom, sdk.NewInt(100))
-			}, false, true},
-		{"source channel not found",
+			}, false, true,
+		},
+		{
+			"source channel not found",
 			func() {
 				// channel references wrong ID
 				suite.coordinator.CreateTransferChannels(path)
 				path.EndpointA.ChannelID = ibctesting.InvalidID
 				amount = sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100))
-			}, true, false},
-		{"next seq send not found",
+			}, true, false,
+		},
+		{
+			"next seq send not found",
 			func() {
 				path.EndpointA.ChannelID = "channel-0"
 				path.EndpointB.ChannelID = "channel-0"
@@ -58,22 +65,28 @@ func (suite *KeeperTestSuite) TestSendTransfer() {
 				)
 				suite.chainA.CreateChannelCapability(suite.chainA.GetSimApp().ScopedIBCMockKeeper, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 				amount = sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100))
-			}, true, false},
+			}, true, false,
+		},
 
 		// createOutgoingPacket tests
 		// - source chain
-		{"send coin failed",
+		{
+			"send coin failed",
 			func() {
 				suite.coordinator.CreateTransferChannels(path)
 				amount = sdk.NewCoin("randomdenom", sdk.NewInt(100))
-			}, true, false},
+			}, true, false,
+		},
 		// - receiving chain
-		{"send from module account failed",
+		{
+			"send from module account failed",
 			func() {
 				suite.coordinator.CreateTransferChannels(path)
 				amount = types.GetTransferCoin(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, " randomdenom", sdk.NewInt(100))
-			}, false, false},
-		{"channel capability not found",
+			}, false, false,
+		},
+		{
+			"channel capability not found",
 			func() {
 				suite.coordinator.CreateTransferChannels(path)
 				cap := suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
@@ -81,7 +94,8 @@ func (suite *KeeperTestSuite) TestSendTransfer() {
 				// Release channel capability
 				suite.chainA.GetSimApp().ScopedTransferKeeper.ReleaseCapability(suite.chainA.GetContext(), cap)
 				amount = sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100))
-			}, true, false},
+			}, true, false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -264,18 +278,22 @@ func (suite *KeeperTestSuite) TestOnAcknowledgementPacket() {
 
 			suite.Require().NoError(simapp.FundAccount(suite.chainA.GetSimApp(), suite.chainA.GetContext(), escrow, sdk.NewCoins(coin)))
 		}, false, true},
-		{"unsuccessful refund from source", failedAck,
+		{
+			"unsuccessful refund from source", failedAck,
 			func() {
 				trace = types.ParseDenomTrace(sdk.DefaultBondDenom)
-			}, false, false},
-		{"successful refund from with coin from external chain", failedAck,
+			}, false, false,
+		},
+		{
+			"successful refund from with coin from external chain", failedAck,
 			func() {
 				escrow := types.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 				trace = types.ParseDenomTrace(types.GetPrefixedDenom(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, sdk.DefaultBondDenom))
 				coin := sdk.NewCoin(trace.IBCDenom(), amount)
 
 				suite.Require().NoError(simapp.FundAccount(suite.chainA.GetSimApp(), suite.chainA.GetContext(), escrow, sdk.NewCoins(coin)))
-			}, false, true},
+			}, false, true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -330,36 +348,46 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 		malleate func()
 		expPass  bool
 	}{
-		{"successful timeout from sender as source chain",
+		{
+			"successful timeout from sender as source chain",
 			func() {
 				escrow := types.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 				trace = types.ParseDenomTrace(sdk.DefaultBondDenom)
 				coin := sdk.NewCoin(trace.IBCDenom(), amount)
 
 				suite.Require().NoError(simapp.FundAccount(suite.chainA.GetSimApp(), suite.chainA.GetContext(), escrow, sdk.NewCoins(coin)))
-			}, true},
-		{"successful timeout from external chain",
+			}, true,
+		},
+		{
+			"successful timeout from external chain",
 			func() {
 				escrow := types.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 				trace = types.ParseDenomTrace(types.GetPrefixedDenom(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, sdk.DefaultBondDenom))
 				coin := sdk.NewCoin(trace.IBCDenom(), amount)
 
 				suite.Require().NoError(simapp.FundAccount(suite.chainA.GetSimApp(), suite.chainA.GetContext(), escrow, sdk.NewCoins(coin)))
-			}, true},
-		{"no balance for coin denom",
+			}, true,
+		},
+		{
+			"no balance for coin denom",
 			func() {
 				trace = types.ParseDenomTrace("bitcoin")
-			}, false},
-		{"unescrow failed",
+			}, false,
+		},
+		{
+			"unescrow failed",
 			func() {
 				trace = types.ParseDenomTrace(sdk.DefaultBondDenom)
-			}, false},
-		{"mint failed",
+			}, false,
+		},
+		{
+			"mint failed",
 			func() {
 				trace = types.ParseDenomTrace(types.GetPrefixedDenom(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, sdk.DefaultBondDenom))
 				amount = sdk.OneInt()
 				sender = "invalid address"
-			}, false},
+			}, false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/modules/apps/transfer/simulation/genesis_test.go
+++ b/modules/apps/transfer/simulation/genesis_test.go
@@ -43,7 +43,6 @@ func TestRandomizedGenState(t *testing.T) {
 	require.True(t, ibcTransferGenesis.Params.SendEnabled)
 	require.True(t, ibcTransferGenesis.Params.ReceiveEnabled)
 	require.Len(t, ibcTransferGenesis.DenomTraces, 0)
-
 }
 
 // TestRandomizedGenState tests abnormal scenarios of applying RandomizedGenState.

--- a/modules/apps/transfer/types/ack_test.go
+++ b/modules/apps/transfer/types/ack_test.go
@@ -224,5 +224,4 @@ func (suite *TypesTestSuite) TestAcknowledgementError() {
 
 	suite.Require().Equal(ack, ackSameABCICode)
 	suite.Require().NotEqual(ack, ackDifferentABCICode)
-
 }

--- a/modules/apps/transfer/types/coin.go
+++ b/modules/apps/transfer/types/coin.go
@@ -27,7 +27,6 @@ func ReceiverChainIsSource(sourcePort, sourceChannel, denom string) bool {
 
 	voucherPrefix := GetDenomPrefix(sourcePort, sourceChannel)
 	return strings.HasPrefix(denom, voucherPrefix)
-
 }
 
 // GetDenomPrefix returns the receiving denomination prefix

--- a/modules/core/02-client/keeper/client.go
+++ b/modules/core/02-client/keeper/client.go
@@ -146,7 +146,8 @@ func (k Keeper) UpdateClient(ctx sdk.Context, clientID string, header exported.H
 // UpgradeClient upgrades the client to a new client state if this new client was committed to
 // by the old client at the specified upgrade height
 func (k Keeper) UpgradeClient(ctx sdk.Context, clientID string, upgradedClient exported.ClientState, upgradedConsState exported.ConsensusState,
-	proofUpgradeClient, proofUpgradeConsState []byte) error {
+	proofUpgradeClient, proofUpgradeConsState []byte,
+) error {
 	clientState, found := k.GetClientState(ctx, clientID)
 	if !found {
 		return sdkerrors.Wrapf(types.ErrClientNotFound, "cannot update client with ID %s", clientID)

--- a/modules/core/02-client/keeper/client_test.go
+++ b/modules/core/02-client/keeper/client_test.go
@@ -418,7 +418,6 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 			suite.Require().Error(err, "verify upgrade passed on invalid case: %s", tc.name)
 		}
 	}
-
 }
 
 func (suite *KeeperTestSuite) TestCheckMisbehaviourAndUpdateState() {
@@ -698,8 +697,6 @@ func (suite *KeeperTestSuite) TestUpdateClientEventEmission() {
 			suite.Require().NoError(err)
 			suite.Require().Equal(header, emittedHeader)
 		}
-
 	}
 	suite.Require().True(contains)
-
 }

--- a/modules/core/02-client/keeper/grpc_query.go
+++ b/modules/core/02-client/keeper/grpc_query.go
@@ -83,7 +83,6 @@ func (q Keeper) ClientStates(c context.Context, req *types.QueryClientStatesRequ
 		clientStates = append(clientStates, identifiedClient)
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +176,6 @@ func (q Keeper) ConsensusStates(c context.Context, req *types.QueryConsensusStat
 		consensusStates = append(consensusStates, types.NewConsensusStateWithHeight(height, consensusState))
 		return true, nil
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/modules/core/02-client/keeper/grpc_query_test.go
+++ b/modules/core/02-client/keeper/grpc_query_test.go
@@ -28,19 +28,22 @@ func (suite *KeeperTestSuite) TestQueryClientState() {
 		malleate func()
 		expPass  bool
 	}{
-		{"req is nil",
+		{
+			"req is nil",
 			func() {
 				req = nil
 			},
 			false,
 		},
-		{"invalid clientID",
+		{
+			"invalid clientID",
 			func() {
 				req = &types.QueryClientStateRequest{}
 			},
 			false,
 		},
-		{"client not found",
+		{
+			"client not found",
 			func() {
 				req = &types.QueryClientStateRequest{
 					ClientId: testClientID,
@@ -100,7 +103,8 @@ func (suite *KeeperTestSuite) TestQueryClientStates() {
 		malleate func()
 		expPass  bool
 	}{
-		{"req is nil",
+		{
+			"req is nil",
 			func() {
 				req = nil
 			},
@@ -190,7 +194,8 @@ func (suite *KeeperTestSuite) TestQueryConsensusState() {
 		malleate func()
 		expPass  bool
 	}{
-		{"req is nil",
+		{
+			"req is nil",
 			func() {
 				req = nil
 			},
@@ -396,9 +401,7 @@ func (suite *KeeperTestSuite) TestQueryConsensusStates() {
 }
 
 func (suite *KeeperTestSuite) TestQueryClientStatus() {
-	var (
-		req *types.QueryClientStatusRequest
-	)
+	var req *types.QueryClientStatusRequest
 
 	testCases := []struct {
 		msg       string
@@ -406,19 +409,22 @@ func (suite *KeeperTestSuite) TestQueryClientStatus() {
 		expPass   bool
 		expStatus string
 	}{
-		{"req is nil",
+		{
+			"req is nil",
 			func() {
 				req = nil
 			},
 			false, "",
 		},
-		{"invalid clientID",
+		{
+			"invalid clientID",
 			func() {
 				req = &types.QueryClientStatusRequest{}
 			},
 			false, "",
 		},
-		{"client not found",
+		{
+			"client not found",
 			func() {
 				req = &types.QueryClientStatusRequest{
 					ClientId: ibctesting.InvalidID,
@@ -503,7 +509,8 @@ func (suite *KeeperTestSuite) TestQueryUpgradedConsensusStates() {
 		malleate func()
 		expPass  bool
 	}{
-		{"req is nil",
+		{
+			"req is nil",
 			func() {
 				req = nil
 			},

--- a/modules/core/02-client/keeper/proposal_test.go
+++ b/modules/core/02-client/keeper/proposal_test.go
@@ -154,7 +154,6 @@ func (suite *KeeperTestSuite) TestClientUpdateProposal() {
 			}
 		})
 	}
-
 }
 
 func (suite *KeeperTestSuite) TestHandleUpgradeProposal() {
@@ -206,7 +205,7 @@ func (suite *KeeperTestSuite) TestHandleUpgradeProposal() {
 
 		suite.Run(tc.name, func() {
 			suite.SetupTest()  // reset
-			oldPlan.Height = 0 //reset
+			oldPlan.Height = 0 // reset
 
 			path := ibctesting.NewPath(suite.chainA, suite.chainB)
 			suite.coordinator.SetupClients(path)
@@ -276,5 +275,4 @@ func (suite *KeeperTestSuite) TestHandleUpgradeProposal() {
 			}
 		})
 	}
-
 }

--- a/modules/core/02-client/legacy/v100/genesis.go
+++ b/modules/core/02-client/legacy/v100/genesis.go
@@ -123,13 +123,11 @@ func MigrateGenesis(cdc codec.BinaryCodec, clientGenState *types.GenesisState, g
 												Key:   ibctmtypes.IterationKey(height),
 												Value: host.ConsensusStateKey(height),
 											})
-
 									}
 								}
 
 							}
 						}
-
 					}
 
 					// if we have metadata for unexipred consensus states, add it to consensusMetadata

--- a/modules/core/02-client/legacy/v100/genesis_test.go
+++ b/modules/core/02-client/legacy/v100/genesis_test.go
@@ -254,7 +254,6 @@ func (suite *LegacyTestSuite) TestMigrateGenesisTendermint() {
 					suite.Require().NotEqual(height, consensusState.Height)
 				}
 			}
-
 		}
 		for _, client := range migrated.ClientsMetadata {
 			if client.ClientId == path1.EndpointA.ClientID {
@@ -275,7 +274,6 @@ func (suite *LegacyTestSuite) TestMigrateGenesisTendermint() {
 					suite.Require().NotEqual(height, consensusState.Height)
 				}
 			}
-
 		}
 		for _, client := range migrated.ClientsMetadata {
 			if client.ClientId == path2.EndpointA.ClientID {
@@ -285,7 +283,6 @@ func (suite *LegacyTestSuite) TestMigrateGenesisTendermint() {
 					suite.Require().NotEqual(ibctmtypes.IterationKey(height), metadata.Key)
 				}
 			}
-
 		}
 	}
 	bz, err := clientCtx.Codec.MarshalJSON(&expectedClientGenState)

--- a/modules/core/02-client/proposal_handler_test.go
+++ b/modules/core/02-client/proposal_handler_test.go
@@ -84,5 +84,4 @@ func (suite *ClientTestSuite) TestNewClientUpdateProposalHandler() {
 			}
 		})
 	}
-
 }

--- a/modules/core/02-client/types/client_test.go
+++ b/modules/core/02-client/types/client_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 func (suite *TypesTestSuite) TestMarshalConsensusStateWithHeight() {
-	var (
-		cswh types.ConsensusStateWithHeight
-	)
+	var cswh types.ConsensusStateWithHeight
 
 	testCases := []struct {
 		name     string

--- a/modules/core/02-client/types/codec_test.go
+++ b/modules/core/02-client/types/codec_test.go
@@ -18,7 +18,6 @@ type caseAny struct {
 }
 
 func (suite *TypesTestSuite) TestPackClientState() {
-
 	testCases := []struct {
 		name        string
 		clientState exported.ClientState

--- a/modules/core/02-client/types/encoding_test.go
+++ b/modules/core/02-client/types/encoding_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func (suite *TypesTestSuite) TestMarshalHeader() {
-
 	cdc := suite.chainA.App.AppCodec()
 	h := &ibctmtypes.Header{
 		TrustedHeight: types.NewHeight(4, 100),
@@ -26,5 +25,4 @@ func (suite *TypesTestSuite) TestMarshalHeader() {
 	invalidHeader, err := types.UnmarshalHeader(cdc, []byte("invalid bytes"))
 	suite.Require().Error(err)
 	suite.Require().Nil(invalidHeader)
-
 }

--- a/modules/core/02-client/types/genesis.go
+++ b/modules/core/02-client/types/genesis.go
@@ -196,7 +196,6 @@ func (gs GenesisState) Validate() error {
 			if err := gm.Validate(); err != nil {
 				return fmt.Errorf("invalid client metadata %v clientID %s index %d: %w", gm, clientMetadata.ClientId, i, err)
 			}
-
 		}
 
 	}

--- a/modules/core/02-client/types/height_test.go
+++ b/modules/core/02-client/types/height_test.go
@@ -126,7 +126,6 @@ func TestParseChainID(t *testing.T) {
 		revision := types.ParseChainID(tc.chainID)
 		require.Equal(t, tc.revision, revision, "chainID %s returns incorrect revision", tc.chainID)
 	}
-
 }
 
 func TestSetRevisionNumber(t *testing.T) {

--- a/modules/core/02-client/types/msgs.go
+++ b/modules/core/02-client/types/msgs.go
@@ -34,7 +34,6 @@ var (
 func NewMsgCreateClient(
 	clientState exported.ClientState, consensusState exported.ConsensusState, signer string,
 ) (*MsgCreateClient, error) {
-
 	anyClientState, err := PackClientState(clientState)
 	if err != nil {
 		return nil, err
@@ -154,7 +153,8 @@ func (msg MsgUpdateClient) UnpackInterfaces(unpacker codectypes.AnyUnpacker) err
 // NewMsgUpgradeClient creates a new MsgUpgradeClient instance
 // nolint: interfacer
 func NewMsgUpgradeClient(clientID string, clientState exported.ClientState, consState exported.ConsensusState,
-	proofUpgradeClient, proofUpgradeConsState []byte, signer string) (*MsgUpgradeClient, error) {
+	proofUpgradeClient, proofUpgradeConsState []byte, signer string,
+) (*MsgUpgradeClient, error) {
 	anyClient, err := PackClientState(clientState)
 	if err != nil {
 		return nil, err

--- a/modules/core/02-client/types/msgs_test.go
+++ b/modules/core/02-client/types/msgs_test.go
@@ -211,7 +211,6 @@ func (suite *TypesTestSuite) TestMarshalMsgUpdateClient() {
 			"tendermint client", func() {
 				msg, err = types.NewMsgUpdateClient("tendermint", suite.chainA.CurrentTMClientHeader(), suite.chainA.SenderAccount.GetAddress().String())
 				suite.Require().NoError(err)
-
 			},
 		},
 	}
@@ -496,7 +495,6 @@ func (suite *TypesTestSuite) TestMarshalMsgSubmitMisbehaviour() {
 				misbehaviour := ibctmtypes.NewMisbehaviour("tendermint", header1, header2)
 				msg, err = types.NewMsgSubmitMisbehaviour("tendermint", misbehaviour, suite.chainA.SenderAccount.GetAddress().String())
 				suite.Require().NoError(err)
-
 			},
 		},
 	}

--- a/modules/core/02-client/types/proposal_test.go
+++ b/modules/core/02-client/types/proposal_test.go
@@ -117,7 +117,6 @@ func (suite *TypesTestSuite) TestUpgradeProposalValidateBasic() {
 			"fails validate abstract - empty title", func() {
 				proposal, err = types.NewUpgradeProposal("", ibctesting.Description, plan, cs)
 				suite.Require().NoError(err)
-
 			}, false,
 		},
 		{
@@ -199,7 +198,6 @@ func (suite *TypesTestSuite) TestMarshalUpgradeProposal() {
 	// unpack client state
 	_, err = types.UnpackClientState(newUp.UpgradedClientState)
 	suite.Require().NoError(err)
-
 }
 
 func (suite *TypesTestSuite) TestUpgradeString() {

--- a/modules/core/03-connection/client/utils/utils.go
+++ b/modules/core/03-connection/client/utils/utils.go
@@ -105,7 +105,6 @@ func queryClientConnectionsABCI(clientCtx client.Context, clientID string) (*typ
 func QueryConnectionClientState(
 	clientCtx client.Context, connectionID string, prove bool,
 ) (*types.QueryConnectionClientStateResponse, error) {
-
 	queryClient := types.NewQueryClient(clientCtx)
 	req := &types.QueryConnectionClientStateRequest{
 		ConnectionId: connectionID,
@@ -140,7 +139,6 @@ func QueryConnectionClientState(
 func QueryConnectionConsensusState(
 	clientCtx client.Context, connectionID string, height clienttypes.Height, prove bool,
 ) (*types.QueryConnectionConsensusStateResponse, error) {
-
 	queryClient := types.NewQueryClient(clientCtx)
 	req := &types.QueryConnectionConsensusStateRequest{
 		ConnectionId:   connectionID,

--- a/modules/core/03-connection/keeper/events.go
+++ b/modules/core/03-connection/keeper/events.go
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	
+
 	"github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 )
 

--- a/modules/core/03-connection/keeper/grpc_query.go
+++ b/modules/core/03-connection/keeper/grpc_query.go
@@ -68,7 +68,6 @@ func (q Keeper) Connections(c context.Context, req *types.QueryConnectionsReques
 		connections = append(connections, &identifiedConnection)
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +136,6 @@ func (q Keeper) ConnectionClientState(c context.Context, req *types.QueryConnect
 
 	height := clienttypes.GetSelfHeight(ctx)
 	return types.NewQueryConnectionClientStateResponse(identifiedClientState, nil, height), nil
-
 }
 
 // ConnectionConsensusState implements the Query/ConnectionConsensusState gRPC method

--- a/modules/core/03-connection/keeper/grpc_query_test.go
+++ b/modules/core/03-connection/keeper/grpc_query_test.go
@@ -30,13 +30,15 @@ func (suite *KeeperTestSuite) TestQueryConnection() {
 			},
 			false,
 		},
-		{"invalid connectionID",
+		{
+			"invalid connectionID",
 			func() {
 				req = &types.QueryConnectionRequest{}
 			},
 			false,
 		},
-		{"connection not found",
+		{
+			"connection not found",
 			func() {
 				req = &types.QueryConnectionRequest{
 					ConnectionId: ibctesting.InvalidID,
@@ -186,13 +188,15 @@ func (suite *KeeperTestSuite) TestQueryClientConnections() {
 			},
 			false,
 		},
-		{"invalid connectionID",
+		{
+			"invalid connectionID",
 			func() {
 				req = &types.QueryClientConnectionsRequest{}
 			},
 			false,
 		},
-		{"connection not found",
+		{
+			"connection not found",
 			func() {
 				req = &types.QueryClientConnectionsRequest{
 					ClientId: ibctesting.InvalidID,

--- a/modules/core/03-connection/keeper/handshake_test.go
+++ b/modules/core/03-connection/keeper/handshake_test.go
@@ -370,7 +370,6 @@ func (suite *KeeperTestSuite) TestConnOpenAck() {
 			tmClient.ChainId = "wrongchainid"
 
 			suite.chainB.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainB.GetContext(), path.EndpointB.ClientID, tmClient)
-
 		}, false},
 		{"consensus height >= latest height", func() {
 			err := path.EndpointA.ConnOpenInit()
@@ -554,7 +553,6 @@ func (suite *KeeperTestSuite) TestConnOpenAck() {
 
 			err = path.EndpointB.ConnOpenTry()
 			suite.Require().NoError(err)
-
 		}, false},
 	}
 

--- a/modules/core/03-connection/keeper/keeper_test.go
+++ b/modules/core/03-connection/keeper/keeper_test.go
@@ -45,7 +45,6 @@ func (suite *KeeperTestSuite) TestSetAndGetConnection() {
 }
 
 func (suite *KeeperTestSuite) TestSetAndGetClientConnectionPaths() {
-
 	path := ibctesting.NewPath(suite.chainA, suite.chainB)
 	suite.coordinator.SetupClients(path)
 

--- a/modules/core/03-connection/types/codec.go
+++ b/modules/core/03-connection/types/codec.go
@@ -38,11 +38,9 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }
 
-var (
-	// SubModuleCdc references the global x/ibc/core/03-connection module codec. Note, the codec should
-	// ONLY be used in certain instances of tests and for JSON encoding.
-	//
-	// The actual codec used for serialization should be provided to x/ibc/core/03-connection and
-	// defined at the application level.
-	SubModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
-)
+// SubModuleCdc references the global x/ibc/core/03-connection module codec. Note, the codec should
+// ONLY be used in certain instances of tests and for JSON encoding.
+//
+// The actual codec used for serialization should be provided to x/ibc/core/03-connection and
+// defined at the application level.
+var SubModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())

--- a/modules/core/03-connection/types/genesis_test.go
+++ b/modules/core/03-connection/types/genesis_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestValidateGenesis(t *testing.T) {
-
 	testCases := []struct {
 		name     string
 		genState types.GenesisState

--- a/modules/core/03-connection/types/msgs_test.go
+++ b/modules/core/03-connection/types/msgs_test.go
@@ -68,7 +68,6 @@ func (suite *MsgTestSuite) SetupTest() {
 	suite.Require().NoError(err)
 
 	suite.proof = proof
-
 }
 
 func TestMsgTestSuite(t *testing.T) {
@@ -81,7 +80,7 @@ func (suite *MsgTestSuite) TestNewMsgConnectionOpenInit() {
 	// will be used in protocol.
 	var version *types.Version
 
-	var testCases = []struct {
+	testCases := []struct {
 		name    string
 		msg     *types.MsgConnectionOpenInit
 		expPass bool
@@ -124,7 +123,7 @@ func (suite *MsgTestSuite) TestNewMsgConnectionOpenTry() {
 		chainID, ibctmtypes.DefaultTrustLevel, ibctesting.TrustingPeriod, ibctesting.UnbondingPeriod, ibctesting.MaxClockDrift, clienttypes.ZeroHeight(), commitmenttypes.GetSDKSpecs(), ibctesting.UpgradePath, false, false,
 	)
 
-	var testCases = []struct {
+	testCases := []struct {
 		name    string
 		msg     *types.MsgConnectionOpenTry
 		expPass bool
@@ -176,7 +175,7 @@ func (suite *MsgTestSuite) TestNewMsgConnectionOpenAck() {
 	)
 	connectionID := "connection-0"
 
-	var testCases = []struct {
+	testCases := []struct {
 		name    string
 		msg     *types.MsgConnectionOpenAck
 		expPass bool
@@ -215,7 +214,7 @@ func (suite *MsgTestSuite) TestNewMsgConnectionOpenConfirm() {
 		types.NewMsgConnectionOpenConfirm(connectionID, suite.proof, clientHeight, signer),
 	}
 
-	var testCases = []struct {
+	testCases := []struct {
 		msg     *types.MsgConnectionOpenConfirm
 		expPass bool
 		errMsg  string

--- a/modules/core/03-connection/types/version_test.go
+++ b/modules/core/03-connection/types/version_test.go
@@ -141,7 +141,6 @@ func TestVerifyProposedVersion(t *testing.T) {
 			require.Error(t, err, "test case %d: %s", i, tc.name)
 		}
 	}
-
 }
 
 func TestVerifySupportedFeature(t *testing.T) {

--- a/modules/core/04-channel/client/utils/utils.go
+++ b/modules/core/04-channel/client/utils/utils.go
@@ -64,7 +64,6 @@ func queryChannelABCI(clientCtx client.Context, portID, channelID string) (*type
 func QueryChannelClientState(
 	clientCtx client.Context, portID, channelID string, prove bool,
 ) (*types.QueryChannelClientStateResponse, error) {
-
 	queryClient := types.NewQueryClient(clientCtx)
 	req := &types.QueryChannelClientStateRequest{
 		PortId:    portID,
@@ -99,7 +98,6 @@ func QueryChannelClientState(
 func QueryChannelConsensusState(
 	clientCtx client.Context, portID, channelID string, height clienttypes.Height, prove bool,
 ) (*types.QueryChannelConsensusStateResponse, error) {
-
 	queryClient := types.NewQueryClient(clientCtx)
 	req := &types.QueryChannelConsensusStateRequest{
 		PortId:         portID,

--- a/modules/core/04-channel/keeper/grpc_query.go
+++ b/modules/core/04-channel/keeper/grpc_query.go
@@ -69,7 +69,6 @@ func (q Keeper) Channels(c context.Context, req *types.QueryChannelsRequest) (*t
 		channels = append(channels, &identifiedChannel)
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +117,6 @@ func (q Keeper) ConnectionChannels(c context.Context, req *types.QueryConnection
 		channels = append(channels, &identifiedChannel)
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +250,6 @@ func (q Keeper) PacketCommitments(c context.Context, req *types.QueryPacketCommi
 		commitments = append(commitments, &commitment)
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +358,6 @@ func (q Keeper) PacketAcknowledgements(c context.Context, req *types.QueryPacket
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +397,7 @@ func (q Keeper) UnreceivedPackets(c context.Context, req *types.QueryUnreceivedP
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	var unreceivedSequences = []uint64{}
+	unreceivedSequences := []uint64{}
 
 	for i, seq := range req.PacketCommitmentSequences {
 		if seq == 0 {
@@ -450,7 +446,7 @@ func (q Keeper) UnreceivedAcks(c context.Context, req *types.QueryUnreceivedAcks
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	var unreceivedSequences = []uint64{}
+	unreceivedSequences := []uint64{}
 
 	for i, seq := range req.PacketAckSequences {
 		if seq == 0 {

--- a/modules/core/04-channel/keeper/grpc_query_test.go
+++ b/modules/core/04-channel/keeper/grpc_query_test.go
@@ -51,7 +51,8 @@ func (suite *KeeperTestSuite) TestQueryChannel() {
 			},
 			false,
 		},
-		{"channel not found",
+		{
+			"channel not found",
 			func() {
 				req = &types.QueryChannelRequest{
 					PortId:    "test-port-id",
@@ -628,7 +629,8 @@ func (suite *KeeperTestSuite) TestQueryPacketCommitment() {
 			},
 			false,
 		},
-		{"invalid sequence",
+		{
+			"invalid sequence",
 			func() {
 				req = &types.QueryPacketCommitmentRequest{
 					PortId:    "test-port-id",
@@ -638,7 +640,8 @@ func (suite *KeeperTestSuite) TestQueryPacketCommitment() {
 			},
 			false,
 		},
-		{"channel not found",
+		{
+			"channel not found",
 			func() {
 				req = &types.QueryPacketCommitmentRequest{
 					PortId:    "test-port-id",
@@ -819,7 +822,8 @@ func (suite *KeeperTestSuite) TestQueryPacketReceipt() {
 			},
 			false,
 		},
-		{"invalid sequence",
+		{
+			"invalid sequence",
 			func() {
 				req = &types.QueryPacketReceiptRequest{
 					PortId:    "test-port-id",
@@ -923,7 +927,8 @@ func (suite *KeeperTestSuite) TestQueryPacketAcknowledgement() {
 			},
 			false,
 		},
-		{"invalid sequence",
+		{
+			"invalid sequence",
 			func() {
 				req = &types.QueryPacketAcknowledgementRequest{
 					PortId:    "test-port-id",
@@ -933,7 +938,8 @@ func (suite *KeeperTestSuite) TestQueryPacketAcknowledgement() {
 			},
 			false,
 		},
-		{"channel not found",
+		{
+			"channel not found",
 			func() {
 				req = &types.QueryPacketAcknowledgementRequest{
 					PortId:    "test-port-id",
@@ -1400,7 +1406,8 @@ func (suite *KeeperTestSuite) TestQueryNextSequenceReceive() {
 			},
 			false,
 		},
-		{"channel not found",
+		{
+			"channel not found",
 			func() {
 				req = &types.QueryNextSequenceReceiveRequest{
 					PortId:    "test-port-id",

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -220,7 +220,6 @@ func (suite *KeeperTestSuite) TestSendPacket() {
 			}
 		})
 	}
-
 }
 
 // TestRecvPacket test RecvPacket on chainB. Since packet commitment verification will always
@@ -487,7 +486,6 @@ func (suite *KeeperTestSuite) TestRecvPacket() {
 			}
 		})
 	}
-
 }
 
 func (suite *KeeperTestSuite) TestWriteAcknowledgement() {

--- a/modules/core/04-channel/keeper/timeout_test.go
+++ b/modules/core/04-channel/keeper/timeout_test.go
@@ -430,5 +430,4 @@ func (suite *KeeperTestSuite) TestTimeoutOnClose() {
 			}
 		})
 	}
-
 }

--- a/modules/core/23-commitment/types/merkle_test.go
+++ b/modules/core/23-commitment/types/merkle_test.go
@@ -72,7 +72,6 @@ func (suite *MerkleTestSuite) TestVerifyMembership() {
 			}
 		})
 	}
-
 }
 
 func (suite *MerkleTestSuite) TestVerifyNonMembership() {
@@ -136,7 +135,6 @@ func (suite *MerkleTestSuite) TestVerifyNonMembership() {
 			}
 		})
 	}
-
 }
 
 func TestApplyPrefix(t *testing.T) {

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -16,9 +16,11 @@ import (
 	coretypes "github.com/cosmos/ibc-go/v3/modules/core/types"
 )
 
-var _ clienttypes.MsgServer = Keeper{}
-var _ connectiontypes.MsgServer = Keeper{}
-var _ channeltypes.MsgServer = Keeper{}
+var (
+	_ clienttypes.MsgServer     = Keeper{}
+	_ connectiontypes.MsgServer = Keeper{}
+	_ channeltypes.MsgServer    = Keeper{}
+)
 
 // CreateClient defines a rpc handler method for MsgCreateClient.
 func (k Keeper) CreateClient(goCtx context.Context, msg *clienttypes.MsgCreateClient) (*clienttypes.MsgCreateClientResponse, error) {

--- a/modules/core/keeper/msg_server_test.go
+++ b/modules/core/keeper/msg_server_test.go
@@ -45,7 +45,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 	// commit some blocks so that QueryProof returns valid proof (cannot return valid query if height <= 1)
 	suite.coordinator.CommitNBlocks(suite.chainA, 2)
 	suite.coordinator.CommitNBlocks(suite.chainB, 2)
-
 }
 
 func TestIBCTestSuite(t *testing.T) {
@@ -447,7 +446,6 @@ func (suite *KeeperTestSuite) TestHandleTimeoutPacket() {
 
 			path.EndpointA.UpdateClient()
 			packetKey = host.NextSequenceRecvKey(packet.GetDestPort(), packet.GetDestChannel())
-
 		}, true},
 		{"channel does not exist", func() {
 			// any non-nil value of packet is valid
@@ -677,7 +675,6 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 		{
 			name: "successful upgrade",
 			setup: func() {
-
 				upgradedClient = ibctmtypes.NewClientState(newChainId, ibctmtypes.DefaultTrustLevel, ibctesting.TrustingPeriod, ibctesting.UnbondingPeriod+ibctesting.TrustingPeriod, ibctesting.MaxClockDrift, newClientHeight, commitmenttypes.GetSDKSpecs(), ibctesting.UpgradePath, false, false)
 				// Call ZeroCustomFields on upgraded clients to clear any client-chosen parameters in test-case upgradedClient
 				upgradedClient = upgradedClient.ZeroCustomFields()
@@ -718,7 +715,6 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 		{
 			name: "VerifyUpgrade fails",
 			setup: func() {
-
 				upgradedClient = ibctmtypes.NewClientState(newChainId, ibctmtypes.DefaultTrustLevel, ibctesting.TrustingPeriod, ibctesting.UnbondingPeriod+ibctesting.TrustingPeriod, ibctesting.MaxClockDrift, newClientHeight, commitmenttypes.GetSDKSpecs(), ibctesting.UpgradePath, false, false)
 				// Call ZeroCustomFields on upgraded clients to clear any client-chosen parameters in test-case upgradedClient
 				upgradedClient = upgradedClient.ZeroCustomFields()

--- a/modules/core/keeper/sdk_middleware_test.go
+++ b/modules/core/keeper/sdk_middleware_test.go
@@ -500,10 +500,12 @@ var _ txtypes.Handler = customTxHandler{}
 func (h customTxHandler) DeliverTx(ctx context.Context, req txtypes.Request) (txtypes.Response, error) {
 	return h.fn(ctx, req)
 }
+
 func (h customTxHandler) CheckTx(ctx context.Context, req txtypes.Request, _ txtypes.RequestCheckTx) (txtypes.Response, txtypes.ResponseCheckTx, error) {
 	res, err := h.fn(ctx, req)
 	return res, txtypes.ResponseCheckTx{}, err
 }
+
 func (h customTxHandler) SimulateTx(ctx context.Context, req txtypes.Request) (txtypes.Response, error) {
 	return h.fn(ctx, req)
 }

--- a/modules/light-clients/06-solomachine/types/client_state_test.go
+++ b/modules/light-clients/06-solomachine/types/client_state_test.go
@@ -82,7 +82,6 @@ func (suite *SoloMachineTestSuite) TestClientStateValidateBasic() {
 			tc := tc
 
 			suite.Run(tc.name, func() {
-
 				err := tc.clientState.Validate()
 
 				if tc.expPass {
@@ -238,7 +237,6 @@ func (suite *SoloMachineTestSuite) TestVerifyClientState() {
 			tc := tc
 
 			suite.Run(tc.name, func() {
-
 				var expSeq uint64
 				if tc.clientState.ConsensusState != nil {
 					expSeq = tc.clientState.Sequence + 1
@@ -359,7 +357,6 @@ func (suite *SoloMachineTestSuite) TestVerifyClientConsensusState() {
 			tc := tc
 
 			suite.Run(tc.name, func() {
-
 				var expSeq uint64
 				if tc.clientState.ConsensusState != nil {
 					expSeq = tc.clientState.Sequence + 1

--- a/modules/light-clients/06-solomachine/types/codec_test.go
+++ b/modules/light-clients/06-solomachine/types/codec_test.go
@@ -55,7 +55,6 @@ func (suite SoloMachineTestSuite) TestUnmarshalDataByType() {
 					path := solomachine.GetConsensusStatePath(counterpartyClientIdentifier, clienttypes.NewHeight(0, 5))
 					data, err = types.ConsensusStateDataBytes(cdc, path, solomachine.ConsensusState())
 					suite.Require().NoError(err)
-
 				}, true,
 			},
 			{
@@ -73,7 +72,6 @@ func (suite SoloMachineTestSuite) TestUnmarshalDataByType() {
 
 					data, err = types.ConnectionStateDataBytes(cdc, path, conn)
 					suite.Require().NoError(err)
-
 				}, true,
 			},
 			{
@@ -104,7 +102,6 @@ func (suite SoloMachineTestSuite) TestUnmarshalDataByType() {
 
 					data, err = types.ConnectionStateDataBytes(cdc, path, conn)
 					suite.Require().NoError(err)
-
 				}, false,
 			},
 			{
@@ -186,5 +183,4 @@ func (suite SoloMachineTestSuite) TestUnmarshalDataByType() {
 			})
 		}
 	}
-
 }

--- a/modules/light-clients/06-solomachine/types/consensus_state_test.go
+++ b/modules/light-clients/06-solomachine/types/consensus_state_test.go
@@ -61,7 +61,6 @@ func (suite *SoloMachineTestSuite) TestConsensusStateValidateBasic() {
 			tc := tc
 
 			suite.Run(tc.name, func() {
-
 				err := tc.consensusState.ValidateBasic()
 
 				if tc.expPass {

--- a/modules/light-clients/06-solomachine/types/misbehaviour_handle.go
+++ b/modules/light-clients/06-solomachine/types/misbehaviour_handle.go
@@ -21,7 +21,6 @@ func (cs ClientState) CheckMisbehaviourAndUpdateState(
 	clientStore sdk.KVStore,
 	misbehaviour exported.Misbehaviour,
 ) (exported.ClientState, error) {
-
 	soloMisbehaviour, ok := misbehaviour.(*Misbehaviour)
 	if !ok {
 		return nil, sdkerrors.Wrapf(
@@ -51,7 +50,6 @@ func (cs ClientState) CheckMisbehaviourAndUpdateState(
 // over the provided data and that the data is valid. The data is valid if it can be
 // unmarshaled into the specified data type.
 func verifySignatureAndData(cdc codec.BinaryCodec, clientState ClientState, misbehaviour *Misbehaviour, sigAndData *SignatureAndData) error {
-
 	// do not check misbehaviour timestamp since we want to allow processing of past misbehaviour
 
 	// ensure data can be unmarshaled to the specified data type
@@ -85,5 +83,4 @@ func verifySignatureAndData(cdc codec.BinaryCodec, clientState ClientState, misb
 	}
 
 	return nil
-
 }

--- a/modules/light-clients/06-solomachine/types/misbehaviour_handle_test.go
+++ b/modules/light-clients/06-solomachine/types/misbehaviour_handle_test.go
@@ -227,7 +227,6 @@ func (suite *SoloMachineTestSuite) TestCheckMisbehaviourAndUpdateState() {
 					m.SignatureTwo.Data = msg
 
 					misbehaviour = m
-
 				},
 				false,
 			},

--- a/modules/light-clients/06-solomachine/types/misbehaviour_test.go
+++ b/modules/light-clients/06-solomachine/types/misbehaviour_test.go
@@ -113,7 +113,6 @@ func (suite *SoloMachineTestSuite) TestMisbehaviourValidateBasic() {
 			tc := tc
 
 			suite.Run(tc.name, func() {
-
 				misbehaviour := solomachine.CreateMisbehaviour()
 				tc.malleateMisbehaviour(misbehaviour)
 

--- a/modules/light-clients/06-solomachine/types/proof.go
+++ b/modules/light-clients/06-solomachine/types/proof.go
@@ -55,7 +55,8 @@ func MisbehaviourSignBytes(
 	sequence, timestamp uint64,
 	diversifier string,
 	dataType DataType,
-	data []byte) ([]byte, error) {
+	data []byte,
+) ([]byte, error) {
 	signBytes := &SignBytes{
 		Sequence:    sequence,
 		Timestamp:   timestamp,

--- a/modules/light-clients/06-solomachine/types/proposal_handle.go
+++ b/modules/light-clients/06-solomachine/types/proposal_handle.go
@@ -22,7 +22,6 @@ func (cs ClientState) CheckSubstituteAndUpdateState(
 	ctx sdk.Context, cdc codec.BinaryCodec, subjectClientStore,
 	_ sdk.KVStore, substituteClient exported.ClientState,
 ) (exported.ClientState, error) {
-
 	if !cs.AllowUpdateAfterProposal {
 		return nil, sdkerrors.Wrapf(
 			clienttypes.ErrUpdateClientFailed,

--- a/modules/light-clients/06-solomachine/types/update_test.go
+++ b/modules/light-clients/06-solomachine/types/update_test.go
@@ -122,7 +122,6 @@ func (suite *SoloMachineTestSuite) TestCheckHeaderAndUpdateState() {
 
 					clientState = cs
 					header = h
-
 				},
 				false,
 			},

--- a/modules/light-clients/07-tendermint/types/client_state_test.go
+++ b/modules/light-clients/07-tendermint/types/client_state_test.go
@@ -27,9 +27,7 @@ const (
 	fiftyOneCharChainID = "123456789012345678901234567890123456789012345678901"
 )
 
-var (
-	invalidProof = []byte("invalid proof")
-)
+var invalidProof = []byte("invalid proof")
 
 func (suite *TendermintTestSuite) TestStatus() {
 	var (
@@ -166,7 +164,6 @@ func (suite *TendermintTestSuite) TestValidate() {
 }
 
 func (suite *TendermintTestSuite) TestInitialize() {
-
 	testCases := []struct {
 		name           string
 		consensusState exported.ConsensusState

--- a/modules/light-clients/07-tendermint/types/consensus_state_test.go
+++ b/modules/light-clients/07-tendermint/types/consensus_state_test.go
@@ -14,49 +14,61 @@ func (suite *TendermintTestSuite) TestConsensusStateValidateBasic() {
 		consensusState *types.ConsensusState
 		expectPass     bool
 	}{
-		{"success",
+		{
+			"success",
 			&types.ConsensusState{
 				Timestamp:          suite.now,
 				Root:               commitmenttypes.NewMerkleRoot([]byte("app_hash")),
 				NextValidatorsHash: suite.valsHash,
 			},
-			true},
-		{"success with sentinel",
+			true,
+		},
+		{
+			"success with sentinel",
 			&types.ConsensusState{
 				Timestamp:          suite.now,
 				Root:               commitmenttypes.NewMerkleRoot([]byte(types.SentinelRoot)),
 				NextValidatorsHash: suite.valsHash,
 			},
-			true},
-		{"root is nil",
+			true,
+		},
+		{
+			"root is nil",
 			&types.ConsensusState{
 				Timestamp:          suite.now,
 				Root:               commitmenttypes.MerkleRoot{},
 				NextValidatorsHash: suite.valsHash,
 			},
-			false},
-		{"root is empty",
+			false,
+		},
+		{
+			"root is empty",
 			&types.ConsensusState{
 				Timestamp:          suite.now,
 				Root:               commitmenttypes.MerkleRoot{},
 				NextValidatorsHash: suite.valsHash,
 			},
-			false},
-		{"nextvalshash is invalid",
+			false,
+		},
+		{
+			"nextvalshash is invalid",
 			&types.ConsensusState{
 				Timestamp:          suite.now,
 				Root:               commitmenttypes.NewMerkleRoot([]byte("app_hash")),
 				NextValidatorsHash: []byte("hi"),
 			},
-			false},
+			false,
+		},
 
-		{"timestamp is zero",
+		{
+			"timestamp is zero",
 			&types.ConsensusState{
 				Timestamp:          time.Time{},
 				Root:               commitmenttypes.NewMerkleRoot([]byte("app_hash")),
 				NextValidatorsHash: suite.valsHash,
 			},
-			false},
+			false,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/modules/light-clients/07-tendermint/types/header_test.go
+++ b/modules/light-clients/07-tendermint/types/header_test.go
@@ -21,9 +21,7 @@ func (suite *TendermintTestSuite) TestGetTime() {
 }
 
 func (suite *TendermintTestSuite) TestHeaderValidateBasic() {
-	var (
-		header *types.Header
-	)
+	var header *types.Header
 	testCases := []struct {
 		name     string
 		malleate func()

--- a/modules/light-clients/07-tendermint/types/misbehaviour_handle.go
+++ b/modules/light-clients/07-tendermint/types/misbehaviour_handle.go
@@ -101,7 +101,6 @@ func (cs ClientState) CheckMisbehaviourAndUpdateState(
 func checkMisbehaviourHeader(
 	clientState *ClientState, consState *ConsensusState, header *Header, currentTimestamp time.Time,
 ) error {
-
 	tmTrustedValset, err := tmtypes.ValidatorSetFromProto(header.TrustedValidators)
 	if err != nil {
 		return sdkerrors.Wrap(err, "trusted validator set is not tendermint validator set type")

--- a/modules/light-clients/07-tendermint/types/proposal_handle_test.go
+++ b/modules/light-clients/07-tendermint/types/proposal_handle_test.go
@@ -9,9 +9,7 @@ import (
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 )
 
-var (
-	frozenHeight = clienttypes.NewHeight(0, 1)
-)
+var frozenHeight = clienttypes.NewHeight(0, 1)
 
 func (suite *TendermintTestSuite) TestCheckSubstituteUpdateStateBasic() {
 	var (
@@ -43,7 +41,6 @@ func (suite *TendermintTestSuite) TestCheckSubstituteUpdateStateBasic() {
 		tc := tc
 
 		suite.Run(tc.name, func() {
-
 			suite.SetupTest() // reset
 			subjectPath := ibctesting.NewPath(suite.chainA, suite.chainB)
 			substitutePath = ibctesting.NewPath(suite.chainA, suite.chainB)
@@ -217,7 +214,6 @@ func (suite *TendermintTestSuite) TestCheckSubstituteAndUpdateState() {
 		// a client are each tested to ensure that unexpiry headers cannot update
 		// a client when a unfreezing header is required.
 		suite.Run(tc.name, func() {
-
 			// start by testing unexpiring the client
 			suite.SetupTest() // reset
 
@@ -303,7 +299,6 @@ func (suite *TendermintTestSuite) TestCheckSubstituteAndUpdateState() {
 				suite.Require().Error(err)
 				suite.Require().Nil(updatedClient)
 			}
-
 		})
 	}
 }
@@ -365,7 +360,6 @@ func (suite *TendermintTestSuite) TestIsMatchingClientState() {
 			tc.malleate()
 
 			suite.Require().Equal(tc.expPass, types.IsMatchingClientState(*subjectClientState, *substituteClientState))
-
 		})
 	}
 }

--- a/modules/light-clients/07-tendermint/types/store.go
+++ b/modules/light-clients/07-tendermint/types/store.go
@@ -96,7 +96,6 @@ func IterateConsensusMetadata(store sdk.KVStore, cb func(key, val []byte) bool) 
 		if len(keySplit) != 3 {
 			// ignore all consensus state keys
 			continue
-
 		}
 
 		if keySplit[2] != "processedTime" && keySplit[2] != "processedHeight" {

--- a/modules/light-clients/07-tendermint/types/upgrade_test.go
+++ b/modules/light-clients/07-tendermint/types/upgrade_test.go
@@ -10,9 +10,7 @@ import (
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 )
 
-var (
-	newChainId = "newChainId-1"
-)
+var newChainId = "newChainId-1"
 
 func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 	var (

--- a/modules/light-clients/09-localhost/types/client_state_test.go
+++ b/modules/light-clients/09-localhost/types/client_state_test.go
@@ -150,7 +150,6 @@ func (suite *LocalhostTestSuite) TestVerifyClientState() {
 			}
 		})
 	}
-
 }
 
 func (suite *LocalhostTestSuite) TestVerifyClientConsensusState() {
@@ -291,7 +290,6 @@ func (suite *LocalhostTestSuite) TestVerifyChannelState() {
 			clientState: types.NewClientState("chainID", clientHeight),
 			malleate: func() {
 				suite.store.Set(host.ChannelKey(testPortID, testChannelID), []byte("channel"))
-
 			},
 			channel: ch1,
 			expPass: false,
@@ -303,7 +301,6 @@ func (suite *LocalhostTestSuite) TestVerifyChannelState() {
 				bz, err := suite.cdc.Marshal(&ch2)
 				suite.Require().NoError(err)
 				suite.store.Set(host.ChannelKey(testPortID, testChannelID), bz)
-
 			},
 			channel: ch1,
 			expPass: false,

--- a/modules/light-clients/09-localhost/types/localhost_test.go
+++ b/modules/light-clients/09-localhost/types/localhost_test.go
@@ -17,9 +17,7 @@ const (
 	height = 4
 )
 
-var (
-	clientHeight = clienttypes.NewHeight(0, 10)
-)
+var clientHeight = clienttypes.NewHeight(0, 10)
 
 type LocalhostTestSuite struct {
 	suite.Suite

--- a/testing/coordinator.go
+++ b/testing/coordinator.go
@@ -181,7 +181,6 @@ func GetChainID(index int) string {
 // CONTRACT: the passed in list of indexes must not contain duplicates
 func (coord *Coordinator) CommitBlock(chains ...*TestChain) {
 	for _, chain := range chains {
-
 		chain.NextBlock()
 	}
 	coord.IncrementTime()

--- a/testing/events.go
+++ b/testing/events.go
@@ -64,7 +64,6 @@ func ParsePacketFromEvents(events sdk.Events) (channeltypes.Packet, error) {
 		if ev.Type == channeltypes.EventTypeSendPacket {
 			packet := channeltypes.Packet{}
 			for _, attr := range ev.Attributes {
-
 				switch string(attr.Key) {
 				case channeltypes.AttributeKeyData:
 					packet.Data = []byte(attr.Value)

--- a/testing/mock/ibc_module.go
+++ b/testing/mock/ibc_module.go
@@ -35,7 +35,6 @@ func (im IBCModule) OnChanOpenInit(
 ) error {
 	if im.IBCApp.OnChanOpenInit != nil {
 		return im.IBCApp.OnChanOpenInit(ctx, order, connectionHops, portID, channelID, chanCap, counterparty, version)
-
 	}
 
 	// Claim channel capability passed back by IBC module

--- a/testing/mock/ibc_module_test.go
+++ b/testing/mock/ibc_module_test.go
@@ -2,7 +2,7 @@ package mock_test
 
 import (
 	"testing"
-	
+
 	"github.com/stretchr/testify/require"
 
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"

--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -246,7 +246,6 @@ func NewSimApp(
 	homePath string, invCheckPeriod uint, encodingConfig simappparams.EncodingConfig,
 	appOpts servertypes.AppOptions, baseAppOptions ...func(*baseapp.BaseApp),
 ) *SimApp {
-
 	appCodec := encodingConfig.Marshaler
 	legacyAmino := encodingConfig.Amino
 	interfaceRegistry := encodingConfig.InterfaceRegistry
@@ -409,7 +408,7 @@ func NewSimApp(
 
 	// NOTE: we may consider parsing `appOpts` inside module constructors. For the moment
 	// we prefer to be more strict in what arguments the modules expect.
-	var skipGenesisInvariants = cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
+	skipGenesisInvariants := cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
 
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
@@ -550,7 +549,6 @@ func (app *SimApp) setTxHandler(txConfig client.TxConfig, indexEventsStr []strin
 		},
 		IBCKeeper: app.GetIBCKeeper(),
 	})
-
 	if err != nil {
 		panic(err)
 	}

--- a/testing/simapp/params/proto.go
+++ b/testing/simapp/params/proto.go
@@ -1,3 +1,4 @@
+//go:build !test_amino
 // +build !test_amino
 
 package params

--- a/testing/simapp/sdk_middleware.go
+++ b/testing/simapp/sdk_middleware.go
@@ -57,7 +57,7 @@ func NewDefaultTxHandler(options TxHandlerOptions) (tx.Handler, error) {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "IBC keeper is required for middlewares")
 	}
 
-	var sigGasConsumer = options.SigGasConsumer
+	sigGasConsumer := options.SigGasConsumer
 	if sigGasConsumer == nil {
 		sigGasConsumer = authmiddleware.DefaultSigVerificationGasConsumer
 	}

--- a/testing/simapp/sim_test.go
+++ b/testing/simapp/sim_test.go
@@ -164,11 +164,13 @@ func TestAppImportExport(t *testing.T) {
 
 	storeKeysPrefixes := []StoreKeysPrefixes{
 		{app.keys[authtypes.StoreKey], newApp.keys[authtypes.StoreKey], [][]byte{}},
-		{app.keys[stakingtypes.StoreKey], newApp.keys[stakingtypes.StoreKey],
+		{
+			app.keys[stakingtypes.StoreKey], newApp.keys[stakingtypes.StoreKey],
 			[][]byte{
 				stakingtypes.UnbondingQueueKey, stakingtypes.RedelegationQueueKey, stakingtypes.ValidatorQueueKey,
 				stakingtypes.HistoricalInfoKey,
-			}}, // ordering may change but it doesn't matter
+			},
+		}, // ordering may change but it doesn't matter
 		{app.keys[slashingtypes.StoreKey], newApp.keys[slashingtypes.StoreKey], [][]byte{}},
 		{app.keys[minttypes.StoreKey], newApp.keys[minttypes.StoreKey], [][]byte{}},
 		{app.keys[distrtypes.StoreKey], newApp.keys[distrtypes.StoreKey], [][]byte{}},

--- a/testing/simapp/simd/cmd/genaccounts_test.go
+++ b/testing/simapp/simd/cmd/genaccounts_test.go
@@ -73,7 +73,8 @@ func TestAddGenesisAccountCmd(t *testing.T) {
 			cmd.SetArgs([]string{
 				tc.addr,
 				tc.denom,
-				fmt.Sprintf("--%s=home", flags.FlagHome)})
+				fmt.Sprintf("--%s=home", flags.FlagHome),
+			})
 
 			if tc.expectErr {
 				require.Error(t, cmd.ExecuteContext(ctx))

--- a/testing/simapp/simd/cmd/root.go
+++ b/testing/simapp/simd/cmd/root.go
@@ -291,8 +291,8 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, a
 // and exports state.
 func (a appCreator) appExport(
 	logger log.Logger, db dbm.DB, traceStore io.Writer, height int64, forZeroHeight bool, jailAllowedAddrs []string,
-	appOpts servertypes.AppOptions) (servertypes.ExportedApp, error) {
-
+	appOpts servertypes.AppOptions,
+) (servertypes.ExportedApp, error) {
 	var simApp *simapp.SimApp
 	homePath, ok := appOpts.Get(flags.FlagHome).(string)
 	if !ok || homePath == "" {

--- a/testing/simapp/simd/cmd/testnet.go
+++ b/testing/simapp/simd/cmd/testnet.go
@@ -95,7 +95,7 @@ Example:
 	return cmd
 }
 
-const nodeDirPerm = 0755
+const nodeDirPerm = 0o755
 
 // Initialize the testnet
 func InitTestnet(
@@ -114,7 +114,6 @@ func InitTestnet(
 	algoStr string,
 	numValidators int,
 ) error {
-
 	if chainID == "" {
 		chainID = "chain-" + tmrand.Str(6)
 	}
@@ -271,7 +270,6 @@ func initGenFiles(
 	genAccounts []authtypes.GenesisAccount, genBalances []banktypes.Balance,
 	genFiles []string, numValidators int,
 ) error {
-
 	appGenState := mbm.DefaultGenesis(clientCtx.Codec)
 
 	// set the accounts in the genesis state
@@ -318,7 +316,6 @@ func collectGenFiles(
 	nodeIDs []string, valPubKeys []cryptotypes.PubKey, numValidators int,
 	outputDir, nodeDirPrefix, nodeDaemonHome string, genBalIterator banktypes.GenesisBalancesIterator,
 ) error {
-
 	var appState json.RawMessage
 	genTime := tmtime.Now()
 
@@ -387,12 +384,12 @@ func writeFile(name string, dir string, contents []byte) error {
 	writePath := filepath.Join(dir)
 	file := filepath.Join(writePath, name)
 
-	err := tmos.EnsureDir(writePath, 0755)
+	err := tmos.EnsureDir(writePath, 0o755)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(file, contents, 0644)
+	err = ioutil.WriteFile(file, contents, 0o644)
 	if err != nil {
 		return err
 	}

--- a/testing/simapp/state.go
+++ b/testing/simapp/state.go
@@ -28,7 +28,6 @@ import (
 func AppStateFn(cdc codec.JSONCodec, simManager *module.SimulationManager) simtypes.AppStateFn {
 	return func(r *rand.Rand, accs []simtypes.Account, config simtypes.Config,
 	) (appState json.RawMessage, simAccs []simtypes.Account, chainID string, genesisTimestamp time.Time) {
-
 		if FlagGenesisTimeValue == 0 {
 			genesisTimestamp = simtypes.RandTimestamp(r)
 		} else {

--- a/testing/simapp/test_helpers.go
+++ b/testing/simapp/test_helpers.go
@@ -64,7 +64,6 @@ func setup(withGenesis bool, invCheckPeriod uint) (*SimApp, GenesisState) {
 
 // Setup initializes a new SimApp. A Nop logger is set in SimApp.
 func Setup(isCheckTx bool) *SimApp {
-
 	privVal := mock.NewPV()
 	pubKey, _ := privVal.GetPubKey(nil)
 
@@ -87,7 +86,8 @@ func Setup(isCheckTx bool) *SimApp {
 
 func genesisStateWithValSet(app *SimApp, genesisState GenesisState,
 	valSet *tmtypes.ValidatorSet, genAccs []authtypes.GenesisAccount,
-	balances ...banktypes.Balance) GenesisState {
+	balances ...banktypes.Balance,
+) GenesisState {
 	// set genesis accounts
 	authGenesis := authtypes.NewGenesisState(authtypes.DefaultParams(), genAccs)
 	genesisState[authtypes.ModuleName] = app.AppCodec().MustMarshalJSON(authGenesis)
@@ -150,7 +150,6 @@ func genesisStateWithValSet(app *SimApp, genesisState GenesisState,
 // of one consensus engine unit in the default token of the simapp from first genesis
 // account. A Nop logger is set in SimApp.
 func SetupWithGenesisValSet(valSet *tmtypes.ValidatorSet, genAccs []authtypes.GenesisAccount, balances ...banktypes.Balance) *SimApp {
-
 	app, genesisState := setup(true, 5)
 	genesisState = genesisStateWithValSet(app, genesisState, valSet, genAccs, balances...)
 
@@ -337,7 +336,6 @@ func SignAndDeliver(
 	t *testing.T, txCfg client.TxConfig, app *bam.BaseApp, header tmproto.Header, msgs []sdk.Msg,
 	chainID string, accNums, accSeqs []uint64, expSimPass, expPass bool, priv ...cryptotypes.PrivKey,
 ) (sdk.GasInfo, *sdk.Result, error) {
-
 	tx, err := helpers.GenTx(
 		txCfg,
 		msgs,

--- a/testing/simapp/utils.go
+++ b/testing/simapp/utils.go
@@ -84,7 +84,7 @@ func CheckExportSimulation(
 			return err
 		}
 
-		if err := ioutil.WriteFile(config.ExportStatePath, []byte(exported.AppState), 0600); err != nil {
+		if err := ioutil.WriteFile(config.ExportStatePath, []byte(exported.AppState), 0o600); err != nil {
 			return err
 		}
 	}
@@ -96,7 +96,7 @@ func CheckExportSimulation(
 			return err
 		}
 
-		if err := ioutil.WriteFile(config.ExportParamsPath, paramsBz, 0600); err != nil {
+		if err := ioutil.WriteFile(config.ExportParamsPath, paramsBz, 0o600); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
- fumpting carlos sdk 46 tendermint 35 branch to make reviews of Notional's sdk 46 work easier

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This is an ergonomics PR that fumpts carlos sdk 46 branch currently in use on gaia, so that we can spare gaia and her dev team the pain of the middleware refactor. 

Intended use:

Merge this <- it fumpts carlos' branch so that it is closer to main
Merge beta-2 pr 1412 <- it updates carlos' branch to be compatible with latest ibc-go and sdk 46 beta 2
Merge sdk-master pr 1413 <- it brings carlos' branch up to date with latest cosmos sdk


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
