### PR TITLE
[WIP] chore: add additional args to client state `GetLatestHeight` interface method

### DIFF
--- a/modules/core/02-client/keeper/client.go
+++ b/modules/core/02-client/keeper/client.go
@@ -31,7 +31,7 @@ func (k Keeper) CreateClient(
 		return "", err
 	}
 
-	k.Logger(ctx).Info("client created at height", "client-id", clientID, "height", clientState.GetLatestHeight().String())
+	k.Logger(ctx).Info("client created at height", "client-id", clientID, "height", clientState.GetLatestHeight(ctx, clientStore, k.cdc).String())
 
 	defer telemetry.IncrCounterWithLabels(
 		[]string{"ibc", "client", "create"},
@@ -124,7 +124,7 @@ func (k Keeper) UpgradeClient(ctx sdk.Context, clientID string, upgradedClient e
 		return sdkerrors.Wrapf(err, "cannot upgrade client with ID %s", clientID)
 	}
 
-	k.Logger(ctx).Info("client state upgraded", "client-id", clientID, "height", upgradedClient.GetLatestHeight().String())
+	k.Logger(ctx).Info("client state upgraded", "client-id", clientID, "height", upgradedClient.GetLatestHeight(ctx, clientStore, k.cdc).String())
 
 	defer telemetry.IncrCounterWithLabels(
 		[]string{"ibc", "client", "upgrade"},

--- a/modules/core/02-client/keeper/events.go
+++ b/modules/core/02-client/keeper/events.go
@@ -21,7 +21,7 @@ func EmitCreateClientEvent(ctx sdk.Context, clientID string, clientState exporte
 			types.EventTypeCreateClient,
 			sdk.NewAttribute(types.AttributeKeyClientID, clientID),
 			sdk.NewAttribute(types.AttributeKeyClientType, clientState.ClientType()),
-			sdk.NewAttribute(types.AttributeKeyConsensusHeight, clientState.GetLatestHeight().String()),
+			sdk.NewAttribute(types.AttributeKeyConsensusHeight, clientState.GetLatestHeight(ctx, nil, nil).String()),
 		),
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
@@ -72,7 +72,7 @@ func EmitUpgradeClientEvent(ctx sdk.Context, clientID string, clientState export
 			types.EventTypeUpgradeClient,
 			sdk.NewAttribute(types.AttributeKeyClientID, clientID),
 			sdk.NewAttribute(types.AttributeKeyClientType, clientState.ClientType()),
-			sdk.NewAttribute(types.AttributeKeyConsensusHeight, clientState.GetLatestHeight().String()),
+			sdk.NewAttribute(types.AttributeKeyConsensusHeight, clientState.GetLatestHeight(ctx, nil, nil).String()),
 		),
 		sdk.NewEvent(
 			sdk.EventTypeMessage,

--- a/modules/core/02-client/keeper/grpc_query_test.go
+++ b/modules/core/02-client/keeper/grpc_query_test.go
@@ -227,7 +227,10 @@ func (suite *KeeperTestSuite) TestQueryConsensusState() {
 			func() {
 				path := ibctesting.NewPath(suite.chainA, suite.chainB)
 				suite.coordinator.SetupClients(path)
-				cs := path.EndpointA.GetConsensusState(path.EndpointA.GetClientState().GetLatestHeight())
+
+				store := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.cdc)
+				cs := path.EndpointA.GetConsensusState(height)
 
 				var err error
 				expConsensusState, err = types.PackConsensusState(cs)
@@ -245,7 +248,9 @@ func (suite *KeeperTestSuite) TestQueryConsensusState() {
 			func() {
 				path := ibctesting.NewPath(suite.chainA, suite.chainB)
 				suite.coordinator.SetupClients(path)
-				height := path.EndpointA.GetClientState().GetLatestHeight()
+
+				store := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.cdc)
 				cs := path.EndpointA.GetConsensusState(height)
 
 				var err error
@@ -328,7 +333,8 @@ func (suite *KeeperTestSuite) TestQueryConsensusStates() {
 				path := ibctesting.NewPath(suite.chainA, suite.chainB)
 				suite.coordinator.SetupClients(path)
 
-				height1 := path.EndpointA.GetClientState().GetLatestHeight().(types.Height)
+				store := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+				height1 := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.cdc).(types.Height)
 				expConsensusStates = append(
 					expConsensusStates,
 					types.NewConsensusStateWithHeight(
@@ -339,7 +345,7 @@ func (suite *KeeperTestSuite) TestQueryConsensusStates() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height2 := path.EndpointA.GetClientState().GetLatestHeight().(types.Height)
+				height2 := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.cdc).(types.Height)
 				expConsensusStates = append(
 					expConsensusStates,
 					types.NewConsensusStateWithHeight(
@@ -432,12 +438,13 @@ func (suite *KeeperTestSuite) TestQueryConsensusStateHeights() {
 				path := ibctesting.NewPath(suite.chainA, suite.chainB)
 				suite.coordinator.SetupClients(path)
 
-				expConsensusStateHeights = append(expConsensusStateHeights, path.EndpointA.GetClientState().GetLatestHeight().(types.Height))
+				store := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+				expConsensusStateHeights = append(expConsensusStateHeights, path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.cdc).(types.Height))
 
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				expConsensusStateHeights = append(expConsensusStateHeights, path.EndpointA.GetClientState().GetLatestHeight().(types.Height))
+				expConsensusStateHeights = append(expConsensusStateHeights, path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.cdc).(types.Height))
 
 				req = &types.QueryConsensusStateHeightsRequest{
 					ClientId: path.EndpointA.ClientID,

--- a/modules/core/02-client/keeper/keeper.go
+++ b/modules/core/02-client/keeper/keeper.go
@@ -236,7 +236,7 @@ func (k Keeper) GetLatestClientConsensusState(ctx sdk.Context, clientID string) 
 	if !ok {
 		return nil, false
 	}
-	return k.GetClientConsensusState(ctx, clientID, clientState.GetLatestHeight())
+	return k.GetClientConsensusState(ctx, clientID, clientState.GetLatestHeight(ctx, k.ClientStore(ctx, clientID), k.cdc))
 }
 
 // GetSelfConsensusState introspects the (self) past historical info at a given height

--- a/modules/core/02-client/keeper/keeper_test.go
+++ b/modules/core/02-client/keeper/keeper_test.go
@@ -343,7 +343,8 @@ func (suite KeeperTestSuite) TestGetAllConsensusStates() { //nolint:govet // thi
 	suite.coordinator.SetupClients(path)
 
 	clientState := path.EndpointA.GetClientState()
-	expConsensusHeight0 := clientState.GetLatestHeight()
+	clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+	expConsensusHeight0 := clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc)
 	consensusState0, ok := suite.chainA.GetConsensusState(path.EndpointA.ClientID, expConsensusHeight0)
 	suite.Require().True(ok)
 
@@ -352,7 +353,7 @@ func (suite KeeperTestSuite) TestGetAllConsensusStates() { //nolint:govet // thi
 	suite.Require().NoError(err)
 
 	clientState = path.EndpointA.GetClientState()
-	expConsensusHeight1 := clientState.GetLatestHeight()
+	expConsensusHeight1 := clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc)
 	suite.Require().True(expConsensusHeight1.GT(expConsensusHeight0))
 	consensusState1, ok := suite.chainA.GetConsensusState(path.EndpointA.ClientID, expConsensusHeight1)
 	suite.Require().True(ok)
@@ -367,7 +368,7 @@ func (suite KeeperTestSuite) TestGetAllConsensusStates() { //nolint:govet // thi
 	suite.coordinator.SetupClients(path2)
 	clientState = path2.EndpointA.GetClientState()
 
-	expConsensusHeight2 := clientState.GetLatestHeight()
+	expConsensusHeight2 := clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc)
 	consensusState2, ok := suite.chainA.GetConsensusState(path2.EndpointA.ClientID, expConsensusHeight2)
 	suite.Require().True(ok)
 

--- a/modules/core/02-client/migrations/v7/solomachine.go
+++ b/modules/core/02-client/migrations/v7/solomachine.go
@@ -55,7 +55,7 @@ func (cs ClientState) ClientType() string {
 }
 
 // GetLatestHeight panics!
-func (cs ClientState) GetLatestHeight() exported.Height {
+func (cs ClientState) GetLatestHeight(_ sdk.Context, _ sdk.KVStore, _ codec.BinaryCodec) exported.Height {
 	panic("legacy solo machine is deprecated!")
 }
 

--- a/modules/core/02-client/types/client_test.go
+++ b/modules/core/02-client/types/client_test.go
@@ -26,11 +26,14 @@ func (suite *TypesTestSuite) TestMarshalConsensusStateWithHeight() {
 			"tendermint client", func() {
 				path := ibctesting.NewPath(suite.chainA, suite.chainB)
 				suite.coordinator.SetupClients(path)
+
 				clientState := suite.chainA.GetClientState(path.EndpointA.ClientID)
-				consensusState, ok := suite.chainA.GetConsensusState(path.EndpointA.ClientID, clientState.GetLatestHeight())
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+
+				consensusState, ok := suite.chainA.GetConsensusState(path.EndpointA.ClientID, clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec))
 				suite.Require().True(ok)
 
-				cswh = types.NewConsensusStateWithHeight(clientState.GetLatestHeight().(types.Height), consensusState)
+				cswh = types.NewConsensusStateWithHeight(clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec).(types.Height), consensusState)
 			},
 		},
 	}

--- a/modules/core/03-connection/keeper/grpc_query_test.go
+++ b/modules/core/03-connection/keeper/grpc_query_test.go
@@ -400,14 +400,17 @@ func (suite *KeeperTestSuite) TestQueryConnectionConsensusState() {
 				suite.coordinator.SetupConnections(path)
 
 				clientState := suite.chainA.GetClientState(path.EndpointA.ClientID)
-				expConsensusState, _ = suite.chainA.GetConsensusState(path.EndpointA.ClientID, clientState.GetLatestHeight())
+				clientStore := suite.chainA.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+
+				latestHeight := clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec)
+				expConsensusState, _ = suite.chainA.GetConsensusState(path.EndpointA.ClientID, latestHeight)
 				suite.Require().NotNil(expConsensusState)
 				expClientID = path.EndpointA.ClientID
 
 				req = &types.QueryConnectionConsensusStateRequest{
 					ConnectionId:   path.EndpointA.ConnectionID,
-					RevisionNumber: clientState.GetLatestHeight().GetRevisionNumber(),
-					RevisionHeight: clientState.GetLatestHeight().GetRevisionHeight(),
+					RevisionNumber: latestHeight.GetRevisionNumber(),
+					RevisionHeight: latestHeight.GetRevisionHeight(),
 				}
 			},
 			true,

--- a/modules/core/03-connection/keeper/handshake_test.go
+++ b/modules/core/03-connection/keeper/handshake_test.go
@@ -199,7 +199,8 @@ func (suite *KeeperTestSuite) TestConnOpenTry() {
 			suite.Require().True(ok)
 
 			tmConsState.Timestamp = time.Now()
-			suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientConsensusState(suite.chainA.GetContext(), path.EndpointA.ClientID, counterpartyClient.GetLatestHeight(), tmConsState)
+			clientStore := suite.chainA.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+			suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientConsensusState(suite.chainA.GetContext(), path.EndpointA.ClientID, counterpartyClient.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec), tmConsState)
 
 			err := path.EndpointA.ConnOpenInit()
 			suite.Require().NoError(err)
@@ -230,7 +231,8 @@ func (suite *KeeperTestSuite) TestConnOpenTry() {
 
 			if consensusHeight.IsZero() {
 				// retrieve consensus state height to provide proof for
-				consensusHeight = counterpartyClient.GetLatestHeight()
+				clientStore := suite.chainA.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+				consensusHeight = counterpartyClient.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec)
 			}
 			consensusKey := host.FullConsensusStateKey(path.EndpointA.ClientID, consensusHeight)
 			proofConsensus, _ := suite.chainA.QueryProof(consensusKey)
@@ -454,7 +456,8 @@ func (suite *KeeperTestSuite) TestConnOpenAck() {
 			suite.Require().True(ok)
 
 			tmConsState.Timestamp = tmConsState.Timestamp.Add(time.Second)
-			suite.chainB.App.GetIBCKeeper().ClientKeeper.SetClientConsensusState(suite.chainB.GetContext(), path.EndpointB.ClientID, counterpartyClient.GetLatestHeight(), tmConsState)
+			clientStore := suite.chainA.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+			suite.chainB.App.GetIBCKeeper().ClientKeeper.SetClientConsensusState(suite.chainB.GetContext(), path.EndpointB.ClientID, counterpartyClient.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec), tmConsState)
 
 			err = path.EndpointB.ConnOpenTry()
 			suite.Require().NoError(err)
@@ -482,7 +485,8 @@ func (suite *KeeperTestSuite) TestConnOpenAck() {
 			if consensusHeight.IsZero() {
 				// retrieve consensus state height to provide proof for
 				clientState := suite.chainB.GetClientState(path.EndpointB.ClientID)
-				consensusHeight = clientState.GetLatestHeight()
+				clientStore := suite.chainA.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+				consensusHeight = clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec)
 			}
 			consensusKey := host.FullConsensusStateKey(path.EndpointB.ClientID, consensusHeight)
 			proofConsensus, _ := suite.chainB.QueryProof(consensusKey)

--- a/modules/core/03-connection/keeper/verify_test.go
+++ b/modules/core/03-connection/keeper/verify_test.go
@@ -104,6 +104,7 @@ func (suite *KeeperTestSuite) TestVerifyClientConsensusState() {
 		}, false},
 		{"verification failed", func() {
 			clientState := suite.chainB.GetClientState(path.EndpointB.ClientID)
+			clientStore := suite.chainB.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainB.GetContext(), path.EndpointB.ClientID)
 
 			// give chainB wrong consensus state for chainA
 			consState, found := suite.chainB.App.GetIBCKeeper().ClientKeeper.GetLatestClientConsensusState(suite.chainB.GetContext(), path.EndpointB.ClientID)
@@ -113,7 +114,9 @@ func (suite *KeeperTestSuite) TestVerifyClientConsensusState() {
 			suite.Require().True(ok)
 
 			tmConsState.Timestamp = time.Now()
-			suite.chainB.App.GetIBCKeeper().ClientKeeper.SetClientConsensusState(suite.chainB.GetContext(), path.EndpointB.ClientID, clientState.GetLatestHeight(), tmConsState)
+
+			latestHeight := clientState.GetLatestHeight(suite.chainB.GetContext(), clientStore, suite.chainB.Codec)
+			suite.chainB.App.GetIBCKeeper().ClientKeeper.SetClientConsensusState(suite.chainB.GetContext(), path.EndpointB.ClientID, latestHeight, tmConsState)
 
 			suite.coordinator.CommitBlock(suite.chainB)
 		}, false},

--- a/modules/core/04-channel/client/utils/utils.go
+++ b/modules/core/04-channel/client/utils/utils.go
@@ -141,11 +141,6 @@ func QueryLatestConsensusState(
 
 	if clientState, ok := clientState.(*ibctm.ClientState); ok {
 		clientHeight := clientState.LatestHeight
-		// if !ok {
-		// 	return nil, clienttypes.Height{}, clienttypes.Height{}, sdkerrors.Wrapf(sdkerrors.ErrInvalidHeight, "invalid height type. expected type: %T, got: %T",
-		// 		clienttypes.Height{}, clientHeight)
-		// }
-
 		res, err := QueryChannelConsensusState(clientCtx, portID, channelID, clientHeight, false)
 		if err != nil {
 			return nil, clienttypes.Height{}, clienttypes.Height{}, err
@@ -159,22 +154,7 @@ func QueryLatestConsensusState(
 		return consensusState, clientHeight, res.ProofHeight, nil
 	}
 
-	// clientHeight, ok := clientState.GetLatestHeight().(clienttypes.Height)
-	// if !ok {
-	// 	return nil, clienttypes.Height{}, clienttypes.Height{}, sdkerrors.Wrapf(sdkerrors.ErrInvalidHeight, "invalid height type. expected type: %T, got: %T",
-	// 		clienttypes.Height{}, clientHeight)
-	// }
-	// res, err := QueryChannelConsensusState(clientCtx, portID, channelID, clientHeight, false)
-	// if err != nil {
-	// 	return nil, clienttypes.Height{}, clienttypes.Height{}, err
-	// }
-
-	// var consensusState exported.ConsensusState
-	// if err := clientCtx.InterfaceRegistry.UnpackAny(res.ConsensusState, &consensusState); err != nil {
-	// 	return nil, clienttypes.Height{}, clienttypes.Height{}, err
-	// }
-
-	return nil, clienttypes.Height{}, clienttypes.Height{}, nil
+	return nil, clienttypes.Height{}, clienttypes.Height{}, sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "failed to query latest consensus state for client:", clientRes.IdentifiedClientState.ClientId)
 }
 
 // QueryNextSequenceReceive returns the next sequence receive.

--- a/modules/core/04-channel/keeper/grpc_query_test.go
+++ b/modules/core/04-channel/keeper/grpc_query_test.go
@@ -549,15 +549,18 @@ func (suite *KeeperTestSuite) TestQueryChannelConsensusState() {
 				suite.Require().NoError(err)
 
 				clientState := suite.chainA.GetClientState(path.EndpointA.ClientID)
-				expConsensusState, _ = suite.chainA.GetConsensusState(path.EndpointA.ClientID, clientState.GetLatestHeight())
+				clientStore := suite.chainA.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+
+				latestHeight := clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec)
+				expConsensusState, _ = suite.chainA.GetConsensusState(path.EndpointA.ClientID, latestHeight)
 				suite.Require().NotNil(expConsensusState)
 				expClientID = path.EndpointA.ClientID
 
 				req = &types.QueryChannelConsensusStateRequest{
 					PortId:         path.EndpointA.ChannelConfig.PortID,
 					ChannelId:      path.EndpointA.ChannelID,
-					RevisionNumber: clientState.GetLatestHeight().GetRevisionNumber(),
-					RevisionHeight: clientState.GetLatestHeight().GetRevisionHeight(),
+					RevisionNumber: latestHeight.GetRevisionNumber(),
+					RevisionHeight: latestHeight.GetRevisionHeight(),
 				}
 			},
 			true,

--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -77,7 +77,7 @@ func (k Keeper) SendPacket(
 	}
 
 	// check if packet is timed out on the receiving chain
-	latestHeight := clientState.GetLatestHeight()
+	latestHeight := clientState.GetLatestHeight(ctx, clientStore, k.cdc)
 	if !timeoutHeight.IsZero() && latestHeight.GTE(timeoutHeight) {
 		return 0, sdkerrors.Wrapf(
 			types.ErrPacketTimeout,

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -160,7 +160,8 @@ func (suite *KeeperTestSuite) TestSendPacket() {
 
 			// use client state latest height for timeout
 			clientState := path.EndpointA.GetClientState()
-			timeoutHeight = clientState.GetLatestHeight().(clienttypes.Height)
+			clientStore := suite.chainA.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+			timeoutHeight = clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec).(clienttypes.Height)
 			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 		}, false},
 		{"timeout timestamp passed", func() {
@@ -169,8 +170,9 @@ func (suite *KeeperTestSuite) TestSendPacket() {
 
 			// use latest time on client state
 			clientState := path.EndpointA.GetClientState()
+			clientStore := suite.chainA.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 			connection := path.EndpointA.GetConnection()
-			timestamp, err := suite.chainA.App.GetIBCKeeper().ConnectionKeeper.GetTimestampAtHeight(suite.chainA.GetContext(), connection, clientState.GetLatestHeight())
+			timestamp, err := suite.chainA.App.GetIBCKeeper().ConnectionKeeper.GetTimestampAtHeight(suite.chainA.GetContext(), connection, clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec))
 			suite.Require().NoError(err)
 
 			timeoutHeight = disabledTimeoutHeight
@@ -188,7 +190,8 @@ func (suite *KeeperTestSuite) TestSendPacket() {
 			path.EndpointA.SetConnection(connection)
 
 			clientState := path.EndpointA.GetClientState()
-			timestamp, err := suite.chainA.App.GetIBCKeeper().ConnectionKeeper.GetTimestampAtHeight(suite.chainA.GetContext(), connection, clientState.GetLatestHeight())
+			clientStore := suite.chainA.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+			timestamp, err := suite.chainA.App.GetIBCKeeper().ConnectionKeeper.GetTimestampAtHeight(suite.chainA.GetContext(), connection, clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec))
 			suite.Require().NoError(err)
 
 			sourceChannel = path.EndpointA.ChannelID

--- a/modules/core/04-channel/keeper/timeout_test.go
+++ b/modules/core/04-channel/keeper/timeout_test.go
@@ -102,7 +102,8 @@ func (suite *KeeperTestSuite) TestTimeoutPacket() {
 			expError = types.ErrInvalidChannelState
 			suite.coordinator.Setup(path)
 
-			timeoutHeight := path.EndpointA.GetClientState().GetLatestHeight().Increment().(clienttypes.Height)
+			clientStore := suite.chainA.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+			timeoutHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec).Increment().(clienttypes.Height)
 
 			sequence, err := path.EndpointA.SendPacket(timeoutHeight, disabledTimeoutTimestamp, ibctesting.MockPacketData)
 			suite.Require().NoError(err)

--- a/modules/core/exported/client.go
+++ b/modules/core/exported/client.go
@@ -37,8 +37,9 @@ type ClientState interface {
 	proto.Message
 
 	ClientType() string
-	GetLatestHeight() Height
 	Validate() error
+
+	GetLatestHeight(ctx sdk.Context, clientStore sdk.KVStore, cdc codec.BinaryCodec) Height
 
 	// Status must return the status of the client. Only Active clients are allowed to process packets.
 	Status(ctx sdk.Context, clientStore sdk.KVStore, cdc codec.BinaryCodec) Status

--- a/modules/light-clients/06-solomachine/client_state.go
+++ b/modules/light-clients/06-solomachine/client_state.go
@@ -34,7 +34,7 @@ func (cs ClientState) ClientType() string {
 // GetLatestHeight returns the latest sequence number.
 // Return exported.Height to satisfy ClientState interface
 // Revision number is always 0 for a solo-machine.
-func (cs ClientState) GetLatestHeight() exported.Height {
+func (cs ClientState) GetLatestHeight(ctx sdk.Context, clientStore sdk.KVStore, cdc codec.BinaryCodec) exported.Height {
 	return clienttypes.NewHeight(0, cs.Sequence)
 }
 
@@ -230,7 +230,7 @@ func produceVerificationArgs(
 		return nil, nil, 0, 0, sdkerrors.Wrapf(ErrInvalidProof, "the consensus state timestamp is greater than the signature timestamp (%d >= %d)", cs.ConsensusState.GetTimestamp(), timestamp)
 	}
 
-	sequence := cs.GetLatestHeight().GetRevisionHeight()
+	sequence := cs.Sequence
 	publicKey, err := cs.ConsensusState.GetPubKey()
 	if err != nil {
 		return nil, nil, 0, 0, err

--- a/modules/light-clients/06-solomachine/client_state_test.go
+++ b/modules/light-clients/06-solomachine/client_state_test.go
@@ -802,7 +802,7 @@ func (suite *SoloMachineTestSuite) TestGetTimestampAtHeight() {
 		{
 			name:        "get timestamp at height exists",
 			clientState: suite.solomachine.ClientState(),
-			height:      suite.solomachine.ClientState().GetLatestHeight(),
+			height:      clienttypes.NewHeight(0, 1),
 			expValue:    suite.solomachine.ClientState().ConsensusState.Timestamp,
 			expPass:     true,
 		},

--- a/modules/light-clients/06-solomachine/solomachine_test.go
+++ b/modules/light-clients/06-solomachine/solomachine_test.go
@@ -145,7 +145,9 @@ func (suite *SoloMachineTestSuite) GetSequenceFromStore() uint64 {
 	var clientState exported.ClientState
 	err := suite.chainA.Codec.UnmarshalInterface(bz, &clientState)
 	suite.Require().NoError(err)
-	return clientState.GetLatestHeight().GetRevisionHeight()
+
+	clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), clientIDSolomachine)
+	return clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec).GetRevisionHeight()
 }
 
 func (suite *SoloMachineTestSuite) GetInvalidProof() []byte {

--- a/modules/light-clients/07-tendermint/client_state.go
+++ b/modules/light-clients/07-tendermint/client_state.go
@@ -49,7 +49,7 @@ func (cs ClientState) ClientType() string {
 }
 
 // GetLatestHeight returns latest block height.
-func (cs ClientState) GetLatestHeight() exported.Height {
+func (cs ClientState) GetLatestHeight(ctx sdk.Context, clientStore sdk.KVStore, cdc codec.BinaryCodec) exported.Height {
 	return cs.LatestHeight
 }
 
@@ -86,7 +86,7 @@ func (cs ClientState) Status(
 	}
 
 	// get latest consensus state from clientStore to check for expiry
-	consState, found := GetConsensusState(clientStore, cdc, cs.GetLatestHeight())
+	consState, found := GetConsensusState(clientStore, cdc, cs.GetLatestHeight(ctx, clientStore, cdc))
 	if !found {
 		// if the client state does not have an associated consensus state for its latest height
 		// then it must be expired
@@ -198,8 +198,8 @@ func (cs ClientState) Initialize(ctx sdk.Context, cdc codec.BinaryCodec, clientS
 	}
 
 	setClientState(clientStore, cdc, &cs)
-	setConsensusState(clientStore, cdc, consensusState, cs.GetLatestHeight())
-	setConsensusMetadata(ctx, clientStore, cs.GetLatestHeight())
+	setConsensusState(clientStore, cdc, consensusState, cs.GetLatestHeight(ctx, clientStore, cdc))
+	setConsensusMetadata(ctx, clientStore, cs.GetLatestHeight(ctx, clientStore, cdc))
 
 	return nil
 }
@@ -218,10 +218,10 @@ func (cs ClientState) VerifyMembership(
 	path exported.Path,
 	value []byte,
 ) error {
-	if cs.GetLatestHeight().LT(height) {
+	if cs.GetLatestHeight(ctx, clientStore, cdc).LT(height) {
 		return sdkerrors.Wrapf(
 			sdkerrors.ErrInvalidHeight,
-			"client state height < proof height (%d < %d), please ensure the client has been updated", cs.GetLatestHeight(), height,
+			"client state height < proof height (%d < %d), please ensure the client has been updated", cs.GetLatestHeight(ctx, clientStore, cdc), height,
 		)
 	}
 
@@ -264,10 +264,10 @@ func (cs ClientState) VerifyNonMembership(
 	proof []byte,
 	path exported.Path,
 ) error {
-	if cs.GetLatestHeight().LT(height) {
+	if cs.GetLatestHeight(ctx, clientStore, cdc).LT(height) {
 		return sdkerrors.Wrapf(
 			sdkerrors.ErrInvalidHeight,
-			"client state height < proof height (%d < %d), please ensure the client has been updated", cs.GetLatestHeight(), height,
+			"client state height < proof height (%d < %d), please ensure the client has been updated", cs.GetLatestHeight(ctx, clientStore, cdc), height,
 		)
 	}
 

--- a/modules/light-clients/07-tendermint/client_state_test.go
+++ b/modules/light-clients/07-tendermint/client_state_test.go
@@ -246,14 +246,15 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 		},
 		{
 			"successful ConsensusState verification", func() {
-				key := host.FullConsensusStateKey(testingpath.EndpointB.ClientID, testingpath.EndpointB.GetClientState().GetLatestHeight())
+				store := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), testingpath.EndpointA.ClientID)
+				key := host.FullConsensusStateKey(testingpath.EndpointB.ClientID, testingpath.EndpointB.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.chainA.Codec))
 				merklePath := commitmenttypes.NewMerklePath(string(key))
 				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
 				proof, proofHeight = suite.chainB.QueryProof(key)
 
-				consensusState := testingpath.EndpointB.GetConsensusState(testingpath.EndpointB.GetClientState().GetLatestHeight()).(*ibctm.ConsensusState)
+				consensusState := testingpath.EndpointB.GetConsensusState(testingpath.EndpointB.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.chainA.Codec)).(*ibctm.ConsensusState)
 				value, err = suite.chainB.Codec.MarshalInterface(consensusState)
 				suite.Require().NoError(err)
 			},
@@ -361,7 +362,8 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 				suite.Require().NoError(err)
 
 				clientState := testingpath.EndpointA.GetClientState()
-				proof, proofHeight = suite.chainB.QueryProofForStore(transfertypes.StoreKey, key, int64(clientState.GetLatestHeight().GetRevisionHeight()))
+				store := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), testingpath.EndpointA.ClientID)
+				proof, proofHeight = suite.chainB.QueryProofForStore(transfertypes.StoreKey, key, int64(clientState.GetLatestHeight(suite.chainA.GetContext(), store, suite.chainA.Codec).GetRevisionHeight()))
 
 				value = []byte(suite.chainB.GetSimApp().TransferKeeper.GetPort(suite.chainB.GetContext()))
 				suite.Require().NoError(err)
@@ -394,7 +396,8 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 		},
 		{
 			"latest client height < height", func() {
-				proofHeight = testingpath.EndpointA.GetClientState().GetLatestHeight().Increment()
+				store := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), testingpath.EndpointA.ClientID)
+				proofHeight = testingpath.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.chainA.Codec).Increment()
 			}, false,
 		},
 		{
@@ -498,7 +501,8 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 		},
 		{
 			"successful ConsensusState verification of non membership", func() {
-				key := host.FullConsensusStateKey(invalidClientID, testingpath.EndpointB.GetClientState().GetLatestHeight())
+				store := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), testingpath.EndpointA.ClientID)
+				key := host.FullConsensusStateKey(invalidClientID, testingpath.EndpointB.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.chainA.Codec))
 				merklePath := commitmenttypes.NewMerklePath(string(key))
 				path, err = commitmenttypes.ApplyPrefix(suite.chainB.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
@@ -570,7 +574,8 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 				suite.Require().NoError(err)
 
 				clientState := testingpath.EndpointA.GetClientState()
-				proof, proofHeight = suite.chainB.QueryProofForStore(transfertypes.StoreKey, key, int64(clientState.GetLatestHeight().GetRevisionHeight()))
+				store := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), testingpath.EndpointA.ClientID)
+				proof, proofHeight = suite.chainB.QueryProofForStore(transfertypes.StoreKey, key, int64(clientState.GetLatestHeight(suite.chainA.GetContext(), store, suite.chainA.Codec).GetRevisionHeight()))
 			},
 			true,
 		},
