### PR TITLE
feat: Add GetAllClientIDsOfType query function 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 
 * (core/02-client) [\#2855](https://github.com/cosmos/ibc-go/pull/2855) Add `GetAllClientIDsOfType` to 02-client keeper.
-* (core/24-host) [\#2855](https://github.com/cosmos/ibc-go/pull/2855) Add `PrefixedClientStorePath` and `PrefixedClientStoreKey` functions to 24-host. Constructs a prefixed key path using the client type. 
+* (core/24-host) [\#2855](https://github.com/cosmos/ibc-go/pull/2855) Add `PrefixedClientStorePath` and `PrefixedClientStoreKey` functions to 24-host
 * (core/02-client) [\#2819](https://github.com/cosmos/ibc-go/pull/2819) Add automatic in-place store migrations to remove the localhost client and migrate existing solo machine definitions.
 * (light-clients/06-solomachine) [\#2826](https://github.com/cosmos/ibc-go/pull/2826) Add `AppModuleBasic` for the 06-solomachine client and remove solo machine type registration from core IBC. Chains must register the `AppModuleBasic` of light clients. 
 * (light-clients/07-tendermint) [\#2825](https://github.com/cosmos/ibc-go/pull/2825) Add `AppModuleBasic` for the 07-tendermint client and remove tendermint type registration from core IBC. Chains must register the `AppModuleBasic` of light clients. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
+* (core/02-client) [\#2855](https://github.com/cosmos/ibc-go/pull/2855) Add `GetAllClientIDsOfType` to 02-client keeper.
+* (core/24-host) [\#2855](https://github.com/cosmos/ibc-go/pull/2855) Add `PrefixedClientStorePath` and `PrefixedClientStoreKey` functions to 24-host. Constructs a prefixed key path using the client type. 
 * (core/02-client) [\#2819](https://github.com/cosmos/ibc-go/pull/2819) Add automatic in-place store migrations to remove the localhost client and migrate existing solo machine definitions.
 * (light-clients/06-solomachine) [\#2826](https://github.com/cosmos/ibc-go/pull/2826) Add `AppModuleBasic` for the 06-solomachine client and remove solo machine type registration from core IBC. Chains must register the `AppModuleBasic` of light clients. 
 * (light-clients/07-tendermint) [\#2825](https://github.com/cosmos/ibc-go/pull/2825) Add `AppModuleBasic` for the 07-tendermint client and remove tendermint type registration from core IBC. Chains must register the `AppModuleBasic` of light clients. 

--- a/modules/core/02-client/keeper/keeper.go
+++ b/modules/core/02-client/keeper/keeper.go
@@ -374,6 +374,28 @@ func (k Keeper) IterateClients(ctx sdk.Context, cb func(clientID string, cs expo
 	}
 }
 
+// GetAllClientIDsOfType will iterate over the provided client type prefix in the client store
+// and return a list of clientIDs associated with the client type.
+func (k Keeper) GetAllClientIDsOfType(ctx sdk.Context, clientType string) (clientIDs []string) {
+	store := ctx.KVStore(k.storeKey)
+	prefix := host.PrefixedClientStoreKey(clientType)
+	iterator := sdk.KVStorePrefixIterator(store, prefix)
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		path := string(iterator.Key())
+		if !strings.Contains(path, host.KeyClientState) {
+			// skip non client state keys
+			continue
+		}
+
+		clientID := host.MustParseClientStatePath(path)
+		clientIDs = append(clientIDs, clientID)
+	}
+
+	return clientIDs
+}
+
 // GetAllClients returns all stored light client State objects.
 func (k Keeper) GetAllClients(ctx sdk.Context) (states []exported.ClientState) {
 	k.IterateClients(ctx, func(_ string, state exported.ClientState) bool {

--- a/modules/core/02-client/keeper/keeper.go
+++ b/modules/core/02-client/keeper/keeper.go
@@ -374,6 +374,15 @@ func (k Keeper) IterateClients(ctx sdk.Context, cb func(clientID string, cs expo
 	}
 }
 
+// GetAllClients returns all stored light client State objects.
+func (k Keeper) GetAllClients(ctx sdk.Context) (states []exported.ClientState) {
+	k.IterateClients(ctx, func(_ string, state exported.ClientState) bool {
+		states = append(states, state)
+		return false
+	})
+	return states
+}
+
 // GetAllClientIDsOfType will iterate over the provided client type prefix in the client store
 // and return a list of clientIDs associated with the client type.
 func (k Keeper) GetAllClientIDsOfType(ctx sdk.Context, clientType string) (clientIDs []string) {
@@ -394,15 +403,6 @@ func (k Keeper) GetAllClientIDsOfType(ctx sdk.Context, clientType string) (clien
 	}
 
 	return clientIDs
-}
-
-// GetAllClients returns all stored light client State objects.
-func (k Keeper) GetAllClients(ctx sdk.Context) (states []exported.ClientState) {
-	k.IterateClients(ctx, func(_ string, state exported.ClientState) bool {
-		states = append(states, state)
-		return false
-	})
-	return states
 }
 
 // ClientStore returns isolated prefix store for each client so they can read/write in separate

--- a/modules/core/02-client/keeper/keeper_test.go
+++ b/modules/core/02-client/keeper/keeper_test.go
@@ -387,8 +387,6 @@ func (suite KeeperTestSuite) TestGetAllConsensusStates() {
 	suite.Require().Equal(expConsensusStates, consStates, "%s \n\n%s", expConsensusStates, consStates)
 }
 
-// 2 clients in total are created on chainA. The first client is updated so it contains an initial consensus state
-// and a consensus state at the update height.
 func (suite KeeperTestSuite) TestGetAllClientIDsOfType() {
 	paths := []*ibctesting.Path{
 		ibctesting.NewPath(suite.chainA, suite.chainB),

--- a/modules/core/02-client/migrations/v7/store.go
+++ b/modules/core/02-client/migrations/v7/store.go
@@ -151,7 +151,7 @@ func handleLocalhostMigration(ctx sdk.Context, store sdk.KVStore, cdc codec.Bina
 // for tendermint clients is included as only one tendermint clientID is required for
 // v7 migrations.
 func collectClients(ctx sdk.Context, store sdk.KVStore, clientType string) (clients []string, err error) {
-	clientPrefix := []byte(fmt.Sprintf("%s/%s", host.KeyClientStorePrefix, clientType))
+	clientPrefix := host.PrefixedClientStoreKey(clientType)
 	iterator := sdk.KVStorePrefixIterator(store, clientPrefix)
 
 	defer iterator.Close()

--- a/modules/core/24-host/keys.go
+++ b/modules/core/24-host/keys.go
@@ -55,6 +55,18 @@ func FullClientKey(clientID string, path []byte) []byte {
 	return []byte(FullClientPath(clientID, string(path)))
 }
 
+// PrefixedClientStorePath takes a client type and returns a prefixed key path
+// which can be used to iterate over client stores belonging to a certain client type.
+func PrefixedClientStorePath(clientType string) string {
+	return fmt.Sprintf("%s/%s", KeyClientStorePrefix, clientType)
+}
+
+// PrefixedClientStoreKey takes a client type and returns a prefixed key
+// which can be used to iterate over client stores belonging to a certain client type.
+func PrefixedClientStoreKey(clientType string) []byte {
+	return []byte(PrefixedClientStorePath(clientType))
+}
+
 // ICS02
 // The following paths are the keys to the store as defined in https://github.com/cosmos/ibc/tree/master/spec/core/ics-002-client-semantics#path-space
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #2844 


### Commit Message / Changelog Entry

```bash
feat: add `GetAllClientIDsOfType` to 02-client keeper.
feat: add `PrefixedClientStorePath` and `PrefixedClientStoreKey` functions to 24-host
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing).
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Review `Codecov Report` in the comment section below once CI passes.
