### PR TITLE
e2e: update icad tags for manual e2e workflow

### DIFF
--- a/.github/workflows/e2e-manual-icad.yaml
+++ b/.github/workflows/e2e-manual-icad.yaml
@@ -25,11 +25,10 @@ on:
         default: master
         options:
           - master
-          - v0.4.0
+          - v0.4.1
           - v0.3.5
-          - v0.3.4
-          - v0.2.3
-          - v0.1.4
+          - v0.2.5
+          - v0.1.7
       chain-b-tag:
         default: master
         description: 'The tag to use for chain B'
@@ -37,11 +36,10 @@ on:
         type: choice
         options:
           - master
-          - v0.4.0
+          - v0.4.1
           - v0.3.5
-          - v0.3.4
-          - v0.2.3
-          - v0.1.4
+          - v0.2.5
+          - v0.1.7
       relayer-tag:
         description: 'The tag to use for the relayer'
         required: true


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- v0.1.7 bumps ibc-go to v3.4.0 (from v3.3.0).
- v0.2.5 bumps ibc-go to v4.2.0 (from v4.0.0-rc2).
- v0.3.4 is deleted since it uses the same version as v0.3.5.
- v0.4.1 bumps ibc-go to v6.0.0-rc1 (from v6.0.0-alpha1).

closes: #XXXX


### Commit Message / Changelog Entry

```bash
e2e: update icad tags for manual e2e workflow
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