@@ -600,7 +605,8 @@ func (suite *TendermintTestSuite) TestVerifyNonMembership() {
 		},
 		{
 			"latest client height < height", func() {
-				proofHeight = testingpath.EndpointA.GetClientState().GetLatestHeight().Increment()
+				store := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), testingpath.EndpointA.ClientID)
+				proofHeight = testingpath.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), store, suite.chainA.Codec).Increment()
 			}, false,
 		},
 		{

--- a/modules/light-clients/07-tendermint/genesis_test.go
+++ b/modules/light-clients/07-tendermint/genesis_test.go
@@ -17,7 +17,7 @@ func (suite *TendermintTestSuite) TestExportMetadata() {
 	suite.coordinator.SetupClients(path)
 	clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 	clientState := path.EndpointA.GetClientState()
-	height := clientState.GetLatestHeight()
+	height := clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec)
 
 	initIteration := ibctm.GetIterationKey(clientStore, height)
 	suite.Require().NotEqual(0, len(initIteration))
@@ -46,7 +46,7 @@ func (suite *TendermintTestSuite) TestExportMetadata() {
 	suite.Require().NoError(err)
 
 	clientState = path.EndpointA.GetClientState()
-	updateHeight := clientState.GetLatestHeight()
+	updateHeight := clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec)
 
 	iteration := ibctm.GetIterationKey(clientStore, updateHeight)
 	suite.Require().NotEqual(0, len(initIteration))

--- a/modules/light-clients/07-tendermint/migrations/migrations_test.go
+++ b/modules/light-clients/07-tendermint/migrations/migrations_test.go
@@ -69,14 +69,15 @@ func (suite *MigrationsTestSuite) TestPruneExpiredConsensusStates() {
 	for _, path := range paths {
 		// collect all heights expected to be pruned
 		var pruneHeights []exported.Height
-		pruneHeights = append(pruneHeights, path.EndpointA.GetClientState().GetLatestHeight())
+		clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+		pruneHeights = append(pruneHeights, path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec))
 
 		// these heights will be expired and also pruned
 		for i := 0; i < 3; i++ {
 			err := path.EndpointA.UpdateClient()
 			suite.Require().NoError(err)
 
-			pruneHeights = append(pruneHeights, path.EndpointA.GetClientState().GetLatestHeight())
+			pruneHeights = append(pruneHeights, path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec))
 		}
 
 		// double chedck all information is currently stored
@@ -110,11 +111,12 @@ func (suite *MigrationsTestSuite) TestPruneExpiredConsensusStates() {
 		var unexpiredHeights []exported.Height
 		err := path.EndpointA.UpdateClient()
 		suite.Require().NoError(err)
-		unexpiredHeights = append(unexpiredHeights, path.EndpointA.GetClientState().GetLatestHeight())
+		clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+		unexpiredHeights = append(unexpiredHeights, path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec))
 
 		err = path.EndpointA.UpdateClient()
 		suite.Require().NoError(err)
-		unexpiredHeights = append(unexpiredHeights, path.EndpointA.GetClientState().GetLatestHeight())
+		unexpiredHeights = append(unexpiredHeights, path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.chainA.Codec))
 
 		unexpiredHeightMap[path] = unexpiredHeights
 	}

