### PR TITLE
chore: updating `VerifyMembership` and `VerifyNonMembership` methods to use `Path` interface

### DIFF
--- a/modules/core/02-client/legacy/v100/solomachine.go
+++ b/modules/core/02-client/legacy/v100/solomachine.go
@@ -227,7 +227,7 @@ func (cs *ClientState) VerifyMembership(
 	delayTimePeriod uint64,
 	delayBlockPeriod uint64,
 	proof []byte,
-	path []byte,
+	path exported.Path,
 	value []byte,
 ) error {
 	panic("legacy solo machine is deprecated!")
@@ -242,7 +242,7 @@ func (cs *ClientState) VerifyNonMembership(
 	delayTimePeriod uint64,
 	delayBlockPeriod uint64,
 	proof []byte,
-	path []byte,
+	path exported.Path,
 ) error {
 	panic("legacy solo machine is deprecated")
 }

--- a/modules/core/03-connection/keeper/verify.go
+++ b/modules/core/03-connection/keeper/verify.go
@@ -41,11 +41,6 @@ func (k Keeper) VerifyClientState(
 		return err
 	}
 
-	path, err := k.cdc.Marshal(&merklePath)
-	if err != nil {
-		return err
-	}
-
 	bz, err := k.cdc.MarshalInterface(clientState)
 	if err != nil {
 		return err
@@ -54,7 +49,7 @@ func (k Keeper) VerifyClientState(
 	if err := targetClient.VerifyMembership(
 		ctx, clientStore, k.cdc, height,
 		0, 0, // skip delay period checks for non-packet processing verification
-		proof, path, bz,
+		proof, merklePath, bz,
 	); err != nil {
 		return sdkerrors.Wrapf(err, "failed client state verification for target client: %s", clientID)
 	}
@@ -90,11 +85,6 @@ func (k Keeper) VerifyClientConsensusState(
 		return err
 	}
 
-	path, err := k.cdc.Marshal(&merklePath)
-	if err != nil {
-		return err
-	}
-
 	bz, err := k.cdc.MarshalInterface(consensusState)
 	if err != nil {
 		return err
@@ -103,7 +93,7 @@ func (k Keeper) VerifyClientConsensusState(
 	if err := clientState.VerifyMembership(
 		ctx, clientStore, k.cdc, height,
 		0, 0, // skip delay period checks for non-packet processing verification
-		proof, path, bz,
+		proof, merklePath, bz,
 	); err != nil {
 		return sdkerrors.Wrapf(err, "failed consensus state verification for client (%s)", clientID)
 	}
@@ -139,11 +129,6 @@ func (k Keeper) VerifyConnectionState(
 		return err
 	}
 
-	path, err := k.cdc.Marshal(&merklePath)
-	if err != nil {
-		return err
-	}
-
 	connectionEnd, ok := counterpartyConnection.(connectiontypes.ConnectionEnd)
 	if !ok {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "invalid connection type %T", counterpartyConnection)
@@ -157,7 +142,7 @@ func (k Keeper) VerifyConnectionState(
 	if err := clientState.VerifyMembership(
 		ctx, clientStore, k.cdc, height,
 		0, 0, // skip delay period checks for non-packet processing verification
-		proof, path, bz,
+		proof, merklePath, bz,
 	); err != nil {
 		return sdkerrors.Wrapf(err, "failed connection state verification for client (%s)", clientID)
 	}
@@ -194,11 +179,6 @@ func (k Keeper) VerifyChannelState(
 		return err
 	}
 
-	path, err := k.cdc.Marshal(&merklePath)
-	if err != nil {
-		return err
-	}
-
 	channelEnd, ok := channel.(channeltypes.Channel)
 	if !ok {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "invalid channel type %T", channel)
@@ -212,7 +192,7 @@ func (k Keeper) VerifyChannelState(
 	if err := clientState.VerifyMembership(
 		ctx, clientStore, k.cdc, height,
 		0, 0, // skip delay period checks for non-packet processing verification
-		proof, path, bz,
+		proof, merklePath, bz,
 	); err != nil {
 		return sdkerrors.Wrapf(err, "failed channel state verification for client (%s)", clientID)
 	}
@@ -254,15 +234,10 @@ func (k Keeper) VerifyPacketCommitment(
 		return err
 	}
 
-	path, err := k.cdc.Marshal(&merklePath)
-	if err != nil {
-		return err
-	}
-
 	if err := clientState.VerifyMembership(
 		ctx, clientStore, k.cdc, height,
 		timeDelay, blockDelay,
-		proof, path, commitmentBytes,
+		proof, merklePath, commitmentBytes,
 	); err != nil {
 		return sdkerrors.Wrapf(err, "failed packet commitment verification for client (%s)", clientID)
 	}
@@ -304,15 +279,10 @@ func (k Keeper) VerifyPacketAcknowledgement(
 		return err
 	}
 
-	path, err := k.cdc.Marshal(&merklePath)
-	if err != nil {
-		return err
-	}
-
 	if err := clientState.VerifyMembership(
 		ctx, clientStore, k.cdc, height,
 		timeDelay, blockDelay,
-		proof, path, channeltypes.CommitAcknowledgement(acknowledgement),
+		proof, merklePath, channeltypes.CommitAcknowledgement(acknowledgement),
 	); err != nil {
 		return sdkerrors.Wrapf(err, "failed packet acknowledgement verification for client (%s)", clientID)
 	}
@@ -354,15 +324,10 @@ func (k Keeper) VerifyPacketReceiptAbsence(
 		return err
 	}
 
-	path, err := k.cdc.Marshal(&merklePath)
-	if err != nil {
-		return err
-	}
-
 	if err := clientState.VerifyNonMembership(
 		ctx, clientStore, k.cdc, height,
 		timeDelay, blockDelay,
-		proof, path,
+		proof, merklePath,
 	); err != nil {
 		return sdkerrors.Wrapf(err, "failed packet receipt absence verification for client (%s)", clientID)
 	}
@@ -403,15 +368,10 @@ func (k Keeper) VerifyNextSequenceRecv(
 		return err
 	}
 
-	path, err := k.cdc.Marshal(&merklePath)
-	if err != nil {
-		return err
-	}
-
 	if err := clientState.VerifyMembership(
 		ctx, clientStore, k.cdc, height,
 		timeDelay, blockDelay,
-		proof, path, sdk.Uint64ToBigEndian(nextSequenceRecv),
+		proof, merklePath, sdk.Uint64ToBigEndian(nextSequenceRecv),
 	); err != nil {
 		return sdkerrors.Wrapf(err, "failed next sequence receive verification for client (%s)", clientID)
 	}

--- a/modules/core/exported/client.go
+++ b/modules/core/exported/client.go
@@ -74,7 +74,7 @@ type ClientState interface {
 		delayTimePeriod uint64,
 		delayBlockPeriod uint64,
 		proof []byte,
-		path []byte,
+		path Path,
 		value []byte,
 	) error
 
@@ -88,7 +88,7 @@ type ClientState interface {
 		delayTimePeriod uint64,
 		delayBlockPeriod uint64,
 		proof []byte,
-		path []byte,
+		path Path,
 	) error
 
 	// VerifyClientMessage must verify a ClientMessage. A ClientMessage could be a Header, Misbehaviour, or batch update.

--- a/modules/light-clients/06-solomachine/client_state.go
+++ b/modules/light-clients/06-solomachine/client_state.go
@@ -112,7 +112,7 @@ func (cs *ClientState) VerifyMembership(
 	delayTimePeriod uint64,
 	delayBlockPeriod uint64,
 	proof []byte,
-	path []byte,
+	path exported.Path,
 	value []byte,
 ) error {
 	publicKey, sigData, timestamp, sequence, err := produceVerificationArgs(cdc, cs, height, proof)
@@ -120,9 +120,9 @@ func (cs *ClientState) VerifyMembership(
 		return err
 	}
 
-	var merklePath commitmenttypes.MerklePath
-	if err := cdc.Unmarshal(path, &merklePath); err != nil {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "failed to unmarshal path into ICS 23 commitment merkle path")
+	merklePath, ok := path.(commitmenttypes.MerklePath)
+	if !ok {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "expected %T, got %T", commitmenttypes.MerklePath{}, path)
 	}
 
 	signBytes := &SignBytes{
@@ -159,16 +159,16 @@ func (cs *ClientState) VerifyNonMembership(
 	delayTimePeriod uint64,
 	delayBlockPeriod uint64,
 	proof []byte,
-	path []byte,
+	path exported.Path,
 ) error {
 	publicKey, sigData, timestamp, sequence, err := produceVerificationArgs(cdc, cs, height, proof)
 	if err != nil {
 		return err
 	}
 
-	var merklePath commitmenttypes.MerklePath
-	if err := cdc.Unmarshal(path, &merklePath); err != nil {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "failed to unmarshal path into ICS 23 commitment merkle path")
+	merklePath, ok := path.(commitmenttypes.MerklePath)
+	if !ok {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "expected %T, got %T", commitmenttypes.MerklePath{}, path)
 	}
 
 	signBytes := &SignBytes{

--- a/modules/light-clients/06-solomachine/client_state_test.go
+++ b/modules/light-clients/06-solomachine/client_state_test.go
@@ -145,7 +145,7 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 			clientState *solomachine.ClientState
 			err         error
 			height      clienttypes.Height
-			path        []byte
+			path        exported.Path
 			proof       []byte
 			testingPath *ibctesting.Path
 			signBytes   solomachine.SignBytes
@@ -168,12 +168,12 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 					clientStateBz, err := suite.chainA.Codec.Marshal(clientState)
 					suite.Require().NoError(err)
 
-					merklePath := suite.solomachine.GetClientStatePath(counterpartyClientIdentifier)
+					path = suite.solomachine.GetClientStatePath(counterpartyClientIdentifier)
 					signBytes = solomachine.SignBytes{
 						Sequence:    sm.GetHeight().GetRevisionHeight(),
 						Timestamp:   sm.Time,
 						Diversifier: sm.Diversifier,
-						Path:        []byte(merklePath.String()),
+						Path:        []byte(path.String()),
 						Data:        clientStateBz,
 					}
 
@@ -186,9 +186,6 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 						SignatureData: sig,
 						Timestamp:     sm.Time,
 					}
-
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
 
 					proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 					suite.Require().NoError(err)
@@ -203,12 +200,12 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 					consensusStateBz, err := suite.chainA.Codec.Marshal(consensusState)
 					suite.Require().NoError(err)
 
-					merklePath := sm.GetConsensusStatePath(counterpartyClientIdentifier, height)
+					path = sm.GetConsensusStatePath(counterpartyClientIdentifier, height)
 					signBytes = solomachine.SignBytes{
 						Sequence:    sm.Sequence,
 						Timestamp:   sm.Time,
 						Diversifier: sm.Diversifier,
-						Path:        []byte(merklePath.String()),
+						Path:        []byte(path.String()),
 						Data:        consensusStateBz,
 					}
 
@@ -221,9 +218,6 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 						SignatureData: sig,
 						Timestamp:     sm.Time,
 					}
-
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
 
 					proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 					suite.Require().NoError(err)
@@ -241,12 +235,12 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 					connectionEndBz, err := suite.chainA.Codec.Marshal(&connectionEnd)
 					suite.Require().NoError(err)
 
-					merklePath := sm.GetConnectionStatePath(ibctesting.FirstConnectionID)
+					path = sm.GetConnectionStatePath(ibctesting.FirstConnectionID)
 					signBytes = solomachine.SignBytes{
 						Sequence:    sm.Sequence,
 						Timestamp:   sm.Time,
 						Diversifier: sm.Diversifier,
-						Path:        []byte(merklePath.String()),
+						Path:        []byte(path.String()),
 						Data:        connectionEndBz,
 					}
 
@@ -259,9 +253,6 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 						SignatureData: sig,
 						Timestamp:     sm.Time,
 					}
-
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
 
 					proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 					suite.Require().NoError(err)
@@ -280,12 +271,12 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 					channelEndBz, err := suite.chainA.Codec.Marshal(&channelEnd)
 					suite.Require().NoError(err)
 
-					merklePath := sm.GetChannelStatePath(ibctesting.MockPort, ibctesting.FirstChannelID)
+					path = sm.GetChannelStatePath(ibctesting.MockPort, ibctesting.FirstChannelID)
 					signBytes = solomachine.SignBytes{
 						Sequence:    sm.Sequence,
 						Timestamp:   sm.Time,
 						Diversifier: sm.Diversifier,
-						Path:        []byte(merklePath.String()),
+						Path:        []byte(path.String()),
 						Data:        channelEndBz,
 					}
 
@@ -298,9 +289,6 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 						SignatureData: sig,
 						Timestamp:     sm.Time,
 					}
-
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
 
 					proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 					suite.Require().NoError(err)
@@ -316,12 +304,12 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 					nextSeqRecv, found := suite.chainA.GetSimApp().IBCKeeper.ChannelKeeper.GetNextSequenceRecv(suite.chainA.GetContext(), ibctesting.MockPort, ibctesting.FirstChannelID)
 					suite.Require().True(found)
 
-					merklePath := sm.GetNextSequenceRecvPath(ibctesting.MockPort, ibctesting.FirstChannelID)
+					path = sm.GetNextSequenceRecvPath(ibctesting.MockPort, ibctesting.FirstChannelID)
 					signBytes = solomachine.SignBytes{
 						Sequence:    sm.Sequence,
 						Timestamp:   sm.Time,
 						Diversifier: sm.Diversifier,
-						Path:        []byte(merklePath.String()),
+						Path:        []byte(path.String()),
 						Data:        sdk.Uint64ToBigEndian(nextSeqRecv),
 					}
 
@@ -334,9 +322,6 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 						SignatureData: sig,
 						Timestamp:     sm.Time,
 					}
-
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
 
 					proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 					suite.Require().NoError(err)
@@ -358,12 +343,12 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 					)
 
 					commitmentBz := channeltypes.CommitPacket(suite.chainA.Codec, packet)
-					merklePath := sm.GetPacketCommitmentPath(ibctesting.MockPort, ibctesting.FirstChannelID)
+					path = sm.GetPacketCommitmentPath(ibctesting.MockPort, ibctesting.FirstChannelID)
 					signBytes = solomachine.SignBytes{
 						Sequence:    sm.Sequence,
 						Timestamp:   sm.Time,
 						Diversifier: sm.Diversifier,
-						Path:        []byte(merklePath.String()),
+						Path:        []byte(path.String()),
 						Data:        commitmentBz,
 					}
 
@@ -377,9 +362,6 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 						Timestamp:     sm.Time,
 					}
 
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
-
 					proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 					suite.Require().NoError(err)
 				},
@@ -388,12 +370,12 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 			{
 				"success: packet acknowledgement verification",
 				func() {
-					merklePath := sm.GetPacketAcknowledgementPath(ibctesting.MockPort, ibctesting.FirstChannelID)
+					path = sm.GetPacketAcknowledgementPath(ibctesting.MockPort, ibctesting.FirstChannelID)
 					signBytes = solomachine.SignBytes{
 						Sequence:    sm.Sequence,
 						Timestamp:   sm.Time,
 						Diversifier: sm.Diversifier,
-						Path:        []byte(merklePath.String()),
+						Path:        []byte(path.String()),
 						Data:        ibctesting.MockAcknowledgement,
 					}
 
@@ -407,9 +389,6 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 						Timestamp:     sm.Time,
 					}
 
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
-
 					proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 					suite.Require().NoError(err)
 				},
@@ -418,12 +397,12 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 			{
 				"success: packet receipt verification",
 				func() {
-					merklePath := sm.GetPacketReceiptPath(ibctesting.MockPort, ibctesting.FirstChannelID)
+					path = sm.GetPacketReceiptPath(ibctesting.MockPort, ibctesting.FirstChannelID)
 					signBytes = solomachine.SignBytes{
 						Sequence:    sm.Sequence,
 						Timestamp:   sm.Time,
 						Diversifier: sm.Diversifier,
-						Path:        []byte(merklePath.String()),
+						Path:        []byte(path.String()),
 						Data:        []byte{byte(1)}, // packet receipt is stored as a single byte
 					}
 
@@ -436,9 +415,6 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 						SignatureData: sig,
 						Timestamp:     sm.Time,
 					}
-
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
 
 					proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 					suite.Require().NoError(err)
@@ -465,19 +441,9 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 				false,
 			},
 			{
-				"malformed merkle path fails to unmarshal",
-				func() {
-					path = []byte("invalid path")
-				},
-				false,
-			},
-			{
 				"malformed proof fails to unmarshal",
 				func() {
-					merklePath := suite.solomachine.GetClientStatePath(counterpartyClientIdentifier)
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
-
+					path = suite.solomachine.GetClientStatePath(counterpartyClientIdentifier)
 					proof = []byte("invalid proof")
 				},
 				false,
@@ -553,12 +519,12 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 				clientState = sm.ClientState()
 				height = clienttypes.NewHeight(sm.GetHeight().GetRevisionNumber(), sm.GetHeight().GetRevisionHeight())
 
-				merklePath := commitmenttypes.NewMerklePath("ibc", "solomachine")
+				path = commitmenttypes.NewMerklePath("ibc", "solomachine")
 				signBytes = solomachine.SignBytes{
 					Sequence:    sm.GetHeight().GetRevisionHeight(),
 					Timestamp:   sm.Time,
 					Diversifier: sm.Diversifier,
-					Path:        []byte(merklePath.String()),
+					Path:        []byte(path.String()),
 					Data:        []byte("solomachine"),
 				}
 
@@ -571,9 +537,6 @@ func (suite *SoloMachineTestSuite) TestVerifyMembership() {
 					SignatureData: sig,
 					Timestamp:     sm.Time,
 				}
-
-				path, err = suite.chainA.Codec.Marshal(&merklePath)
-				suite.Require().NoError(err)
 
 				proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 				suite.Require().NoError(err)
@@ -611,7 +574,7 @@ func (suite *SoloMachineTestSuite) TestVerifyNonMembership() {
 			clientState *solomachine.ClientState
 			err         error
 			height      clienttypes.Height
-			path        []byte
+			path        exported.Path
 			proof       []byte
 			signBytes   solomachine.SignBytes
 		)
@@ -629,12 +592,12 @@ func (suite *SoloMachineTestSuite) TestVerifyNonMembership() {
 			{
 				"success: packet receipt absence verification",
 				func() {
-					merklePath := suite.solomachine.GetPacketReceiptPath(ibctesting.MockPort, ibctesting.FirstChannelID)
+					path = suite.solomachine.GetPacketReceiptPath(ibctesting.MockPort, ibctesting.FirstChannelID)
 					signBytes = solomachine.SignBytes{
 						Sequence:    sm.GetHeight().GetRevisionHeight(),
 						Timestamp:   sm.Time,
 						Diversifier: sm.Diversifier,
-						Path:        []byte(merklePath.String()),
+						Path:        []byte(path.String()),
 						Data:        nil,
 					}
 
@@ -647,9 +610,6 @@ func (suite *SoloMachineTestSuite) TestVerifyNonMembership() {
 						SignatureData: sig,
 						Timestamp:     sm.Time,
 					}
-
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
 
 					proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 					suite.Require().NoError(err)
@@ -676,19 +636,9 @@ func (suite *SoloMachineTestSuite) TestVerifyNonMembership() {
 				false,
 			},
 			{
-				"malformed merkle path fails to unmarshal",
-				func() {
-					path = []byte("invalid path")
-				},
-				false,
-			},
-			{
 				"malformed proof fails to unmarshal",
 				func() {
-					merklePath := suite.solomachine.GetClientStatePath(counterpartyClientIdentifier)
-					path, err = suite.chainA.Codec.Marshal(&merklePath)
-					suite.Require().NoError(err)
-
+					path = suite.solomachine.GetClientStatePath(counterpartyClientIdentifier)
 					proof = []byte("invalid proof")
 				},
 				false,
@@ -774,12 +724,12 @@ func (suite *SoloMachineTestSuite) TestVerifyNonMembership() {
 				clientState = sm.ClientState()
 				height = clienttypes.NewHeight(sm.GetHeight().GetRevisionNumber(), sm.GetHeight().GetRevisionHeight())
 
-				merklePath := commitmenttypes.NewMerklePath("ibc", "solomachine")
+				path = commitmenttypes.NewMerklePath("ibc", "solomachine")
 				signBytes = solomachine.SignBytes{
 					Sequence:    sm.GetHeight().GetRevisionHeight(),
 					Timestamp:   sm.Time,
 					Diversifier: sm.Diversifier,
-					Path:        []byte(merklePath.String()),
+					Path:        []byte(path.String()),
 					Data:        nil,
 				}
 
@@ -792,9 +742,6 @@ func (suite *SoloMachineTestSuite) TestVerifyNonMembership() {
 					SignatureData: sig,
 					Timestamp:     sm.Time,
 				}
-
-				path, err = suite.chainA.Codec.Marshal(&merklePath)
-				suite.Require().NoError(err)
 
 				proof, err = suite.chainA.Codec.Marshal(signatureDoc)
 				suite.Require().NoError(err)

--- a/modules/light-clients/07-tendermint/client_state.go
+++ b/modules/light-clients/07-tendermint/client_state.go
@@ -210,7 +210,7 @@ func (cs ClientState) VerifyMembership(
 	delayTimePeriod uint64,
 	delayBlockPeriod uint64,
 	proof []byte,
-	path []byte,
+	path exported.Path,
 	value []byte,
 ) error {
 	if cs.GetLatestHeight().LT(height) {
@@ -229,9 +229,9 @@ func (cs ClientState) VerifyMembership(
 		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "failed to unmarshal proof into ICS 23 commitment merkle proof")
 	}
 
-	var merklePath commitmenttypes.MerklePath
-	if err := cdc.Unmarshal(path, &merklePath); err != nil {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "failed to unmarshal path into ICS 23 commitment merkle path")
+	merklePath, ok := path.(commitmenttypes.MerklePath)
+	if !ok {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "expected %T, got %T", commitmenttypes.MerklePath{}, path)
 	}
 
 	consensusState, found := GetConsensusState(clientStore, cdc, height)
@@ -256,7 +256,7 @@ func (cs ClientState) VerifyNonMembership(
 	delayTimePeriod uint64,
 	delayBlockPeriod uint64,
 	proof []byte,
-	path []byte,
+	path exported.Path,
 ) error {
 	if cs.GetLatestHeight().LT(height) {
 		return sdkerrors.Wrapf(
@@ -274,9 +274,9 @@ func (cs ClientState) VerifyNonMembership(
 		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "failed to unmarshal proof into ICS 23 commitment merkle proof")
 	}
 
-	var merklePath commitmenttypes.MerklePath
-	if err := cdc.Unmarshal(path, &merklePath); err != nil {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "failed to unmarshal path into ICS 23 commitment merkle path")
+	merklePath, ok := path.(commitmenttypes.MerklePath)
+	if !ok {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "expected %T, got %T", commitmenttypes.MerklePath{}, path)
 	}
 
 	consensusState, found := GetConsensusState(clientStore, cdc, height)

--- a/modules/light-clients/07-tendermint/client_state_test.go
+++ b/modules/light-clients/07-tendermint/client_state_test.go
@@ -214,9 +214,10 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 		testingpath      *ibctesting.Path
 		delayTimePeriod  uint64
 		delayBlockPeriod uint64
+		err              error
 		proofHeight      exported.Height
 		proof            []byte
-		path             []byte
+		path             exported.Path
 		value            []byte
 	)
 
@@ -236,10 +237,7 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 			"successful ConsensusState verification", func() {
 				key := host.FullConsensusStateKey(testingpath.EndpointB.ClientID, testingpath.EndpointB.GetClientState().GetLatestHeight())
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = suite.chainB.QueryProof(key)
@@ -254,10 +252,7 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 			"successful Connection verification", func() {
 				key := host.ConnectionKey(testingpath.EndpointB.ConnectionID)
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = suite.chainB.QueryProof(key)
@@ -272,10 +267,7 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 			"successful Channel verification", func() {
 				key := host.ChannelKey(testingpath.EndpointB.ChannelConfig.PortID, testingpath.EndpointB.ChannelID)
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = suite.chainB.QueryProof(key)
@@ -296,10 +288,7 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 				packet := channeltypes.NewPacket(ibctesting.MockPacketData, sequence, testingpath.EndpointB.ChannelConfig.PortID, testingpath.EndpointB.ChannelID, testingpath.EndpointA.ChannelConfig.PortID, testingpath.EndpointA.ChannelID, clienttypes.NewHeight(1, 100), 0)
 				key := host.PacketCommitmentKey(packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = testingpath.EndpointB.QueryProof(key)
@@ -320,10 +309,7 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 
 				key := host.PacketAcknowledgementKey(packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = testingpath.EndpointB.QueryProof(key)
@@ -347,10 +333,7 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 
 				key := host.NextSequenceRecvKey(packet.GetSourcePort(), packet.GetSourceChannel())
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = testingpath.EndpointB.QueryProof(key)
@@ -363,10 +346,7 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 			"successful verification outside IBC store", func() {
 				key := transfertypes.PortKey
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(commitmenttypes.NewMerklePrefix([]byte(transfertypes.StoreKey)), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(commitmenttypes.NewMerklePrefix([]byte(transfertypes.StoreKey)), merklePath)
 				suite.Require().NoError(err)
 
 				clientState := testingpath.EndpointA.GetClientState()
@@ -407,11 +387,6 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 			}, false,
 		},
 		{
-			"failed to unmarshal merkle path", func() {
-				path = []byte("invalid merkle path")
-			}, false,
-		},
-		{
 			"failed to unmarshal merkle proof", func() {
 				proof = invalidProof
 			}, false,
@@ -446,10 +421,7 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 			// may be overwritten by malleate()
 			key := host.FullClientStateKey(testingpath.EndpointB.ClientID)
 			merklePath := commitmenttypes.NewMerklePath(string(key))
-			merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-			suite.Require().NoError(err)
-
-			path, err = suite.chainA.Codec.Marshal(&merklePath)
+			path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 			suite.Require().NoError(err)
 
 			proof, proofHeight = suite.chainB.QueryProof(key)
@@ -484,9 +456,10 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 		testingpath         *ibctesting.Path
 		delayTimePeriod     uint64
 		delayBlockPeriod    uint64
+		err                 error
 		proofHeight         exported.Height
+		path                exported.Path
 		proof               []byte
-		path                []byte
 		invalidClientID     = "09-tendermint"
 		invalidConnectionID = "connection-100"
 		invalidChannelID    = "channel-800"
@@ -509,10 +482,7 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 			"successful ConsensusState verification of non membership", func() {
 				key := host.FullConsensusStateKey(invalidClientID, testingpath.EndpointB.GetClientState().GetLatestHeight())
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = suite.chainB.QueryProof(key)
@@ -523,10 +493,7 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 			"successful Connection verification of non membership", func() {
 				key := host.ConnectionKey(invalidConnectionID)
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = suite.chainB.QueryProof(key)
@@ -537,10 +504,7 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 			"successful Channel verification of non membership", func() {
 				key := host.ChannelKey(testingpath.EndpointB.ChannelConfig.PortID, invalidChannelID)
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = suite.chainB.QueryProof(key)
@@ -552,10 +516,7 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 				// make packet commitment proof
 				key := host.PacketCommitmentKey(invalidPortID, invalidChannelID, 1)
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = testingpath.EndpointB.QueryProof(key)
@@ -565,10 +526,7 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 			"successful Acknowledgement verification of non membership", func() {
 				key := host.PacketAcknowledgementKey(invalidPortID, invalidChannelID, 1)
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = testingpath.EndpointB.QueryProof(key)
@@ -579,10 +537,7 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 			"successful NextSequenceRecv verification of non membership", func() {
 				key := host.NextSequenceRecvKey(invalidPortID, invalidChannelID)
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = testingpath.EndpointB.QueryProof(key)
@@ -593,10 +548,7 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 			"successful verification of non membership outside IBC store", func() {
 				key := []byte{0x08}
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(commitmenttypes.NewMerklePrefix([]byte(transfertypes.StoreKey)), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainB.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(commitmenttypes.NewMerklePrefix([]byte(transfertypes.StoreKey)), merklePath)
 				suite.Require().NoError(err)
 
 				clientState := testingpath.EndpointA.GetClientState()
@@ -634,11 +586,6 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 			}, false,
 		},
 		{
-			"failed to unmarshal merkle path", func() {
-				path = []byte("invalid merkle path")
-			}, false,
-		},
-		{
 			"failed to unmarshal merkle proof", func() {
 				proof = invalidProof
 			}, false,
@@ -653,10 +600,7 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 				// change the value being proved
 				key := host.FullClientStateKey(testingpath.EndpointB.ClientID)
 				merklePath := commitmenttypes.NewMerklePath(string(key))
-				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-				suite.Require().NoError(err)
-
-				path, err = suite.chainA.Codec.Marshal(&merklePath)
+				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = suite.chainB.QueryProof(key)
@@ -682,10 +626,7 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 			key := host.FullClientStateKey("invalid-client-id")
 
 			merklePath := commitmenttypes.NewMerklePath(string(key))
-			merklePath, err := commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
-			suite.Require().NoError(err)
-
-			path, err = suite.chainA.Codec.Marshal(&merklePath)
+			path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 			suite.Require().NoError(err)
 
 			proof, proofHeight = suite.chainB.QueryProof(key)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Updating `VerifyMembership` and `VerifyNonMembership` client state methods to use `Path` interface in favour of `[]byte`. This removes the need for marshalling and unmarshalling the key path in `03-connection` and lightclient modules respectively.

closes: #1884 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
