### PR TITLE
Add scripts to run linting on only modified files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,9 @@ lint:
 
 lint-fix:
 	golangci-lint run --fix --out-format=tab --issues-exit-code=0
-.PHONY: lint lint-fix
+
+lint-fix-changed:
+	./scripts/linting/lint-changed-go-files.sh
 
 format:
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./docs/client/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' -not -name '*.pb.gw.go' | xargs gofumpt -w
@@ -304,6 +306,11 @@ format:
 
 docs-lint:
 	markdownlint . --fix
+
+docs-lint-changed:
+	./scripts/linting/lint-changed-md-files.sh
+
+.PHONY: lint lint-fix lint-fix-changed docs-lint docs-lint-changed
 
 ###############################################################################
 ###                                Protobuf                                 ###

--- a/scripts/linting/lint-changed-go-files.sh
+++ b/scripts/linting/lint-changed-go-files.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# lint_modified_go_files runs the linter only if changes have been made to any go files.
+function lint_modified_go_files() {
+  local go_files="$(git diff --name-only | grep \.go$)"
+  for f in $go_files; do
+    golangci-lint run "${f}" --fix --out-format=tab --issues-exit-code=0
+  done
+}
+
+lint_modified_go_files

--- a/scripts/linting/lint-changed-md-files.sh
+++ b/scripts/linting/lint-changed-md-files.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# lint_modified_markdown_files runs the linter only if changes have been made to any md files.
+function lint_modified_markdown_files() {
+  local markdown_files="$(git diff --name-only | grep \.md$)"
+  for f in $markdown_files; do
+    markdownlint "${f}" --fix
+  done
+}
+
+lint_modified_markdown_files


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

I found running the existing `make lint-fix` and `make docs-lint` take some time to run as they are currently formatting all files in the repo. This PR adds an additional command which formats only the relevant files changed.


closes: N/A


### Commit Message / Changelog Entry

N/A

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