--- a/modules/light-clients/07-tendermint/misbehaviour_handle_test.go
+++ b/modules/light-clients/07-tendermint/misbehaviour_handle_test.go
@@ -7,6 +7,7 @@ import (
 
 	tmtypes "github.com/tendermint/tendermint/types"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v6/modules/core/exported"
 	solomachine "github.com/cosmos/ibc-go/v6/modules/light-clients/06-solomachine"
@@ -29,6 +30,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 	altSigners := getAltSigners(altVal, altPrivVal)
 
 	var (
+		clientStore  sdk.KVStore
 		path         *ibctesting.Path
 		misbehaviour exported.ClientMessage
 	)
@@ -40,7 +42,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 	}{
 		{
 			"valid fork misbehaviour", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -48,7 +50,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, trustedVals, suite.chainB.Signers),
@@ -59,7 +61,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"valid time misbehaviour", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -73,7 +75,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"valid time misbehaviour, header 1 time stricly less than header 2 time", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -87,7 +89,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"valid misbehavior at height greater than last consensusState", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -100,7 +102,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"valid misbehaviour with different trusted heights", func() {
-				trustedHeight1 := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight1 := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals1, found := suite.chainB.GetValsAtHeight(int64(trustedHeight1.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -108,7 +110,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				trustedHeight2 := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight2 := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals2, found := suite.chainB.GetValsAtHeight(int64(trustedHeight2.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -122,7 +124,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"valid misbehaviour at a previous revision", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -130,7 +132,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, trustedVals, suite.chainB.Signers),
@@ -145,12 +147,12 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"valid misbehaviour at a future revision", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				futureRevision := fmt.Sprintf("%s-%d", strings.TrimSuffix(suite.chainB.ChainID, fmt.Sprintf("-%d", clienttypes.ParseChainID(suite.chainB.ChainID))), height.GetRevisionNumber()+1)
 
@@ -163,7 +165,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"valid misbehaviour with trusted heights at a previous revision", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -172,7 +174,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err = path.EndpointB.UpgradeChain()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, trustedVals, suite.chainB.Signers),
@@ -183,7 +185,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"consensus state's valset hash different from misbehaviour should still pass", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -191,7 +193,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				// Create bothValSet with both suite validator and altVal
 				bothValSet := tmtypes.NewValidatorSet(append(suite.chainB.Vals.Validators, altValSet.Proposer))
@@ -206,7 +208,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"invalid fork misbehaviour: identical headers", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -214,7 +216,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviourHeader := suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, trustedVals, suite.chainB.Signers)
 				misbehaviour = &ibctm.Misbehaviour{
@@ -225,7 +227,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"invalid time misbehaviour: monotonically increasing time", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -238,7 +240,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"invalid misbehaviour: misbehaviour from different chain", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -246,7 +248,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader("evmos", int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, trustedVals, suite.chainB.Signers),
@@ -256,12 +258,12 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"misbehaviour trusted validators does not match validator hash in trusted consensus state", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, altValSet, suite.chainB.Signers),
@@ -271,7 +273,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"trusted consensus state does not exist", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -289,7 +291,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"trusting period expired", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -297,7 +299,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				suite.chainA.ExpireClient(path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod)
 
@@ -309,7 +311,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"header 1 valset has too much change", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -317,7 +319,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), altValSet, suite.chainB.NextVals, trustedVals, altSigners),
@@ -327,7 +329,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"header 2 valset has too much change", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -335,7 +337,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, trustedVals, suite.chainB.Signers),
@@ -345,7 +347,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 		},
 		{
 			"both header 1 and header 2 valsets have too much change", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -353,7 +355,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), altValSet, suite.chainB.NextVals, trustedVals, altSigners),
