### PR TITLE
Update TransferAuthorization ValidateBasic to return an error when there is a duplicate channel id

### DIFF
--- a/modules/apps/transfer/types/transfer_authorization.go
+++ b/modules/apps/transfer/types/transfer_authorization.go
@@ -5,6 +5,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 
+	channeltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
 	host "github.com/cosmos/ibc-go/v6/modules/core/24-host"
 
 	"golang.org/x/exp/slices"
@@ -74,7 +75,15 @@ func (a TransferAuthorization) ValidateBasic() error {
 		return sdkerrors.Wrap(ErrInvalidAuthorization, "allocations cannot be empty")
 	}
 
+	foundChannels := make(map[string]bool, 0)
+
 	for _, allocation := range a.Allocations {
+		if _, found := foundChannels[allocation.SourceChannel]; found {
+			return sdkerrors.Wrapf(channeltypes.ErrInvalidChannel, "duplicate source channel ID: %s", allocation.SourceChannel)
+		}
+
+		foundChannels[allocation.SourceChannel] = true
+
 		if allocation.SpendLimit == nil {
 			return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "spend limit cannot be nil")
 		}

--- a/modules/apps/transfer/types/transfer_authorization_test.go
+++ b/modules/apps/transfer/types/transfer_authorization_test.go
@@ -243,7 +243,10 @@ func (suite *TypesTestSuite) TestTransferAuthorizationValidateBasic() {
 			name: "duplicate channel ID",
 			malleate: func() {
 				allocation := types.Allocation{
-					SourcePort: transferAuthz.Allocations[0].SourceChannel,
+					SourcePort:    mock.PortID,
+					SourceChannel: transferAuthz.Allocations[0].SourceChannel,
+					SpendLimit:    sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100))),
+					AllowList:     []string{ibctesting.TestAccAddress},
 				}
 
 				transferAuthz.Allocations = append(transferAuthz.Allocations, allocation)

--- a/modules/apps/transfer/types/transfer_authorization_test.go
+++ b/modules/apps/transfer/types/transfer_authorization_test.go
@@ -181,7 +181,7 @@ func (suite *TypesTestSuite) TestTransferAuthorizationValidateBasic() {
 			func() {
 				allocation := types.Allocation{
 					SourcePort:    types.PortID,
-					SourceChannel: ibctesting.FirstChannelID,
+					SourceChannel: "channel-1",
 					SpendLimit:    sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100))),
 					AllowList:     []string{},
 				}
@@ -238,6 +238,17 @@ func (suite *TypesTestSuite) TestTransferAuthorizationValidateBasic() {
 				transferAuthz.Allocations[0].SourceChannel = ""
 			},
 			false,
+		},
+		{
+			name: "duplicate channel ID",
+			malleate: func() {
+				allocation := types.Allocation{
+					SourcePort: transferAuthz.Allocations[0].SourceChannel,
+				}
+
+				transferAuthz.Allocations = append(transferAuthz.Allocations, allocation)
+			},
+			expPass: false,
 		},
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #3012


### Commit Message / Changelog Entry

```bash
chore: TransferAuthorization ValidateBasic now returns an error when there is a duplicate channel id
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
