### PR TITLE
Add manually triggerable Action to build simd Docker image

### DIFF
--- a/.github/workflows/build-simd-image-from-tag.yml
+++ b/.github/workflows/build-simd-image-from-tag.yml
@@ -25,4 +25,7 @@ jobs:
          - name: Fetch latest Dockerfile
            run: curl https://raw.githubusercontent.com/cosmos/ibc-go/main/Dockerfile -o Dockerfile
          - name: Build image
-           run: docker build . -t "${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}"
+           run: |
+            docker build . -t "${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}"
+            docker push "${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}"
+        

--- a/.github/workflows/build-simd-image-from-tag.yml
+++ b/.github/workflows/build-simd-image-from-tag.yml
@@ -23,6 +23,6 @@ jobs:
               username: ${{ github.actor }}
               password: ${{ secrets.GITHUB_TOKEN }}
          - name: Fetch latest Dockerfile
-           run: git checkout main -- Dockerfile
+           run: curl https://raw.githubusercontent.com/cosmos/ibc-go/main/Dockerfile -o Dockerfile
          - name: Build image
            run: docker build . -t "${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}"

--- a/.github/workflows/build-simd-image-from-tag.yml
+++ b/.github/workflows/build-simd-image-from-tag.yml
@@ -1,0 +1,28 @@
+name: Build Simd Image
+on:
+   push:
+
+env:
+   REGISTRY: ghcr.io
+   ORG: cosmos
+   IMAGE_NAME: ibc-go-simd-e2e
+   VERSION: v3.0.0
+
+jobs:
+   build-simd-image:
+      runs-on: ubuntu-latest
+      steps:
+         - uses: actions/checkout@v3
+           with:
+            ref: "${{ env.VERSION }}"
+            fetch-depth: 0
+         - name: Log in to the Container registry
+           uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+           with:
+              registry: ${{ env.REGISTRY }}
+              username: ${{ github.actor }}
+              password: ${{ secrets.GITHUB_TOKEN }}
+         - name: Fetch latest Dockerfile
+           run: git checkout main -- Dockerfile
+         - name: Build image
+           run: docker build . -t "${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}"

--- a/.github/workflows/build-simd-image-from-tag.yml
+++ b/.github/workflows/build-simd-image-from-tag.yml
@@ -1,15 +1,20 @@
 name: Build Simd Image
 on:
-   push:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag of the image to build'
+        required: true
+        type: string
 
 env:
    REGISTRY: ghcr.io
    ORG: cosmos
-   IMAGE_NAME: ibc-go-simd-e2e
-   VERSION: v2.0.0
+   IMAGE_NAME: ibc-go-simd
+   VERSION: "${{ inputs.tag }}"
 
 jobs:
-   build-simd-image:
+   build-image-at-tag:
       runs-on: ubuntu-latest
       steps:
          - uses: actions/checkout@v3
@@ -28,4 +33,3 @@ jobs:
            run: |
             docker build . -t "${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}"
             docker push "${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}"
-        

--- a/.github/workflows/build-simd-image-from-tag.yml
+++ b/.github/workflows/build-simd-image-from-tag.yml
@@ -6,7 +6,7 @@ env:
    REGISTRY: ghcr.io
    ORG: cosmos
    IMAGE_NAME: ibc-go-simd-e2e
-   VERSION: v3.0.0
+   VERSION: v2.0.0
 
 jobs:
    build-simd-image:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -316,7 +316,7 @@ All tests will be run on different hosts.
 
 If we ever need to manually build and push an image, we can do so with the [Build Simd Image](../.github/workflows/build-simd-image-from-tag.yml) GitHub workflow.
 
-Thie can be triggered manually from the UI by navigating to
+This can be triggered manually from the UI by navigating to
 
 `Actions` -> `Build Simd Image` -> `Run Workflow`
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -310,7 +310,7 @@ All tests will be run on different hosts.
 * When upgrading from e.g. v4 -> v5, in ibc-go, we cannot upgrade the go.mod under `e2e` since v5 will not yet exist. We need to upgrade it in a follow up PR.
 
 
-### Github Workflows
+### GitHub Workflows
 
 #### Building and pushing a `simd` image.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -322,7 +322,7 @@ Thie can be triggered manually from the UI by navigating to
 
 And providing the git tag.
 
-Alternatively, the [gh](https://cli.github.com/) cli tool can be used to trigger this workflow.
+Alternatively, the [gh](https://cli.github.com/) CLI tool can be used to trigger this workflow.
 
 ```bash
 gh workflow run "Build Simd Image" -f tag=v3.0.0

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -314,7 +314,7 @@ All tests will be run on different hosts.
 
 #### Building and pushing a `simd` image.
 
-If we ever need to manually build and push an image, we can do so with the [Build Simd Image](../.github/workflows/build-simd-image-from-tag.yml) github workflow.
+If we ever need to manually build and push an image, we can do so with the [Build Simd Image](../.github/workflows/build-simd-image-from-tag.yml) GitHub workflow.
 
 Thie can be triggered manually from the UI by navigating to
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,7 +15,8 @@
 2. [Test design](#test-design)
    - a. [ibctest](#ibctest)
    - b. [CI configuration](#ci-configuration)
-3. [Troubleshooting](#troubleshooting)
+3. [Github Workflows](#github-workflows) 
+4. [Troubleshooting](#troubleshooting)
 
 
 ## How to write tests
@@ -307,6 +308,25 @@ All tests will be run on different hosts.
 
 * Gas fees are set to zero to simply calcuations when asserting account balances.
 * When upgrading from e.g. v4 -> v5, in ibc-go, we cannot upgrade the go.mod under `e2e` since v5 will not yet exist. We need to upgrade it in a follow up PR.
+
+
+### Github Workflows
+
+#### Building and bushing a simd image.
+
+If we ever need to manually build and push an image, we can do so with the [Build Simd Image](../.github/workflows/build-simd-image-from-tag.yml) github workflow.
+
+Thie can be triggered manually from the UI by navigating to
+
+`Actions` -> `Build Simd Image` -> `Run Workflow`
+
+And providing the git tag.
+
+Alternatively, the [gh](https://cli.github.com/) cli tool can be used to trigger this workflow.
+
+```bash
+gh workflow run "Build Simd Image" -f tag=v3.0.0
+```
 
 ### Troubleshooting
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -312,7 +312,7 @@ All tests will be run on different hosts.
 
 ### Github Workflows
 
-#### Building and bushing a simd image.
+#### Building and pushing a `simd` image.
 
 If we ever need to manually build and push an image, we can do so with the [Build Simd Image](../.github/workflows/build-simd-image-from-tag.yml) github workflow.
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


I ran into a permissions error during the e2e tests which seems to have been a result of the original images not being built on a github runner. (they had been built on my local machine). The errors only occurred when using images that were not built on a github host.

See [this failure](https://github.com/cosmos/ibc-go/runs/7807503289?check_suite_focus=true) as a reference. 

See [this passing test](https://github.com/cosmos/ibc-go/runs/7808214404?check_suite_focus=true) which uses an image built by this workflow.

The test failures no longer occurred when the same image is built using this action instead.

Note: this workflow can be run with 

```bash
gh workflow run "Build Simd Image" --ref "cian/build-image-from-tag" -f tag=v3.0.0
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
