### PR TITLE
feat: replacing concrete client keeper struct with an interface

### DIFF
--- a/modules/core/02-client/abci.go
+++ b/modules/core/02-client/abci.go
@@ -3,12 +3,13 @@ package client
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	clientexported "github.com/cosmos/ibc-go/v6/modules/core/02-client/exported"
 	"github.com/cosmos/ibc-go/v6/modules/core/02-client/keeper"
 	ibctm "github.com/cosmos/ibc-go/v6/modules/light-clients/07-tendermint"
 )
 
 // BeginBlocker is used to perform IBC client upgrades
-func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
+func BeginBlocker(ctx sdk.Context, k clientexported.ClientKeeper) {
 	plan, found := k.GetUpgradePlan(ctx)
 	if found {
 		// Once we are at the last block this chain will commit, set the upgraded consensus state

--- a/modules/core/02-client/exported/exported.go
+++ b/modules/core/02-client/exported/exported.go
@@ -1,0 +1,68 @@
+package exported
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	"github.com/cosmos/ibc-go/v6/modules/core/exported"
+)
+
+// ClientKeeper defines the expected interface of the light client used for IBC
+type ClientKeeper interface {
+	CreateClient(ctx sdk.Context, clientState exported.ClientState, consensusState exported.ConsensusState) (string, error)
+	UpdateClient(ctx sdk.Context, clientID string, clientMsg exported.ClientMessage) error
+	UpgradeClient(ctx sdk.Context, clientID string, upgradedClient exported.ClientState, upgradedConsState exported.ConsensusState, proofUpgradeClient, proofUpgradeConsState []byte) error
+	GenerateClientIdentifier(ctx sdk.Context, clientType string) string
+	SetClientState(ctx sdk.Context, clientID string, clientState exported.ClientState)
+	GetClientState(ctx sdk.Context, clientID string) (exported.ClientState, bool)
+	IterateClientStates(ctx sdk.Context, prefix []byte, cb func(string, exported.ClientState) bool)
+	GetClientConsensusState(ctx sdk.Context, clientID string, height exported.Height) (exported.ConsensusState, bool)
+	SetClientConsensusState(ctx sdk.Context, clientID string, height exported.Height, consensusState exported.ConsensusState)
+	GetNextClientSequence(ctx sdk.Context) uint64
+	SetNextClientSequence(ctx sdk.Context, sequence uint64)
+	IterateConsensusStates(ctx sdk.Context, cb func(clientID string, cs clienttypes.ConsensusStateWithHeight) bool)
+	GetAllGenesisClients(ctx sdk.Context) clienttypes.IdentifiedClientStates
+	GetAllClientMetadata(ctx sdk.Context, genClients []clienttypes.IdentifiedClientState) ([]clienttypes.IdentifiedGenesisMetadata, error)
+	SetAllClientMetadata(ctx sdk.Context, genMetadata []clienttypes.IdentifiedGenesisMetadata)
+	GetAllConsensusStates(ctx sdk.Context) clienttypes.ClientsConsensusStates
+	HasClientConsensusState(ctx sdk.Context, clientID string, height exported.Height) bool
+	GetLatestClientConsensusState(ctx sdk.Context, clientID string) (exported.ConsensusState, bool)
+	GetSelfConsensusState(ctx sdk.Context, height exported.Height) (exported.ConsensusState, error)
+	ValidateSelfClient(ctx sdk.Context, clientState exported.ClientState) error
+	GetUpgradePlan(ctx sdk.Context) (plan upgradetypes.Plan, havePlan bool)
+	GetUpgradedClient(ctx sdk.Context, planHeight int64) ([]byte, bool)
+	GetUpgradedConsensusState(ctx sdk.Context, planHeight int64) ([]byte, bool)
+	SetUpgradedConsensusState(ctx sdk.Context, planHeight int64, bz []byte) error
+	GetAllClients(ctx sdk.Context) (states []exported.ClientState)
+	ClientStore(ctx sdk.Context, clientID string) sdk.KVStore
+
+	// encoding-related functions
+	UnmarshalClientState(bz []byte) (exported.ClientState, error)
+	MustUnmarshalClientState(bz []byte) exported.ClientState
+	UnmarshalConsensusState(bz []byte) (exported.ConsensusState, error)
+	MustUnmarshalConsensusState(bz []byte) exported.ConsensusState
+	MustMarshalClientState(clientState exported.ClientState) []byte
+	MustMarshalConsensusState(consensusState exported.ConsensusState) []byte
+
+	// params-related functions
+	GetAllowedClients(ctx sdk.Context) []string
+	GetParams(ctx sdk.Context) clienttypes.Params
+	SetParams(ctx sdk.Context, params clienttypes.Params)
+
+	// proposal-related functions
+	ClientUpdateProposal(ctx sdk.Context, p *clienttypes.ClientUpdateProposal) error
+	HandleUpgradeProposal(ctx sdk.Context, p *clienttypes.UpgradeProposal) error
+
+	// GRPC query functions
+	ClientState(context.Context, *clienttypes.QueryClientStateRequest) (*clienttypes.QueryClientStateResponse, error)
+	ClientStates(context.Context, *clienttypes.QueryClientStatesRequest) (*clienttypes.QueryClientStatesResponse, error)
+	ConsensusState(context.Context, *clienttypes.QueryConsensusStateRequest) (*clienttypes.QueryConsensusStateResponse, error)
+	ConsensusStates(context.Context, *clienttypes.QueryConsensusStatesRequest) (*clienttypes.QueryConsensusStatesResponse, error)
+	ConsensusStateHeights(context.Context, *clienttypes.QueryConsensusStateHeightsRequest) (*clienttypes.QueryConsensusStateHeightsResponse, error)
+	ClientStatus(context.Context, *clienttypes.QueryClientStatusRequest) (*clienttypes.QueryClientStatusResponse, error)
+	ClientParams(context.Context, *clienttypes.QueryClientParamsRequest) (*clienttypes.QueryClientParamsResponse, error)
+	UpgradedClientState(context.Context, *clienttypes.QueryUpgradedClientStateRequest) (*clienttypes.QueryUpgradedClientStateResponse, error)
+	UpgradedConsensusState(context.Context, *clienttypes.QueryUpgradedConsensusStateRequest) (*clienttypes.QueryUpgradedConsensusStateResponse, error)
+}

--- a/modules/core/02-client/genesis.go
+++ b/modules/core/02-client/genesis.go
@@ -5,14 +5,14 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/cosmos/ibc-go/v6/modules/core/02-client/keeper"
+	clientexported "github.com/cosmos/ibc-go/v6/modules/core/02-client/exported"
 	"github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v6/modules/core/exported"
 )
 
 // InitGenesis initializes the ibc client submodule's state from a provided genesis
 // state.
