### PR TITLE
docs: updating migration docs with additional ics27 host parameter

### DIFF
--- a/docs/migrations/v4-to-v5.md
+++ b/docs/migrations/v4-to-v5.md
@@ -38,6 +38,25 @@ The `AnteDecorator` was actually renamed twice, but in [this PR](https://github.
 
 ## IBC Apps
 
+### ICS27 - Interchain Accounts
+
+An additional parameter, `ics4Wrapper` has been added to the `host` submodule `NewKeeper` function in `modules/apps/27-interchain-accounts/host/keeper`.
+This allows the `host` submodule to correctly unwrap the channel version for channel reopening handshakes in the `OnChanOpenTry` callback.
+
+```diff
+func NewKeeper(
+   cdc codec.BinaryCodec, 
+   key storetypes.StoreKey, 
+   paramSpace paramtypes.Subspace,
++  ics4Wrapper icatypes.ICS4Wrapper,
+   channelKeeper icatypes.ChannelKeeper, 
+   portKeeper icatypes.PortKeeper,
+	accountKeeper icatypes.AccountKeeper, 
+   scopedKeeper icatypes.ScopedKeeper, 
+   msgRouter icatypes.MessageRouter,
+) Keeper
+```
+
 ### Core
 
 The `key` parameter of the `NewKeeper` function in `modules/core/keeper` is now of type `storetypes.StoreKey` (where `storetypes` is an import alias for `"github.com/cosmos/cosmos-sdk/store/types"`):

--- a/docs/migrations/v4-to-v5.md
+++ b/docs/migrations/v4-to-v5.md
@@ -51,7 +51,7 @@ func NewKeeper(
 +  ics4Wrapper icatypes.ICS4Wrapper,
    channelKeeper icatypes.ChannelKeeper, 
    portKeeper icatypes.PortKeeper,
-	accountKeeper icatypes.AccountKeeper, 
+   accountKeeper icatypes.AccountKeeper, 
    scopedKeeper icatypes.ScopedKeeper, 
    msgRouter icatypes.MessageRouter,
 ) Keeper


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Adding API breaking change to migration docs for ICS27 `host` submodule `NewKeeper` function.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