@@ -373,11 +375,11 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviour() {
 			err := path.EndpointA.CreateClient()
 			suite.Require().NoError(err)
 
+			clientStore = suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+
 			tc.malleate()
 
 			clientState := path.EndpointA.GetClientState()
-			clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
-
 			err = clientState.VerifyClientMessage(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), clientStore, misbehaviour)
 
 			if tc.expPass {
@@ -409,6 +411,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 	altSigners := getAltSigners(altVal, altPrivVal)
 
 	var (
+		clientStore  sdk.KVStore
 		path         *ibctesting.Path
 		misbehaviour exported.ClientMessage
 	)
@@ -420,7 +423,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 	}{
 		{
 			"valid fork misbehaviour", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -428,7 +431,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, trustedVals, suite.chainB.Signers),
@@ -439,7 +442,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"valid time misbehaviour", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -453,7 +456,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"valid time misbehaviour, header 1 time stricly less than header 2 time", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -467,7 +470,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"valid misbehavior at height greater than last consensusState", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -480,7 +483,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"valid misbehaviour with different trusted heights", func() {
-				trustedHeight1 := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight1 := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals1, found := suite.chainB.GetValsAtHeight(int64(trustedHeight1.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -488,7 +491,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				trustedHeight2 := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight2 := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals2, found := suite.chainB.GetValsAtHeight(int64(trustedHeight2.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -502,7 +505,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"consensus state's valset hash different from misbehaviour should still pass", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -510,7 +513,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				// Create bothValSet with both suite validator and altVal
 				bothValSet := tmtypes.NewValidatorSet(append(suite.chainB.Vals.Validators, altValSet.Proposer))
@@ -525,7 +528,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"invalid fork misbehaviour: identical headers", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -533,7 +536,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviourHeader := suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, trustedVals, suite.chainB.Signers)
 				misbehaviour = &ibctm.Misbehaviour{
@@ -544,7 +547,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"invalid time misbehaviour: monotonically increasing time", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -557,7 +560,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"invalid misbehaviour: misbehaviour from different chain", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -565,7 +568,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader("evmos", int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, trustedVals, suite.chainB.Signers),
@@ -575,12 +578,12 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"misbehaviour trusted validators does not match validator hash in trusted consensus state", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, altValSet, suite.chainB.Signers),
@@ -590,7 +593,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"trusted consensus state does not exist", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -608,7 +611,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"trusting period expired", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -616,7 +619,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				suite.chainA.ExpireClient(path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod)
 
@@ -628,7 +631,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"header 1 valset has too much change", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -636,7 +639,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), altValSet, suite.chainB.NextVals, trustedVals, altSigners),
@@ -646,7 +649,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"header 2 valset has too much change", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -654,7 +657,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), suite.chainB.Vals, suite.chainB.NextVals, trustedVals, suite.chainB.Signers),
@@ -664,7 +667,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 		},
 		{
 			"both header 1 and header 2 valsets have too much change", func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -672,7 +675,7 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				height := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				height := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				misbehaviour = &ibctm.Misbehaviour{
 					Header1: suite.chainB.CreateTMClientHeader(suite.chainB.ChainID, int64(height.RevisionHeight), trustedHeight, suite.chainB.CurrentHeader.Time.Add(time.Minute), altValSet, suite.chainB.NextVals, trustedVals, altSigners),
@@ -692,11 +695,11 @@ func (suite *TendermintTestSuite) TestVerifyMisbehaviourNonRevisionChainID() {
 			err := path.EndpointA.CreateClient()
 			suite.Require().NoError(err)
 
+			clientStore = suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+
 			tc.malleate()
 
 			clientState := path.EndpointA.GetClientState()
-			clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
-
 			err = clientState.VerifyClientMessage(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), clientStore, misbehaviour)
 
 			if tc.expPass {

--- a/modules/light-clients/07-tendermint/proposal_handle.go
+++ b/modules/light-clients/07-tendermint/proposal_handle.go
@@ -44,7 +44,7 @@ func (cs ClientState) CheckSubstituteAndUpdateState(
 
 	// copy consensus states and processed time from substitute to subject
 	// starting from initial height and ending on the latest height (inclusive)
-	height := substituteClientState.GetLatestHeight()
+	height := substituteClientState.GetLatestHeight(ctx, substituteClientStore, cdc)
 
 	consensusState, found := GetConsensusState(substituteClientStore, cdc, height)
 	if !found {

--- a/modules/light-clients/07-tendermint/proposal_handle_test.go
+++ b/modules/light-clients/07-tendermint/proposal_handle_test.go
@@ -125,12 +125,12 @@ func (suite *TendermintTestSuite) TestCheckSubstituteAndUpdateState() {
 			subjectClientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), subjectPath.EndpointA.ClientID)
 			substituteClientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), substitutePath.EndpointA.ClientID)
 
-			expectedConsState := substitutePath.EndpointA.GetConsensusState(substituteClientState.GetLatestHeight())
-			expectedProcessedTime, found := ibctm.GetProcessedTime(substituteClientStore, substituteClientState.GetLatestHeight())
+			expectedConsState := substitutePath.EndpointA.GetConsensusState(substituteClientState.GetLatestHeight(suite.chainA.GetContext(), substituteClientStore, suite.cdc))
+			expectedProcessedTime, found := ibctm.GetProcessedTime(substituteClientStore, substituteClientState.GetLatestHeight(suite.chainA.GetContext(), substituteClientStore, suite.cdc))
 			suite.Require().True(found)
-			expectedProcessedHeight, found := ibctm.GetProcessedTime(substituteClientStore, substituteClientState.GetLatestHeight())
+			expectedProcessedHeight, found := ibctm.GetProcessedTime(substituteClientStore, substituteClientState.GetLatestHeight(suite.chainA.GetContext(), substituteClientStore, suite.cdc))
 			suite.Require().True(found)
-			expectedIterationKey := ibctm.GetIterationKey(substituteClientStore, substituteClientState.GetLatestHeight())
+			expectedIterationKey := ibctm.GetIterationKey(substituteClientStore, substituteClientState.GetLatestHeight(suite.chainA.GetContext(), substituteClientStore, suite.cdc))
 
 			err := subjectClientState.CheckSubstituteAndUpdateState(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), subjectClientStore, substituteClientStore, substituteClientState)
 
@@ -143,13 +143,13 @@ func (suite *TendermintTestSuite) TestCheckSubstituteAndUpdateState() {
 				subjectClientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), subjectPath.EndpointA.ClientID)
 
 				// check that the correct consensus state was copied over