-func InitGenesis(ctx sdk.Context, k keeper.Keeper, gs types.GenesisState) {
+func InitGenesis(ctx sdk.Context, k clientexported.ClientKeeper, gs types.GenesisState) {
 	k.SetParams(ctx, gs.Params)
 
 	// Set all client metadata first. This will allow client keeper to overwrite client and consensus state keys
@@ -49,7 +49,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, gs types.GenesisState) {
 }
 
 // ExportGenesis returns the ibc client submodule's exported genesis.
-func ExportGenesis(ctx sdk.Context, k keeper.Keeper) types.GenesisState {
+func ExportGenesis(ctx sdk.Context, k clientexported.ClientKeeper) types.GenesisState {
 	genClients := k.GetAllGenesisClients(ctx)
 	clientsMetadata, err := k.GetAllClientMetadata(ctx, genClients)
 	if err != nil {

--- a/modules/core/02-client/keeper/keeper_test.go
+++ b/modules/core/02-client/keeper/keeper_test.go
@@ -86,7 +86,9 @@ func (suite *KeeperTestSuite) SetupTest() {
 
 	suite.cdc = app.AppCodec()
 	suite.ctx = app.BaseApp.NewContext(isCheckTx, tmproto.Header{Height: height, ChainID: testClientID, Time: now2})
-	suite.keeper = &app.IBCKeeper.ClientKeeper
+	clientKeeper, ok := app.IBCKeeper.ClientKeeper.(keeper.Keeper)
+	suite.Require().True(ok)
+	suite.keeper = &clientKeeper
 	suite.privVal = ibctestingmock.NewPV()
 
 	pubKey, err := suite.privVal.GetPubKey()

--- a/modules/core/02-client/proposal_handler.go
+++ b/modules/core/02-client/proposal_handler.go
@@ -5,12 +5,12 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
-	"github.com/cosmos/ibc-go/v6/modules/core/02-client/keeper"
+	clientexported "github.com/cosmos/ibc-go/v6/modules/core/02-client/exported"
 	"github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
 )
 
 // NewClientProposalHandler defines the 02-client proposal handler
-func NewClientProposalHandler(k keeper.Keeper) govtypes.Handler {
+func NewClientProposalHandler(k clientexported.ClientKeeper) govtypes.Handler {
 	return func(ctx sdk.Context, content govtypes.Content) error {
 		switch c := content.(type) {
 		case *types.ClientUpdateProposal:

--- a/modules/core/keeper/keeper.go
+++ b/modules/core/keeper/keeper.go
@@ -9,6 +9,7 @@ import (
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
+	clientexported "github.com/cosmos/ibc-go/v6/modules/core/02-client/exported"
 	clientkeeper "github.com/cosmos/ibc-go/v6/modules/core/02-client/keeper"
 	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
 	connectionkeeper "github.com/cosmos/ibc-go/v6/modules/core/03-connection/keeper"
@@ -28,7 +29,7 @@ type Keeper struct {
 
 	cdc codec.BinaryCodec
 
-	ClientKeeper     clientkeeper.Keeper
+	ClientKeeper     clientexported.ClientKeeper
 	ConnectionKeeper connectionkeeper.Keeper
 	ChannelKeeper    channelkeeper.Keeper
 	PortKeeper       portkeeper.Keeper

--- a/modules/core/keeper/migrations.go
+++ b/modules/core/keeper/migrations.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	clientkeeper "github.com/cosmos/ibc-go/v6/modules/core/02-client/keeper"
@@ -18,7 +20,12 @@ func NewMigrator(keeper Keeper) Migrator {
 
 // Migrate2to3 migrates from version 2 to 3. See 02-client keeper function Migrate2to3.
 func (m Migrator) Migrate2to3(ctx sdk.Context) error {
-	clientMigrator := clientkeeper.NewMigrator(m.keeper.ClientKeeper)
+	clientKeeper, ok := m.keeper.ClientKeeper.(clientkeeper.Keeper)
+	if !ok {
+		return fmt.Errorf("failed to assert m.keeper.ClientKeeper to type clientkeeper.Keeper")
+	}
+
+	clientMigrator := clientkeeper.NewMigrator(clientKeeper)
 	if err := clientMigrator.Migrate2to3(ctx); err != nil {
 		return err
 	}

--- a/modules/core/module.go
+++ b/modules/core/module.go
@@ -139,7 +139,12 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	channeltypes.RegisterMsgServer(cfg.MsgServer(), am.keeper)
 	types.RegisterQueryService(cfg.QueryServer(), am.keeper)
 
-	m := clientkeeper.NewMigrator(am.keeper.ClientKeeper)
+	clientKeeper, ok := am.keeper.ClientKeeper.(clientkeeper.Keeper)
+	if !ok {
+		panic("failed to assert am.keeper.ClientKeeper to type clientkeeper.Keeper")
+	}
+
+	m := clientkeeper.NewMigrator(clientKeeper)
 	err := cfg.RegisterMigration(host.ModuleName, 2, m.Migrate2to3)
 	if err != nil {
 		panic(err)

--- a/modules/light-clients/07-tendermint/migrations/migrations_test.go
+++ b/modules/light-clients/07-tendermint/migrations/migrations_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	clientkeeper "github.com/cosmos/ibc-go/v6/modules/core/02-client/keeper"
 	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
 	host "github.com/cosmos/ibc-go/v6/modules/core/24-host"
 	"github.com/cosmos/ibc-go/v6/modules/core/exported"
@@ -119,11 +120,14 @@ func (suite *MigrationsTestSuite) TestPruneExpiredConsensusStates() {
 		unexpiredHeightMap[path] = unexpiredHeights
 	}
 
+	clientKeeper, ok := suite.chainA.App.GetIBCKeeper().ClientKeeper.(clientkeeper.Keeper)
+	suite.Require().True(ok)
+
 	// Increment the time by another week, then update the client.
 	// This will cause the consensus states created before the first time increment
 	// to be expired
 	suite.coordinator.IncrementTimeBy(7 * 24 * time.Hour)
-	totalPruned, err := ibctmmigrations.PruneExpiredConsensusStates(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), suite.chainA.GetSimApp().IBCKeeper.ClientKeeper)
+	totalPruned, err := ibctmmigrations.PruneExpiredConsensusStates(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), clientKeeper)
 	suite.Require().NoError(err)
 	suite.Require().NotZero(totalPruned)
 

--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -105,6 +105,7 @@ import (
 	ibc "github.com/cosmos/ibc-go/v6/modules/core"
 	ibcclient "github.com/cosmos/ibc-go/v6/modules/core/02-client"
 	ibcclientclient "github.com/cosmos/ibc-go/v6/modules/core/02-client/client"
+	clientkeeper "github.com/cosmos/ibc-go/v6/modules/core/02-client/keeper"
 	ibcclienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
 	porttypes "github.com/cosmos/ibc-go/v6/modules/core/05-port/types"
 	ibchost "github.com/cosmos/ibc-go/v6/modules/core/24-host"
@@ -893,13 +894,18 @@ func (app *SimApp) setupUpgradeHandlers() {
 		),
 	)
 
+	clientKeeper, ok := app.IBCKeeper.ClientKeeper.(clientkeeper.Keeper)
+	if !ok {
+		panic("failed to assert app.IBCKeeper.ClientKeeper into type clientkeeper.Keeper")
+	}
+
 	app.UpgradeKeeper.SetUpgradeHandler(
 		v7.UpgradeName,
 		v7.CreateUpgradeHandler(
 			app.mm,
 			app.configurator,
 			app.appCodec,
-			app.IBCKeeper.ClientKeeper,
+			clientKeeper,
 		),
 	)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR replaces the concrete `ClientKeeper` struct with an interface. This allows IBC-enabled applications to add extra functionalities atop the client keeper (without forking IBC-Go), including

- adding hooks to these keepers, so that other modules can learn internal states of IBC
- defining and emitting new events upon certain state changes in the IBC module
- implementing new queries and messages for these internal keepers

closes: #2880 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
