### PR TITLE
feat: add optional migration pruning for tendermint consensus states

### DIFF
--- a/modules/core/02-client/migrations/store.go
+++ b/modules/core/02-client/migrations/store.go
@@ -1,0 +1,71 @@
+package migrations
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	host "github.com/cosmos/ibc-go/v6/modules/core/24-host"
+	"github.com/cosmos/ibc-go/v6/modules/core/exported"
+	ibctm "github.com/cosmos/ibc-go/v6/modules/light-clients/07-tendermint"
+)
+
+// PruneTendermintConsensusStates prunes all expired tendermint consensus states. This function
+// may optionally be called during in-place store migrations. The 02-client store key must be provided.
+func PruneTendermintConsensusStates(ctx sdk.Context, cdc codec.BinaryCodec, storeKey storetypes.StoreKey) error {
+	store := ctx.KVStore(storeKey)
+
+	// iterate over 02-client store with prefix: clients/07-tendermint,
+	// example iterator.Key = -100/clientState (second half of the clientID + clientStore specific keys)
+	tendermintClientPrefix := []byte(fmt.Sprintf("%s/%s", host.KeyClientStorePrefix, exported.Tendermint))
+	iterator := sdk.KVStorePrefixIterator(store, tendermintClientPrefix)
+
+	var clients []string
+
+	// collect all clients to avoid performing store state changes during iteration
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		path := string(iterator.Key())
+		if !strings.Contains(path, host.KeyClientState) {
+			// skip non client state keys
+			continue
+		}
+
+		clientID, err := host.ParseClientStatePath(path)
+		if err != nil {
+			return err
+		}
+
+		clients = append(clients, clientID)
+	}
+
+	for _, clientID := range clients {
+		clientPrefix := []byte(fmt.Sprintf("%s/%s/", host.KeyClientStorePrefix, clientID))
+		clientStore := prefix.NewStore(ctx.KVStore(storeKey), clientPrefix)
+
+		bz := clientStore.Get(host.ClientStateKey())
+		if bz == nil {
+			return clienttypes.ErrClientNotFound
+		}
+
+		var clientState exported.ClientState
+		if err := cdc.UnmarshalInterface(bz, &clientState); err != nil {
+			return sdkerrors.Wrap(err, "failed to unmarshal client state bytes into tendermint client state")
+		}
+
+		tmClientState, ok := clientState.(*ibctm.ClientState)
+		if !ok {
+			return sdkerrors.Wrap(clienttypes.ErrInvalidClient, "client state is not tendermint even though client id contains 07-tendermint")
+		}
+
+		ibctm.PruneAllExpiredConsensusStates(ctx, clientStore, cdc, tmClientState)
+	}
+
+	return nil
+}