-				suite.Require().Equal(substituteClientState.GetLatestHeight(), updatedClient.GetLatestHeight())
-				subjectConsState := subjectPath.EndpointA.GetConsensusState(updatedClient.GetLatestHeight())
-				subjectProcessedTime, found := ibctm.GetProcessedTime(subjectClientStore, updatedClient.GetLatestHeight())
+				suite.Require().Equal(substituteClientState.GetLatestHeight(suite.chainA.GetContext(), substituteClientStore, suite.cdc), updatedClient.GetLatestHeight(suite.chainA.GetContext(), subjectClientStore, suite.cdc))
+				subjectConsState := subjectPath.EndpointA.GetConsensusState(updatedClient.GetLatestHeight(suite.chainA.GetContext(), subjectClientStore, suite.cdc))
+				subjectProcessedTime, found := ibctm.GetProcessedTime(subjectClientStore, updatedClient.GetLatestHeight(suite.chainA.GetContext(), subjectClientStore, suite.cdc))
 				suite.Require().True(found)
-				subjectProcessedHeight, found := ibctm.GetProcessedTime(substituteClientStore, updatedClient.GetLatestHeight())
+				subjectProcessedHeight, found := ibctm.GetProcessedTime(substituteClientStore, updatedClient.GetLatestHeight(suite.chainA.GetContext(), subjectClientStore, suite.cdc))
 				suite.Require().True(found)
