### PR TITLE
chore: adding defensive checks to ics27 capability migrations

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/migrations/v6/migrations.go
+++ b/modules/apps/27-interchain-accounts/controller/migrations/v6/migrations.go
@@ -9,6 +9,7 @@ import (
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 
 	controllertypes "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/controller/types"
+	host "github.com/cosmos/ibc-go/v6/modules/core/24-host"
 )
 
 // MigrateICS27ChannelCapability performs a search on a prefix store using the provided store key and module name.
@@ -31,6 +32,10 @@ func MigrateICS27ChannelCapability(
 
 		var owners capabilitytypes.CapabilityOwners
 		cdc.MustUnmarshal(iterator.Value(), &owners)
+
+		if !hasIBCOwner(owners.GetOwners()) {
+			continue
+		}
 
 		for _, owner := range owners.GetOwners() {
 			if owner.Module == module {
@@ -55,4 +60,18 @@ func MigrateICS27ChannelCapability(
 	capabilityKeeper.InitMemStore(ctx)
 
 	return nil
+}
+
+func hasIBCOwner(owners []capabilitytypes.Owner) bool {
+	if len(owners) != 2 {
+		return false
+	}
+
+	for _, owner := range owners {
+		if owner.Module == host.ModuleName {
+			return true
+		}
+	}
+
+	return false
 }

--- a/modules/apps/27-interchain-accounts/controller/migrations/v6/migrations_test.go
+++ b/modules/apps/27-interchain-accounts/controller/migrations/v6/migrations_test.go
@@ -93,6 +93,9 @@ func (suite *MigrationsTestSuite) TestMigrateICS27ChannelCapability() {
 	err := suite.SetupPath()
 	suite.Require().NoError(err)
 
+	// create additional capabilities to cover edge cases
+	suite.CreateMockCapabilities()
+
 	// create and claim a new capability with ibc/mock for "channel-1"
 	// note: suite.SetupPath() now claims the chanel capability using icacontroller for "channel-0"
 	capName := host.ChannelCapabilityPath(suite.path.EndpointA.ChannelConfig.PortID, channeltypes.FormatChannelIdentifier(1))
@@ -147,6 +150,22 @@ func (suite *MigrationsTestSuite) TestMigrateICS27ChannelCapability() {
 
 	isAuthenticated = suite.chainA.GetSimApp().ScopedICAControllerKeeper.AuthenticateCapability(suite.chainA.GetContext(), cap, capName)
 	suite.Require().True(isAuthenticated)
+}
+
+// CreateMockCapabilities creates an additional two capabilities used for testing purposes:
+// 1. A capability with a single owner
+// 2. A capability with with two owners, niether of which is "ibc"
+func (suite *MigrationsTestSuite) CreateMockCapabilities() {
+	cap, err := suite.chainA.GetSimApp().ScopedIBCMockKeeper.NewCapability(suite.chainA.GetContext(), "mock")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(cap)
+
+	cap, err = suite.chainA.GetSimApp().ScopedICAMockKeeper.NewCapability(suite.chainA.GetContext(), "mock")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(cap)
+
+	err = suite.chainA.GetSimApp().ScopedIBCMockKeeper.ClaimCapability(suite.chainA.GetContext(), cap, "mock")
+	suite.Require().NoError(err)
 }
 
 // ResetMemstore removes all existing fwd and rev capability kv pairs and deletes `KeyMemInitialised` from the x/capability memstore.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

closes: #2785 


### Commit Message / Changelog Entry

```bash
chore: adding defensive checks to ics27 capability migrations
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
