### PR TITLE
Adding manual triggering of e2e via workflow dispatch

### DIFF
--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -1,14 +1,16 @@
 name: Tests / E2E Fork
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
     paths-ignore:
       - docs/**
+
 jobs:
   # dynamically build a matrix of test/test suite pairs to run
   build-test-matrix:
-    if: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -24,7 +26,7 @@ jobs:
     env:
       SIMD_TAG: latest
       SIMD_IMAGE: ibc-go-simd-e2e
-    if: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     needs:
       - build-test-matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   docker-build:
-    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
 
   # dynamically build a matrix of test/test suite pairs to run
   build-test-matrix:
-    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -57,7 +57,7 @@ jobs:
   # the tag of the image will differ if this is a PR or the branch is being merged into main.
   # we store the tag as an environment variable and use it in the E2E tests to determine the tag.
   determine-image-tag:
-    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     outputs:
       simd-tag: ${{ steps.get-tag.outputs.simd-tag }}
@@ -74,7 +74,7 @@ jobs:
 
 
   e2e:
-    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     needs:
       - build-test-matrix

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,5 +1,6 @@
 name: Tests / E2E
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -13,7 +14,7 @@ env:
 
 jobs:
   docker-build:
-    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +41,7 @@ jobs:
 
   # dynamically build a matrix of test/test suite pairs to run
   build-test-matrix:
-    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -56,7 +57,7 @@ jobs:
   # the tag of the image will differ if this is a PR or the branch is being merged into main.
   # we store the tag as an environment variable and use it in the E2E tests to determine the tag.
   determine-image-tag:
-    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       simd-tag: ${{ steps.get-tag.outputs.simd-tag }}
@@ -73,7 +74,7 @@ jobs:
 
 
   e2e:
-    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     needs:
       - build-test-matrix


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adding the ability to trigger e2e workflows manually via `workflow_dispatch` will make debugging issues easier.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
