### PR TITLE
Use single registry for all images

### DIFF
--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -25,7 +25,7 @@ jobs:
   e2e:
     env:
       CHAIN_A_SIMD_TAG: latest
-      CHAIN_A_SIMD_IMAGE: ibc-go-simd-e2e
+      CHAIN_A_SIMD_IMAGE: ibc-go-simd
     if: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     needs:
       - build-test-matrix

--- a/.github/workflows/e2e-manual.yaml
+++ b/.github/workflows/e2e-manual.yaml
@@ -15,7 +15,7 @@ on:
         description: 'The image to use for chain A'
         required: true
         type: string
-        default: "ghcr.io/cosmos/ibc-go-simd-e2e"
+        default: "ghcr.io/cosmos/ibc-go-simd"
       chain-a-tag:
         description: 'The tag to use for chain A'
         required: true
@@ -39,6 +39,7 @@ on:
         required: true
         type: choice
         options:
+          - main
           - v4.0.0-rc3
           - v3.0.0
           - v2.2.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ibc-go-simd-e2e
+  IMAGE_NAME: ibc-go-simd
 
 jobs:
   docker-build:
@@ -82,7 +82,7 @@ jobs:
       - docker-build
     env:
       CHAIN_A_SIMD_TAG: ${{ needs.determine-image-tag.outputs.simd-tag }}
-      CHAIN_A_SIMD_IMAGE: ghcr.io/cosmos/ibc-go-simd-e2e
+      CHAIN_A_SIMD_IMAGE: ghcr.io/cosmos/ibc-go-simd
       # see images here https://github.com/cosmos/relayer/pkgs/container/relayer/versions
       RLY_TAG: "v2.0.0-rc2"
     strategy:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -58,7 +58,7 @@ Every time changes are pushed to a branch or to `main`, a new `simd` image is bu
 
 ```sh
 export CHAIN_A_SIMD_IMAGE="ghcr.io/cosmos/ibc-go-simd"
-export CHAIN_A_SIMD_TAG="pr-1650"
+export CHAIN_A_SIMD_TAG="main"
 
 # We can also specify different values for the chains if needed.
 # they will default to the same as chain a.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -40,29 +40,29 @@ There are several envinronment variables that alter the behaviour of the make ta
 
 | Environment Variable      | Description | Default Value|
 | ----------- | ----------- | ----------- |
-| SIMD_IMAGE      | The image that will be used for simd       | ibc-go-simd-e2e |
+| SIMD_IMAGE      | The image that will be used for simd       | ibc-go-simd |
 | SIMD_TAG   | The tag used for simd        | latest|
 | RLY_TAG   | The tag used for the go relayer        | main|
 
 
-> Note: when running tests locally, **no images are pushed** to the `ghcr.io/cosmos/ibc-go-simd-e2e` registry.
+> Note: when running tests locally, **no images are pushed** to the `ghcr.io/cosmos/ibc-go-simd` registry.
 The images which are used only exist on your machine.
 
 These environment variables allow us to run tests with arbitrary verions (from branches or released) of simd
 and the go relayer.
 
-Every time changes are pushed to a branch or to `main`, a new `simd` image is built and pushed [here](https://github.com/cosmos/ibc-go/pkgs/container/ibc-go-simd-e2e).
+Every time changes are pushed to a branch or to `main`, a new `simd` image is built and pushed [here](https://github.com/cosmos/ibc-go/pkgs/container/ibc-go-simd).
 
 
 #### Example Command:
 
 ```sh
-export CHAIN_A_SIMD_IMAGE="ghcr.io/cosmos/ibc-go-simd-e2e"
+export CHAIN_A_SIMD_IMAGE="ghcr.io/cosmos/ibc-go-simd"
 export CHAIN_A_SIMD_TAG="pr-1650"
 
 # We can also specify different values for the chains if needed.
 # they will default to the same as chain a.
-# export CHAIN_B_SIMD_IMAGE="ghcr.io/cosmos/ibc-go-simd-e2e"
+# export CHAIN_B_SIMD_IMAGE="ghcr.io/cosmos/ibc-go-simd"
 # export CHAIN_B_SIMD_TAG="pr-1650"
 
 export RLY_TAG="v2.0.0-rc2"
@@ -209,7 +209,7 @@ There are two main github actions for e2e tests.
 
 [e2e-fork.yaml](https://github.com/cosmos/ibc-go/blob/main/.github/workflows/e2e-fork.yml) which runs when forks are created.
 
-In `e2e.yaml`, the `simd` image is built and pushed to [a registry](https://github.com/cosmos/ibc-go/pkgs/container/ibc-go-simd-e2e) and every test
+In `e2e.yaml`, the `simd` image is built and pushed to [a registry](https://github.com/cosmos/ibc-go/pkgs/container/ibc-go-simd) and every test
 that is run uses the image that was built.
 
 In `e2e-fork.yaml`, images are not pushed to this registry, but instead remain local to the host runner.

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SUITE="${1}"
 TEST="${2}"
 export SIMD_TAG="${CHAIN_A_SIMD_TAG:-latest}"
-export SIMD_IMAGE="${CHAIN_A_SIMD_IMAGE:-ibc-go-simd-e2e}"
+export SIMD_IMAGE="${CHAIN_A_SIMD_IMAGE:-ibc-go-simd}"
 
 # In CI, the docker images will be built separately.
 # context for building the image is one directory up.

--- a/e2e/testconfig/testconfig.go
+++ b/e2e/testconfig/testconfig.go
@@ -20,7 +20,7 @@ const (
 	ChainBSimdTagEnv = "CHAIN_B_SIMD_TAG"
 	GoRelayerTagEnv  = "RLY_TAG"
 
-	defaultSimdImage = "ghcr.io/cosmos/ibc-go-simd-e2e"
+	defaultSimdImage = "ghcr.io/cosmos/ibc-go-simd"
 	defaultRlyTag    = "main"
 )
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Initially we used two registries to store images, `ghcr.io/cosmos/ibc-go-simd` for tags, e.g. `v2.0.0` and `ghcr.io/cosmos/ibc-go-simd-e2e` which stored images for `prs`. I think this actually makes things more convoluted and it would be simpler and easier to maintain to just store the images in a single registry.

All images will go [here](https://github.com/cosmos/ibc-go/pkgs/container/ibc-go-simd/versions) after this PR is merged.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