--- a/modules/core/02-client/migrations/store_test.go
+++ b/modules/core/02-client/migrations/store_test.go
@@ -1,0 +1,150 @@
+package migrations_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/cosmos/ibc-go/v6/modules/core/02-client/migrations"
+	"github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	host "github.com/cosmos/ibc-go/v6/modules/core/24-host"
+	"github.com/cosmos/ibc-go/v6/modules/core/exported"
+	ibctm "github.com/cosmos/ibc-go/v6/modules/light-clients/07-tendermint"
+	ibctesting "github.com/cosmos/ibc-go/v6/testing"
+)
+
+type MigrationsTestSuite struct {
+	suite.Suite
+
+	coordinator *ibctesting.Coordinator
+
+	chainA *ibctesting.TestChain
+	chainB *ibctesting.TestChain
+}
+
+// TestMigrationsTestSuite runs all the tests within this package.
+func TestMigrationsTestSuite(t *testing.T) {
+	suite.Run(t, new(MigrationsTestSuite))
+}
+
+// SetupTest creates a coordinator with 2 test chains.
+func (suite *MigrationsTestSuite) SetupTest() {
+	suite.coordinator = ibctesting.NewCoordinator(suite.T(), 2)
+	suite.chainA = suite.coordinator.GetChain(ibctesting.GetChainID(1))
+	suite.chainB = suite.coordinator.GetChain(ibctesting.GetChainID(2))
+}
+
+// test pruning of multiple expired tendermint consensus states
+func (suite *MigrationsTestSuite) TestMigrateStoreTendermint() {
+	// create path and setup clients
+	path1 := ibctesting.NewPath(suite.chainA, suite.chainB)
+	suite.coordinator.SetupClients(path1)
+
+	path2 := ibctesting.NewPath(suite.chainA, suite.chainB)
+	suite.coordinator.SetupClients(path2)
+
+	pruneHeightMap := make(map[*ibctesting.Path][]exported.Height)
+	unexpiredHeightMap := make(map[*ibctesting.Path][]exported.Height)
+
+	for _, path := range []*ibctesting.Path{path1, path2} {
+		// collect all heights expected to be pruned
+		var pruneHeights []exported.Height
+		pruneHeights = append(pruneHeights, path.EndpointA.GetClientState().GetLatestHeight())
+
+		// these heights will be expired and also pruned
+		for i := 0; i < 3; i++ {
+			err := path.EndpointA.UpdateClient()
+			suite.Require().NoError(err)
+
+			pruneHeights = append(pruneHeights, path.EndpointA.GetClientState().GetLatestHeight())
+		}
+
+		// double chedck all information is currently stored
+		for _, pruneHeight := range pruneHeights {
+			consState, ok := suite.chainA.GetConsensusState(path.EndpointA.ClientID, pruneHeight)
+			suite.Require().True(ok)
+			suite.Require().NotNil(consState)
+
+			ctx := suite.chainA.GetContext()
+			clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(ctx, path.EndpointA.ClientID)
+
+			processedTime, ok := ibctm.GetProcessedTime(clientStore, pruneHeight)
+			suite.Require().True(ok)
+			suite.Require().NotNil(processedTime)
+
+			processedHeight, ok := ibctm.GetProcessedHeight(clientStore, pruneHeight)
+			suite.Require().True(ok)
+			suite.Require().NotNil(processedHeight)
+
+			expectedConsKey := ibctm.GetIterationKey(clientStore, pruneHeight)
+			suite.Require().NotNil(expectedConsKey)
+		}
+		pruneHeightMap[path] = pruneHeights
+	}
+
+	// Increment the time by a week
+	suite.coordinator.IncrementTimeBy(7 * 24 * time.Hour)
+
+	for _, path := range []*ibctesting.Path{path1, path2} {
+		// create the consensus state that can be used as trusted height for next update
+		var unexpiredHeights []exported.Height
+		err := path.EndpointA.UpdateClient()
+		suite.Require().NoError(err)
+		unexpiredHeights = append(unexpiredHeights, path.EndpointA.GetClientState().GetLatestHeight())
+
+		err = path.EndpointA.UpdateClient()
+		suite.Require().NoError(err)
+		unexpiredHeights = append(unexpiredHeights, path.EndpointA.GetClientState().GetLatestHeight())
+
+		unexpiredHeightMap[path] = unexpiredHeights
+	}
+
+	// Increment the time by another week, then update the client.
+	// This will cause the consensus states created before the first time increment
+	// to be expired
+	suite.coordinator.IncrementTimeBy(7 * 24 * time.Hour)
+	err := migrations.PruneTendermintConsensusStates(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), suite.chainA.GetSimApp().GetKey(host.StoreKey))
+	suite.Require().NoError(err)
+
+	for _, path := range []*ibctesting.Path{path1, path2} {
+		ctx := suite.chainA.GetContext()
+		clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(ctx, path.EndpointA.ClientID)
+
+		// ensure everything has been pruned
+		for i, pruneHeight := range pruneHeightMap[path] {
+			consState, ok := suite.chainA.GetConsensusState(path.EndpointA.ClientID, pruneHeight)
+			suite.Require().False(ok, i)
+			suite.Require().Nil(consState, i)
+
+			processedTime, ok := ibctm.GetProcessedTime(clientStore, pruneHeight)
+			suite.Require().False(ok, i)
+			suite.Require().Equal(uint64(0), processedTime, i)
+
+			processedHeight, ok := ibctm.GetProcessedHeight(clientStore, pruneHeight)
+			suite.Require().False(ok, i)
+			suite.Require().Nil(processedHeight, i)
+
+			expectedConsKey := ibctm.GetIterationKey(clientStore, pruneHeight)
+			suite.Require().Nil(expectedConsKey, i)
+		}
+
+		// ensure metadata is set for unexpired consensus state
+		for _, height := range unexpiredHeightMap[path] {
+			consState, ok := suite.chainA.GetConsensusState(path.EndpointA.ClientID, height)
+			suite.Require().True(ok)
+			suite.Require().NotNil(consState)
+
+			processedTime, ok := ibctm.GetProcessedTime(clientStore, height)
+			suite.Require().True(ok)
+			suite.Require().NotEqual(uint64(0), processedTime)
+
+			processedHeight, ok := ibctm.GetProcessedHeight(clientStore, height)
+			suite.Require().True(ok)
+			suite.Require().NotEqual(types.ZeroHeight(), processedHeight)
+
+			consKey := ibctm.GetIterationKey(clientStore, height)
+			suite.Require().Equal(host.ConsensusStateKey(height), consKey)
+		}
+	}
+}

