### PR TITLE
testing/ - Fix chain.LastHeader callsite

### DIFF
--- a/testing/chain.go
+++ b/testing/chain.go
@@ -271,14 +271,14 @@ func (chain *TestChain) NextBlock() {
 
 	chain.App.Commit()
 
-	// set the last header to the current header
-	// use nil trusted fields
-	chain.LastHeader = chain.CurrentTMClientHeader()
-
 	// val set changes returned from previous block get applied to the next validators
 	// of this block. See tendermint spec for details.
 	chain.Vals = chain.NextVals
 	chain.NextVals = ApplyValSetChanges(chain.T, chain.Vals, res.ValidatorUpdates)
+
+	// set the last header to the current header
+	// use nil trusted fields
+	chain.LastHeader = chain.CurrentTMClientHeader()
 
 	// increment the current header
 	chain.CurrentHeader = tmproto.Header{


### PR DESCRIPTION
## Bug

The way the light client works is:

When an `UpdateClient` operation completes and a header `H0` with height `h0`, `valset` `v0` and `nextValset` `nV0` becomes trusted the client stores `nV0` as the `trustedValset` for `h0`. A future `UpdateClient` operation might occur with header `H1`, height `h1` (`h0` < `h1`) and citing `h0` as the trusted height. For this operation to succeed the `trustedValset` included in `H1` must equal `nV0`. 

The bug is in the code: suppose an attempted execution following the above pattern. Suppose the header `H0` is trusted by the light client. This header was created from the field `chain.LastHeader` which is updated too early and thus has an incorrect `nextValSet`. Thus the field `nextValset` is set to `v0` and not `nV0`. This is trusted by the client so the client will expect a future header `H1` to have `trustedValset` equal to `v0`. But this `trustedValset` is correctly queried here

https://github.com/cosmos/ibc-go/blob/527a11a2bbe59e172649d5c22b87878d86859806/testing/chain.go#L411

using historical info, set by the staking module based on the correct notion of `nextVals`. Thus there is a mismatch. It will trigger this

https://github.com/cosmos/ibc-go/blob/527a11a2bbe59e172649d5c22b87878d86859806/modules/light-clients/07-tendermint/types/update.go#L155

I can replicate this bug but it is a bit involved. I will update this PR with more info if wanted when I have time.

## Extra info

See also `ValidatorHash` and `NextValidatorHash` here 

https://github.com/tendermint/tendermint/blob/master/spec/core/data_structures.md#header=

as well as [here in tendermint](https://github.com/tendermint/tendermint/blob/27c523dccbe7f2f577868ee871b0042c1fef9a53/proto/tendermint/types/types.pb.go#L276-L278)


```go
	// hashes from the app output from the prev block
	ValidatorsHash     []byte `protobuf:"bytes,8,opt,name=validators_hash,json=validatorsHash,proto3" json:"validators_hash,omitempty"`
	NextValidatorsHash []byte `protobuf:"bytes,9,opt,name=next_validators_hash,json=nextValidatorsHash,proto3" json:"next_validators_hash,omitempty"`
```

thus `Vals` and `NextVals` should be the same for both fields here

https://github.com/cosmos/ibc-go/blob/527a11a2bbe59e172649d5c22b87878d86859806/testing/chain.go#L56-L57

which they are not.

**PS: I wonder if there is a 'two wrongs make a right' thing going on somewhere in testing/, generally*