### PR TITLE
chore: moving reusable fee queries to E2ETestSuite

### DIFF
--- a/e2e/fee_middleware_test.go
+++ b/e2e/fee_middleware_test.go
@@ -34,19 +34,6 @@ func (s *FeeMiddlewareTestSuite) RegisterCounterPartyPayee(ctx context.Context, 
 	return s.BroadcastMessages(ctx, chain, user, msg)
 }
 
-// QueryCounterPartyPayee queries the counterparty payee of the given chain and relayer address on the specified channel.
-func (s *FeeMiddlewareTestSuite) QueryCounterPartyPayee(ctx context.Context, chain ibc.Chain, relayerAddress, channelID string) (string, error) {
-	queryClient := s.GetChainGRCPClients(chain).FeeQueryClient
-	res, err := queryClient.CounterpartyPayee(ctx, &feetypes.QueryCounterpartyPayeeRequest{
-		ChannelId: channelID,
-		Relayer:   relayerAddress,
-	})
-	if err != nil {
-		return "", err
-	}
-	return res.CounterpartyPayee, nil
-}
-
 // PayPacketFeeAsync broadcasts a MsgPayPacketFeeAsync message.
 func (s *FeeMiddlewareTestSuite) PayPacketFeeAsync(
 	ctx context.Context,
@@ -57,24 +44,6 @@ func (s *FeeMiddlewareTestSuite) PayPacketFeeAsync(
 ) (sdk.TxResponse, error) {
 	msg := feetypes.NewMsgPayPacketFeeAsync(packetID, packetFee)
 	return s.BroadcastMessages(ctx, chain, user, msg)
-}
-
-// QueryIncentivizedPacketsForChannel queries the incentivized packets on the specified channel.
-func (s *FeeMiddlewareTestSuite) QueryIncentivizedPacketsForChannel(
-	ctx context.Context,
-	chain *cosmos.CosmosChain,
-	portId,
-	channelId string,
-) ([]*feetypes.IdentifiedPacketFees, error) {
-	queryClient := s.GetChainGRCPClients(chain).FeeQueryClient
-	res, err := queryClient.IncentivizedPacketsForChannel(ctx, &feetypes.QueryIncentivizedPacketsForChannelRequest{
-		PortId:    portId,
-		ChannelId: channelId,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.IncentivizedPackets, err
 }
 
 func (s *FeeMiddlewareTestSuite) TestMsgPayPacketFee_AsyncSingleSender_Succeeds() {

--- a/e2e/interchain_accounts_test.go
+++ b/e2e/interchain_accounts_test.go
@@ -42,42 +42,11 @@ func (s *InterchainAccountsTestSuite) RegisterInterchainAccount(ctx context.Cont
 	return err
 }
 
-// QueryIncentivizedPacketsForChannel queries the incentivized packets on the specified channel.
-func (s *InterchainAccountsTestSuite) QueryIncentivizedPacketsForChannel(
-	ctx context.Context,
-	chain *cosmos.CosmosChain,
-	portId,
-	channelId string,
-) ([]*feetypes.IdentifiedPacketFees, error) {
-	queryClient := s.GetChainGRCPClients(chain).FeeQueryClient
-	res, err := queryClient.IncentivizedPacketsForChannel(ctx, &feetypes.QueryIncentivizedPacketsForChannelRequest{
-		PortId:    portId,
-		ChannelId: channelId,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.IncentivizedPackets, err
-}
-
 // RegisterCounterPartyPayee broadcasts a MsgRegisterCounterpartyPayee message.
 func (s *InterchainAccountsTestSuite) RegisterCounterPartyPayee(ctx context.Context, chain *cosmos.CosmosChain,
 	user *ibctest.User, portID, channelID, relayerAddr, counterpartyPayeeAddr string) (sdk.TxResponse, error) {
 	msg := feetypes.NewMsgRegisterCounterpartyPayee(portID, channelID, relayerAddr, counterpartyPayeeAddr)
 	return s.BroadcastMessages(ctx, chain, user, msg)
-}
-
-// QueryCounterPartyPayee queries the counterparty payee of the given chain and relayer address on the specified channel.
-func (s *InterchainAccountsTestSuite) QueryCounterPartyPayee(ctx context.Context, chain ibc.Chain, relayerAddress, channelID string) (string, error) {
-	queryClient := s.GetChainGRCPClients(chain).FeeQueryClient
-	res, err := queryClient.CounterpartyPayee(ctx, &feetypes.QueryCounterpartyPayeeRequest{
-		ChannelId: channelID,
-		Relayer:   relayerAddress,
-	})
-	if err != nil {
-		return "", err
-	}
-	return res.CounterpartyPayee, nil
 }
 
 func (s *InterchainAccountsTestSuite) TestMsgSubmitTx_SuccessfulTransfer() {

--- a/e2e/testsuite/grpc_query.go
+++ b/e2e/testsuite/grpc_query.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	intertxtypes "github.com/cosmos/interchain-accounts/x/inter-tx/types"
+	"github.com/strangelove-ventures/ibctest/chain/cosmos"
 	"github.com/strangelove-ventures/ibctest/ibc"
 
+	feetypes "github.com/cosmos/ibc-go/v5/modules/apps/29-fee/types"
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v5/modules/core/exported"
@@ -54,4 +56,35 @@ func (s *E2ETestSuite) QueryInterchainAccount(ctx context.Context, chain ibc.Cha
 		return "", err
 	}
 	return res.InterchainAccountAddress, nil
+}
+
+// QueryIncentivizedPacketsForChannel queries the incentivized packets on the specified channel.
+func (s *E2ETestSuite) QueryIncentivizedPacketsForChannel(
+	ctx context.Context,
+	chain *cosmos.CosmosChain,
+	portId,
+	channelId string,
+) ([]*feetypes.IdentifiedPacketFees, error) {
+	queryClient := s.GetChainGRCPClients(chain).FeeQueryClient
+	res, err := queryClient.IncentivizedPacketsForChannel(ctx, &feetypes.QueryIncentivizedPacketsForChannelRequest{
+		PortId:    portId,
+		ChannelId: channelId,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.IncentivizedPackets, err
+}
+
+// QueryCounterPartyPayee queries the counterparty payee of the given chain and relayer address on the specified channel.
+func (s *E2ETestSuite) QueryCounterPartyPayee(ctx context.Context, chain ibc.Chain, relayerAddress, channelID string) (string, error) {
+	queryClient := s.GetChainGRCPClients(chain).FeeQueryClient
+	res, err := queryClient.CounterpartyPayee(ctx, &feetypes.QueryCounterpartyPayeeRequest{
+		ChannelId: channelID,
+		Relayer:   relayerAddress,
+	})
+	if err != nil {
+		return "", err
+	}
+	return res.CounterpartyPayee, nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Moves duplicate fee queries to `E2ETestSuite`.

- https://github.com/cosmos/ibc-go/pull/2023#discussion_r947917429

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