-				subjectIterationKey := ibctm.GetIterationKey(substituteClientStore, updatedClient.GetLatestHeight())
+				subjectIterationKey := ibctm.GetIterationKey(substituteClientStore, updatedClient.GetLatestHeight(suite.chainA.GetContext(), subjectClientStore, suite.cdc))
 
 				suite.Require().Equal(expectedConsState, subjectConsState)
 				suite.Require().Equal(expectedProcessedTime, subjectProcessedTime)

--- a/modules/light-clients/07-tendermint/update_test.go
+++ b/modules/light-clients/07-tendermint/update_test.go
@@ -17,8 +17,9 @@ import (
 
 func (suite *TendermintTestSuite) TestVerifyHeader() {
 	var (
-		path   *ibctesting.Path
-		header *ibctm.Header
+		clientStore sdk.KVStore
+		path        *ibctesting.Path
+		header      *ibctm.Header
 	)
 
 	// Setup different validators and signers for testing different types of updates
@@ -47,7 +48,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "successful verify header for header with a previous height",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -66,7 +67,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "successful verify header: header with future height and different validator set",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -83,7 +84,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "successful verify header: header with next height and different validator set",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -100,7 +101,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful updates, passed in incorrect trusted validators for given consensus state",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				// Create bothValSet with both suite validator and altVal
 				bothValSet := tmtypes.NewValidatorSet(append(suite.chainB.Vals.Validators, altVal))
@@ -114,7 +115,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful verify header with next height: update header mismatches nextValSetHash",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -127,7 +128,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful update with future height: too much change in validator set",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -139,7 +140,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful verify header: header height revision and trusted height revision mismatch",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
 
@@ -150,7 +151,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful verify header: header height < consensus height",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -173,7 +174,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful verify header: header timestamp is not past last client timestamp",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight))
 				suite.Require().True(found)
@@ -185,7 +186,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful verify header: header with incorrect header chain-id",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight))
 				suite.Require().True(found)
@@ -197,7 +198,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful update: trusting period has passed since last client timestamp",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight))
 				suite.Require().True(found)
@@ -211,7 +212,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful update for a previous revision",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -228,7 +229,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "successful update with identical header to a previous update",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -246,7 +247,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful update to a future revision",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -259,7 +260,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful update: header height revision and trusted height revision mismatch",
 			malleate: func() {
-				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -287,11 +288,10 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		header, err = path.EndpointA.Chain.ConstructUpdateTMClientHeader(path.EndpointA.Counterparty.Chain, path.EndpointA.ClientID)
 		suite.Require().NoError(err)
 
-		tc.malleate()
-
 		clientState := path.EndpointA.GetClientState()
+		clientStore = suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 
-		clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+		tc.malleate()
 
 		err = clientState.VerifyClientMessage(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), clientStore, header)
 
