### PR TITLE
chore: adding channel upgrade restore path and key funcs to 24-host

### DIFF
--- a/modules/core/24-host/channel_keys.go
+++ b/modules/core/24-host/channel_keys.go
@@ -3,8 +3,10 @@ package host
 import "fmt"
 
 const (
-	KeyChannelEndPrefix = "channelEnds"
-	KeyChannelPrefix    = "channels"
+	KeyChannelEndPrefix     = "channelEnds"
+	KeyChannelPrefix        = "channels"
+	KeyChannelUpgradePrefix = "channelUpgrades"
+	KeyChannelRestoreSuffix = "restore"
 )
 
 // ICS04
@@ -26,6 +28,20 @@ func ChannelCapabilityPath(portID, channelID string) string {
 	return fmt.Sprintf("%s/%s", KeyChannelCapabilityPrefix, channelPath(portID, channelID))
 }
 
+// ChannelRestorePath defines the path under which channel ends are stored for restoration in the event of upgrade handshake failure
+func ChannelRestorePath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s", channelUpgradePath(portID, channelID), KeyChannelRestoreSuffix)
+}
+
+// ChannelRestoreKey returns the store key for a particular channel end used for restoratoin in the event of upgrade handshake failure
+func ChannelRestoreKey(portID, channelID string) []byte {
+	return []byte(ChannelRestorePath(portID, channelID))
+}
+
 func channelPath(portID, channelID string) string {
 	return fmt.Sprintf("%s/%s/%s/%s", KeyPortPrefix, portID, KeyChannelPrefix, channelID)
+}
+
+func channelUpgradePath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s", KeyChannelUpgradePrefix, channelPath(portID, channelID))
 }

--- a/modules/core/24-host/channel_keys.go
+++ b/modules/core/24-host/channel_keys.go
@@ -33,7 +33,7 @@ func ChannelRestorePath(portID, channelID string) string {
 	return fmt.Sprintf("%s/%s", channelUpgradePath(portID, channelID), KeyChannelRestoreSuffix)
 }
 
-// ChannelRestoreKey returns the store key for a particular channel end used for restoratoin in the event of upgrade handshake failure
+// ChannelRestoreKey returns the store key for a particular channel end used for restoration in the event of upgrade handshake failure
 func ChannelRestoreKey(portID, channelID string) []byte {
 	return []byte(ChannelRestorePath(portID, channelID))
 }

--- a/modules/core/24-host/channel_keys.go
+++ b/modules/core/24-host/channel_keys.go
@@ -6,7 +6,7 @@ const (
 	KeyChannelEndPrefix     = "channelEnds"
 	KeyChannelPrefix        = "channels"
 	KeyChannelUpgradePrefix = "channelUpgrades"
-	KeyChannelRestoreSuffix = "restore"
+	KeyChannelRestorePrefix = "restore"
 )
 
 // ICS04
@@ -30,7 +30,7 @@ func ChannelCapabilityPath(portID, channelID string) string {
 
 // ChannelRestorePath defines the path under which channel ends are stored for restoration in the event of upgrade handshake failure
 func ChannelRestorePath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s", channelUpgradePath(portID, channelID), KeyChannelRestoreSuffix)
+	return fmt.Sprintf("%s/%s/%s", KeyChannelUpgradePrefix, KeyChannelRestorePrefix, channelPath(portID, channelID))
 }
 
 // ChannelRestoreKey returns the store key for a particular channel end used for restoration in the event of upgrade handshake failure
@@ -40,8 +40,4 @@ func ChannelRestoreKey(portID, channelID string) []byte {
 
 func channelPath(portID, channelID string) string {
 	return fmt.Sprintf("%s/%s/%s/%s", KeyPortPrefix, portID, KeyChannelPrefix, channelID)
-}
-
-func channelUpgradePath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s", KeyChannelUpgradePrefix, channelPath(portID, channelID))
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Adding channel upgrade restore path and key funcs to `24-host`

closes: #1601

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
