### PR TITLE
fix: correctly close iterator in `07-tendermint` 

### DIFF
--- a/modules/light-clients/07-tendermint/store.go
+++ b/modules/light-clients/07-tendermint/store.go
@@ -80,7 +80,6 @@ func IterateConsensusMetadata(store sdk.KVStore, cb func(key, val []byte) bool) 
 	iterator := sdk.KVStorePrefixIterator(store, []byte(host.KeyConsensusStatePrefix))
 
 	// iterate over processed time and processed height
-	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		keySplit := strings.Split(string(iterator.Key()), "/")
 		// processed time key in prefix store has format: "consensusState/<height>/processedTime"
@@ -98,6 +97,8 @@ func IterateConsensusMetadata(store sdk.KVStore, cb func(key, val []byte) bool) 
 			break
 		}
 	}
+
+	iterator.Close()
 
 	// iterate over iteration keys
 	iterator = sdk.KVStorePrefixIterator(store, []byte(KeyIterateConsensusStatePrefix))

--- a/modules/light-clients/07-tendermint/store.go
+++ b/modules/light-clients/07-tendermint/store.go
@@ -80,6 +80,7 @@ func IterateConsensusMetadata(store sdk.KVStore, cb func(key, val []byte) bool) 
 	iterator := sdk.KVStorePrefixIterator(store, []byte(host.KeyConsensusStatePrefix))
 
 	// iterate over processed time and processed height
+	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		keySplit := strings.Split(string(iterator.Key()), "/")
 		// processed time key in prefix store has format: "consensusState/<height>/processedTime"
@@ -98,14 +99,12 @@ func IterateConsensusMetadata(store sdk.KVStore, cb func(key, val []byte) bool) 
 		}
 	}
 
-	iterator.Close()
-
 	// iterate over iteration keys
-	iterator = sdk.KVStorePrefixIterator(store, []byte(KeyIterateConsensusStatePrefix))
+	iter := sdk.KVStorePrefixIterator(store, []byte(KeyIterateConsensusStatePrefix))
 
-	defer iterator.Close()
-	for ; iterator.Valid(); iterator.Next() {
-		if cb(iterator.Key(), iterator.Value()) {
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		if cb(iter.Key(), iter.Value()) {
 			break
 		}
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- An iterator is reassigned in `07-tendermint` while `defer iterator.Close()` is called on both. The reassignment would mean that the first iterator is not closed cleanly using `defer`.

closes: #XXXX


### Commit Message / Changelog Entry

```bash
fix: correctly close iterator in `07-tendermint` 
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