@@ -324,15 +324,15 @@ func (suite *TendermintTestSuite) TestUpdateState() {
 			"success with height later than latest height", func() {
 				tmHeader, ok := clientMessage.(*ibctm.Header)
 				suite.Require().True(ok)
-				suite.Require().True(path.EndpointA.GetClientState().GetLatestHeight().LT(tmHeader.GetHeight()))
+				suite.Require().True(path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).LT(tmHeader.GetHeight()))
 			},
 			func() {
 				tmHeader, ok := clientMessage.(*ibctm.Header)
 				suite.Require().True(ok)
 
 				clientState := path.EndpointA.GetClientState()
-				suite.Require().True(clientState.GetLatestHeight().EQ(tmHeader.GetHeight())) // new update, updated client state should have changed
-				suite.Require().True(clientState.GetLatestHeight().EQ(consensusHeights[0]))
+				suite.Require().True(clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).EQ(tmHeader.GetHeight())) // new update, updated client state should have changed
+				suite.Require().True(clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).EQ(consensusHeights[0]))
 			}, true,
 		},
 		{
@@ -345,14 +345,14 @@ func (suite *TendermintTestSuite) TestUpdateState() {
 
 				tmHeader, ok := clientMessage.(*ibctm.Header)
 				suite.Require().True(ok)
-				suite.Require().True(path.EndpointA.GetClientState().GetLatestHeight().GT(tmHeader.GetHeight()))
+				suite.Require().True(path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GT(tmHeader.GetHeight()))
 
 				prevClientState = path.EndpointA.GetClientState()
 			},
 			func() {
 				clientState := path.EndpointA.GetClientState()
 				suite.Require().Equal(clientState, prevClientState) // fill in height, no change to client state
-				suite.Require().True(clientState.GetLatestHeight().GT(consensusHeights[0]))
+				suite.Require().True(clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GT(consensusHeights[0]))
 			}, true,
 		},
 		{
@@ -367,7 +367,7 @@ func (suite *TendermintTestSuite) TestUpdateState() {
 
 				tmHeader, ok := clientMessage.(*ibctm.Header)
 				suite.Require().True(ok)
-				suite.Require().Equal(path.EndpointA.GetClientState().GetLatestHeight(), tmHeader.GetHeight())
+				suite.Require().Equal(path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc), tmHeader.GetHeight())
 
 				prevClientState = path.EndpointA.GetClientState()
 				prevConsensusState = path.EndpointA.GetConsensusState(tmHeader.GetHeight())
@@ -375,7 +375,7 @@ func (suite *TendermintTestSuite) TestUpdateState() {
 			func() {
 				clientState := path.EndpointA.GetClientState()
 				suite.Require().Equal(clientState, prevClientState)
-				suite.Require().True(clientState.GetLatestHeight().EQ(consensusHeights[0]))
+				suite.Require().True(clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).EQ(consensusHeights[0]))
 
 				tmHeader, ok := clientMessage.(*ibctm.Header)
 				suite.Require().True(ok)
@@ -387,7 +387,7 @@ func (suite *TendermintTestSuite) TestUpdateState() {
 				// this height will be expired and pruned
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
-				pruneHeight = path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				pruneHeight = path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				// Increment the time by a week
 				suite.coordinator.IncrementTimeBy(7 * 24 * time.Hour)
@@ -412,8 +412,8 @@ func (suite *TendermintTestSuite) TestUpdateState() {
 				suite.Require().True(ok)
 
 				clientState := path.EndpointA.GetClientState()
-				suite.Require().True(clientState.GetLatestHeight().EQ(tmHeader.GetHeight())) // new update, updated client state should have changed
-				suite.Require().True(clientState.GetLatestHeight().EQ(consensusHeights[0]))
+				suite.Require().True(clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).EQ(tmHeader.GetHeight())) // new update, updated client state should have changed
+				suite.Require().True(clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).EQ(consensusHeights[0]))
 
 				// ensure consensus state was pruned
 				_, found := path.EndpointA.Chain.GetConsensusState(path.EndpointA.ClientID, pruneHeight)
@@ -425,7 +425,7 @@ func (suite *TendermintTestSuite) TestUpdateState() {
 				// this height will be expired and pruned
 				err := path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
-				pruneHeight = path.EndpointA.GetClientState().GetLatestHeight().(clienttypes.Height)
+				pruneHeight = path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				// assert that a consensus state exists at the prune height
 				consensusState, found := path.EndpointA.Chain.GetConsensusState(path.EndpointA.ClientID, pruneHeight)
@@ -454,8 +454,8 @@ func (suite *TendermintTestSuite) TestUpdateState() {
 				suite.Require().True(ok)
 
 				clientState := path.EndpointA.GetClientState()
-				suite.Require().True(clientState.GetLatestHeight().EQ(tmHeader.GetHeight())) // new update, updated client state should have changed
-				suite.Require().True(clientState.GetLatestHeight().EQ(consensusHeights[0]))
+				suite.Require().True(clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).EQ(tmHeader.GetHeight())) // new update, updated client state should have changed
+				suite.Require().True(clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).EQ(consensusHeights[0]))
 
 				// ensure consensus state was pruned
 				_, found := path.EndpointA.Chain.GetConsensusState(path.EndpointA.ClientID, pruneHeight)
@@ -535,7 +535,7 @@ func (suite *TendermintTestSuite) TestPruneConsensusState() {
 	// this height will be expired but not pruned
 	err := path.EndpointA.UpdateClient()
 	suite.Require().NoError(err)
-	expiredHeight := path.EndpointA.GetClientState().GetLatestHeight()
+	expiredHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc)
 
 	// expected values that must still remain in store after pruning
 	expectedConsState, ok := path.EndpointA.Chain.GetConsensusState(path.EndpointA.ClientID, expiredHeight)

--- a/modules/light-clients/07-tendermint/update_test.go
+++ b/modules/light-clients/07-tendermint/update_test.go
@@ -17,9 +17,8 @@ import (
 
 func (suite *TendermintTestSuite) TestVerifyHeader() {
 	var (
-		clientStore sdk.KVStore
-		path        *ibctesting.Path
-		header      *ibctm.Header
+		path   *ibctesting.Path
+		header *ibctm.Header
 	)
 
 	// Setup different validators and signers for testing different types of updates
@@ -48,6 +47,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "successful verify header for header with a previous height",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
@@ -67,6 +67,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "successful verify header: header with future height and different validator set",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
@@ -84,6 +85,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "successful verify header: header with next height and different validator set",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
@@ -101,6 +103,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful updates, passed in incorrect trusted validators for given consensus state",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				// Create bothValSet with both suite validator and altVal
@@ -115,6 +118,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful verify header with next height: update header mismatches nextValSetHash",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
@@ -128,6 +132,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful update with future height: too much change in validator set",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
@@ -140,6 +145,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful verify header: header height revision and trusted height revision mismatch",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
 				suite.Require().True(found)
@@ -151,6 +157,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful verify header: header height < consensus height",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
@@ -174,6 +181,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful verify header: header timestamp is not past last client timestamp",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight))
@@ -186,6 +194,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful verify header: header with incorrect header chain-id",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight))
@@ -198,6 +207,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful update: trusting period has passed since last client timestamp",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight))
@@ -212,6 +222,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful update for a previous revision",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
@@ -229,6 +240,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "successful update with identical header to a previous update",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
@@ -247,6 +259,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful update to a future revision",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
@@ -260,6 +273,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		{
 			name: "unsuccessful update: header height revision and trusted height revision mismatch",
 			malleate: func() {
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				trustedHeight := path.EndpointA.GetClientState().GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).(clienttypes.Height)
 
 				trustedVals, found := suite.chainB.GetValsAtHeight(int64(trustedHeight.RevisionHeight) + 1)
@@ -288,10 +302,10 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		header, err = path.EndpointA.Chain.ConstructUpdateTMClientHeader(path.EndpointA.Counterparty.Chain, path.EndpointA.ClientID)
 		suite.Require().NoError(err)
 
-		clientState := path.EndpointA.GetClientState()
-		clientStore = suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
-
 		tc.malleate()
+
+		clientState := path.EndpointA.GetClientState()
+		clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 
 		err = clientState.VerifyClientMessage(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), clientStore, header)
 

--- a/modules/light-clients/07-tendermint/update_test.go
+++ b/modules/light-clients/07-tendermint/update_test.go
@@ -298,7 +298,7 @@ func (suite *TendermintTestSuite) TestVerifyHeader() {
 		if tc.expPass {
 			suite.Require().NoError(err, tc.name)
 		} else {
-			suite.Require().Error(err)
+			suite.Require().Error(err, tc.name)
 		}
 	}
 }

--- a/modules/light-clients/07-tendermint/upgrade.go
+++ b/modules/light-clients/07-tendermint/upgrade.go
@@ -34,11 +34,11 @@ func (cs ClientState) VerifyUpgradeAndUpdateState(
 	}
 
 	// last height of current counterparty chain must be client's latest height
-	lastHeight := cs.GetLatestHeight()
+	lastHeight := cs.GetLatestHeight(ctx, clientStore, cdc)
 
-	if !upgradedClient.GetLatestHeight().GT(lastHeight) {
+	if !upgradedClient.GetLatestHeight(ctx, clientStore, cdc).GT(lastHeight) {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidHeight, "upgraded client height %s must be at greater than current client height %s",
-			upgradedClient.GetLatestHeight(), lastHeight)
+			upgradedClient.GetLatestHeight(ctx, clientStore, cdc), lastHeight)
 	}
 
 	// upgraded client state and consensus state must be IBC tendermint client state and consensus state

--- a/modules/light-clients/07-tendermint/upgrade_test.go
+++ b/modules/light-clients/07-tendermint/upgrade_test.go
@@ -1,6 +1,7 @@
 package tendermint_test
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
@@ -13,6 +14,7 @@ import (
 func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 	var (
 		newChainID                                  string
+		clientStore                                 sdk.KVStore
 		upgradedClient                              exported.ClientState
 		upgradedConsState                           exported.ConsensusState
 		lastHeight                                  clienttypes.Height
@@ -46,15 +48,15 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: true,
 		},
 		{
 			name: "successful upgrade to same revision",
 			setup: func() {
-				upgradedClient = ibctm.NewClientState(suite.chainB.ChainID, ibctm.DefaultTrustLevel, trustingPeriod, ubdPeriod+trustingPeriod, maxClockDrift, clienttypes.NewHeight(clienttypes.ParseChainID(suite.chainB.ChainID), upgradedClient.GetLatestHeight().GetRevisionHeight()+10), commitmenttypes.GetSDKSpecs(), upgradePath)
+				upgradedClient = ibctm.NewClientState(suite.chainB.ChainID, ibctm.DefaultTrustLevel, trustingPeriod, ubdPeriod+trustingPeriod, maxClockDrift, clienttypes.NewHeight(clienttypes.ParseChainID(suite.chainB.ChainID), upgradedClient.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight()+10), commitmenttypes.GetSDKSpecs(), upgradePath)
 				upgradedClient = upgradedClient.ZeroCustomFields()
 				upgradedClientBz, err = clienttypes.MarshalClientState(suite.chainA.App.AppCodec(), upgradedClient)
 				suite.Require().NoError(err)
@@ -75,8 +77,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: true,
 		},
@@ -100,8 +102,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -129,8 +131,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -154,8 +156,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -176,8 +178,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -205,8 +207,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -218,7 +220,7 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 
 				proofUpgradedClient = []byte("proof")
 			},
@@ -232,7 +234,7 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 
 				proofUpgradedConsState = []byte("proof")
 			},
@@ -251,8 +253,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -269,8 +271,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -292,8 +294,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 
 				// SetClientState with empty upgrade path
 				tmClient, _ := cs.(*ibctm.ClientState)
@@ -320,8 +322,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -343,8 +345,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -366,8 +368,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -389,8 +391,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -418,8 +420,8 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 				suite.Require().True(found)
 
-				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
-				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight().GetRevisionHeight())
+				proofUpgradedClient, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
+				proofUpgradedConsState, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), cs.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight())
 			},
 			expPass: false,
 		},
