### PR TITLE
chore: remove error return in IterateConsensusStateAscending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (06-solomachine) [\#1100](https://github.com/cosmos/ibc-go/pull/1100) Deprecate `ClientId` field in 06-solomachine `Misbehaviour` type. 
 * (07-tendermint) [\#1097](https://github.com/cosmos/ibc-go/pull/1097) Remove `GetClientID` function from 07-tendermint `Misbehaviour` type.
 * (07-tendermint) [\#1097](https://github.com/cosmos/ibc-go/pull/1097) Deprecate `ClientId` field in 07-tendermint `Misbehaviour` type.
-* (modules/core/exported) [\#1107](https://github.com/cosmos/ibc-go/pull/1107) Merging the `Header` and `Misbehaviour` interfaces into a single `ClientMessage` type
+* (modules/core/exported) [\#1107](https://github.com/cosmos/ibc-go/pull/1107) Merging the `Header` and `Misbehaviour` interfaces into a single `ClientMessage` type.
+* (07-tendermint) [\#1896](https://github.com/cosmos/ibc-go/pull/1896) Remove error return from `IterateConsensusStateAscending` in `07-tendermint`.
 
 ### State Machine Breaking
 

--- a/modules/core/02-client/legacy/v100/store.go
+++ b/modules/core/02-client/legacy/v100/store.go
@@ -96,10 +96,7 @@ func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.Binar
 			// add iteration keys so pruning will be successful
 			addConsensusMetadata(ctx, clientStore)
 
-			if err = ibctm.PruneAllExpiredConsensusStates(ctx, clientStore, cdc, tmClientState); err != nil {
-				return err
-			}
-
+			ibctm.PruneAllExpiredConsensusStates(ctx, clientStore, cdc, tmClientState)
 		default:
 			continue
 		}

--- a/modules/light-clients/07-tendermint/update.go
+++ b/modules/light-clients/07-tendermint/update.go
@@ -186,9 +186,7 @@ func (cs ClientState) pruneOldestConsensusState(ctx sdk.Context, cdc codec.Binar
 		return true
 	}
 
-	if err := IterateConsensusStateAscending(clientStore, pruneCb); err != nil {
-		panic(err)
-	}
+	IterateConsensusStateAscending(clientStore, pruneCb)
 
 	// if pruneHeight is set, delete consensus state and metadata
 	if pruneHeight != nil {

--- a/modules/light-clients/07-tendermint/update_test.go
+++ b/modules/light-clients/07-tendermint/update_test.go
@@ -488,8 +488,7 @@ func (suite *TendermintTestSuite) TestPruneConsensusState() {
 	}
 	ctx := path.EndpointA.Chain.GetContext()
 	clientStore := path.EndpointA.Chain.App.GetIBCKeeper().ClientKeeper.ClientStore(ctx, path.EndpointA.ClientID)
-	err := ibctm.IterateConsensusStateAscending(clientStore, getFirstHeightCb)
-	suite.Require().Nil(err)
+	ibctm.IterateConsensusStateAscending(clientStore, getFirstHeightCb)
 
 	// this height will be expired but not pruned
 	path.EndpointA.UpdateClient()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Removing error return from `IterateConsensusStateAscending` 
- Updating legacy code
- Updating tests

closes: #1886 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
