### PR TITLE
bug: add switch case to detect blank pointers in keeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (light-clients/solomachine) [#1839](https://github.com/cosmos/ibc-go/issues/1839) Fixed usage of the new diversifier in validation of changing diversifiers for the solo machine. The current diversifier must sign over the new diversifier.
 * (light-clients/07-tendermint) [\#1674](https://github.com/cosmos/ibc-go/pull/1674) Submitted ClientState is zeroed out before checking the proof in order to prevent the proposal from containing information governance is not actually voting on.
 * (modules/core/02-client)[\#1676](https://github.com/cosmos/ibc-go/pull/1676) ClientState must be zeroed out for `UpgradeProposals` to pass validation. This prevents a proposal containing information governance is not actually voting on.
+* (modules/core/keeper) [\#2268](https://github.com/cosmos/ibc-go/pull/2393) Added switch case in NewKeeper to cater for blank pointers.
 
 ## [v4.1.0](https://github.com/cosmos/ibc-go/releases/tag/v4.1.0) - 2022-09-20
 

--- a/modules/core/keeper/keeper.go
+++ b/modules/core/keeper/keeper.go
@@ -50,12 +50,28 @@ func NewKeeper(
 	}
 
 	// panic if any of the keepers passed in is empty
-	if reflect.ValueOf(stakingKeeper).IsZero() {
-		panic(fmt.Errorf("cannot initialize IBC keeper: empty staking keeper"))
+
+	// switch case to detect blank pointers
+	switch reflect.TypeOf(stakingKeeper).Kind() {
+	case reflect.Ptr:
+		if reflect.ValueOf(&stakingKeeper).IsZero() {
+			panic(fmt.Errorf("cannot initialize IBC keeper: empty staking keeper"))
+		}
+	default:
+		if reflect.ValueOf(stakingKeeper).IsZero() {
+			panic(fmt.Errorf("cannot initialize IBC keeper: empty staking keeper"))
+		}
 	}
 
-	if reflect.ValueOf(upgradeKeeper).IsZero() {
-		panic(fmt.Errorf("cannot initialize IBC keeper: empty upgrade keeper"))
+	switch reflect.TypeOf(upgradeKeeper).Kind() {
+	case reflect.Ptr:
+		if reflect.ValueOf(&upgradeKeeper).IsZero() {
+			panic(fmt.Errorf("cannot initialize IBC keeper: empty upgrade keeper"))
+		}
+	default:
+		if reflect.ValueOf(upgradeKeeper).IsZero() {
+			panic(fmt.Errorf("cannot initialize IBC keeper: empty upgrade keeper"))
+		}
 	}
 
 	if reflect.DeepEqual(capabilitykeeper.ScopedKeeper{}, scopedKeeper) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Added switch case to detect blank pointers in the keeper.


closes: #2268

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing) (already written)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`) (not applicable)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