@@ -441,7 +443,7 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 		newChainID, err = clienttypes.SetRevisionNumber(clientState.ChainId, revisionNumber+1)
 		suite.Require().NoError(err)
 
-		upgradedClient = ibctm.NewClientState(newChainID, ibctm.DefaultTrustLevel, trustingPeriod, ubdPeriod+trustingPeriod, maxClockDrift, clienttypes.NewHeight(revisionNumber+1, clientState.GetLatestHeight().GetRevisionHeight()+1), commitmenttypes.GetSDKSpecs(), upgradePath)
+		upgradedClient = ibctm.NewClientState(newChainID, ibctm.DefaultTrustLevel, trustingPeriod, ubdPeriod+trustingPeriod, maxClockDrift, clienttypes.NewHeight(revisionNumber+1, clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc).GetRevisionHeight()+1), commitmenttypes.GetSDKSpecs(), upgradePath)
 		upgradedClient = upgradedClient.ZeroCustomFields()
 		upgradedClientBz, err = clienttypes.MarshalClientState(suite.chainA.App.AppCodec(), upgradedClient)
 		suite.Require().NoError(err)
@@ -452,10 +454,11 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 		upgradedConsStateBz, err = clienttypes.MarshalConsensusState(suite.chainA.App.AppCodec(), upgradedConsState)
 		suite.Require().NoError(err)
 
+		clientStore = suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
+
 		tc.setup()
 
 		cs := suite.chainA.GetClientState(path.EndpointA.ClientID)
-		clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), path.EndpointA.ClientID)
 
 		// Call ZeroCustomFields on upgraded clients to clear any client-chosen parameters in test-case upgradedClient
 		upgradedClient = upgradedClient.ZeroCustomFields()
@@ -476,7 +479,7 @@ func (suite *TendermintTestSuite) TestVerifyUpgrade() {
 			clientState := suite.chainA.GetClientState(path.EndpointA.ClientID)
 			suite.Require().NotNil(clientState, "verify upgrade failed on valid case: %s", tc.name)
 
-			consensusState, found := suite.chainA.GetConsensusState(path.EndpointA.ClientID, clientState.GetLatestHeight())
+			consensusState, found := suite.chainA.GetConsensusState(path.EndpointA.ClientID, clientState.GetLatestHeight(suite.chainA.GetContext(), clientStore, suite.cdc))
 			suite.Require().NotNil(consensusState, "verify upgrade failed on valid case: %s", tc.name)
 			suite.Require().True(found)
 		} else {

--- a/testing/chain.go
+++ b/testing/chain.go
@@ -260,8 +260,9 @@ func (chain *TestChain) QueryUpgradeProof(key []byte, height uint64) ([]byte, cl
 // stored on the given clientID. The proof and consensusHeight are returned.
 func (chain *TestChain) QueryConsensusStateProof(clientID string) ([]byte, clienttypes.Height) {
 	clientState := chain.GetClientState(clientID)
+	clientStore := chain.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(chain.GetContext(), clientID)
 
-	consensusHeight := clientState.GetLatestHeight().(clienttypes.Height)
+	consensusHeight := clientState.GetLatestHeight(chain.GetContext(), clientStore, chain.Codec).(clienttypes.Height)
 	consensusKey := host.FullConsensusStateKey(clientID, consensusHeight)
 	proofConsensus, _ := chain.QueryProof(consensusKey)
 
@@ -404,7 +405,9 @@ func (chain *TestChain) ConstructUpdateTMClientHeaderWithTrustedHeight(counterpa
 	header := counterparty.LastHeader
 	// Relayer must query for LatestHeight on client to get TrustedHeight if the trusted height is not set
 	if trustedHeight.IsZero() {
-		trustedHeight = chain.GetClientState(clientID).GetLatestHeight().(clienttypes.Height)
+		clientState := chain.GetClientState(clientID)
+		clientStore := chain.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(chain.GetContext(), clientID)
+		trustedHeight = clientState.GetLatestHeight(chain.GetContext(), clientStore, chain.Codec).(clienttypes.Height)
 	}
 	var (
 		tmTrustedVals *tmtypes.ValidatorSet

--- a/testing/solomachine.go
+++ b/testing/solomachine.go
@@ -281,6 +281,7 @@ func (solo *Solomachine) ConnOpenAck(chain *TestChain, clientID, connectionID st
 	proofTry := solo.GenerateConnOpenTryProof(clientID, connectionID)
 
 	clientState := ibctm.NewClientState(chain.ChainID, DefaultTrustLevel, TrustingPeriod, UnbondingPeriod, MaxClockDrift, chain.LastHeader.GetHeight().(clienttypes.Height), commitmenttypes.GetSDKSpecs(), UpgradePath)
+	clientStore := chain.GetSimApp().GetIBCKeeper().ClientKeeper.ClientStore(chain.GetContext(), clientID)
 	proofClient := solo.GenerateClientStateProof(clientState)
 
 	consensusState := chain.LastHeader.ConsensusState()
@@ -290,7 +291,7 @@ func (solo *Solomachine) ConnOpenAck(chain *TestChain, clientID, connectionID st
 	msgConnOpenAck := connectiontypes.NewMsgConnectionOpenAck(
 		connectionID, connectionIDSolomachine, clientState,
 		proofTry, proofClient, proofConsensus,
-		clienttypes.ZeroHeight(), clientState.GetLatestHeight().(clienttypes.Height),
+		clienttypes.ZeroHeight(), clientState.GetLatestHeight(chain.GetContext(), clientStore, chain.Codec).(clienttypes.Height),
 		ConnectionVersion,
 		chain.SenderAccount.GetAddress().String(),
 	)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR is a work-in-progress. Looks like `GetLatestHeight` is used extensively throughout the codebase in test code.

closes: #XXXX


### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