--- a/modules/core/24-host/parse.go
+++ b/modules/core/24-host/parse.go
@@ -32,6 +32,29 @@ func ParseIdentifier(identifier, prefix string) (uint64, error) {
 	return sequence, nil
 }
 
+// ParseClientStatePath returns the client ID from a client state path. It returns
+// an error if the provided path is invalid.
+func ParseClientStatePath(path string) (string, error) {
+	split := strings.Split(path, "/")
+	if len(split) != 3 {
+		return "", sdkerrors.Wrapf(ErrInvalidPath, "cannot parse client state path %s", path)
+	}
+
+	if split[0] != string(KeyClientStorePrefix) {
+		return "", sdkerrors.Wrapf(ErrInvalidPath, "path does not begin with client store prefix: expected %s, got %s", KeyClientStorePrefix, split[0])
+	}
+
+	if split[2] != KeyClientState {
+		return "", sdkerrors.Wrapf(ErrInvalidPath, "path does not end with client state key: expected %s, got %s", KeyClientState, split[2])
+	}
+
+	if strings.TrimSpace(split[1]) == "" {
+		return "", sdkerrors.Wrap(ErrInvalidPath, "clientID is empty")
+	}
+
+	return split[1], nil
+}
+
 // ParseConnectionPath returns the connection ID from a full path. It returns
 // an error if the provided path is invalid.
 func ParseConnectionPath(path string) (string, error) {

--- a/modules/light-clients/07-tendermint/store.go
+++ b/modules/light-clients/07-tendermint/store.go
@@ -273,11 +273,11 @@ func GetPreviousConsensusState(clientStore sdk.KVStore, cdc codec.BinaryCodec, h
 
 // PruneAllExpiredConsensusStates iterates over all consensus states for a given
 // client store. If a consensus state is expired, it is deleted and its metadata
-// is deleted.
+// is deleted. The number of consensus states pruned is returned.
 func PruneAllExpiredConsensusStates(
 	ctx sdk.Context, clientStore sdk.KVStore,
 	cdc codec.BinaryCodec, clientState *ClientState,
-) {
+) int {
 	var heights []exported.Height
 
 	pruneCb := func(height exported.Height) bool {
@@ -299,6 +299,8 @@ func PruneAllExpiredConsensusStates(
 		deleteConsensusState(clientStore, height)
 		deleteConsensusMetadata(clientStore, height)
 	}
+
+	return len(heights)
 }
 
 // Helper function for GetNextConsensusState and GetPreviousConsensusState


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Took out a portion of work from #1863 

ref: #1863 
closes: #52


### Commit Message / Changelog Entry

```bash
feat: add optional in-place store migration function to prune all expired tendermint consensus states
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
