### PR TITLE
chore: use sentinel proofs for localhost channels

### DIFF
--- a/e2e/tests/interchain_accounts/localhost_test.go
+++ b/e2e/tests/interchain_accounts/localhost_test.go
@@ -13,6 +13,7 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	connectiontypes "github.com/cosmos/ibc-go/v7/modules/core/03-connection/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	localhost "github.com/cosmos/ibc-go/v7/modules/light-clients/09-localhost"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"
 	"github.com/stretchr/testify/suite"
 
@@ -72,7 +73,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_Localhost(
 			icatypes.HostPortID, icatypes.Version,
 			channeltypes.ORDERED, []string{connectiontypes.LocalhostID},
 			controllerPortID, msgChanOpenInitRes.GetChannelId(),
-			version, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			version, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenTry)
@@ -86,7 +87,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_Localhost(
 		msgChanOpenAck := channeltypes.NewMsgChannelOpenAck(
 			controllerPortID, msgChanOpenInitRes.GetChannelId(),
 			msgChanOpenTryRes.GetChannelId(), msgChanOpenTryRes.GetVersion(),
-			nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenAck)
@@ -97,7 +98,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_Localhost(
 	t.Run("channel open confirm localhost", func(t *testing.T) {
 		msgChanOpenConfirm := channeltypes.NewMsgChannelOpenConfirm(
 			icatypes.HostPortID, msgChanOpenTryRes.GetChannelId(),
-			nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenConfirm)
@@ -165,7 +166,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_Localhost(
 	})
 
 	t.Run("recv packet localhost interchain accounts", func(t *testing.T) {
-		msgRecvPacket := channeltypes.NewMsgRecvPacket(packet, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
+		msgRecvPacket := channeltypes.NewMsgRecvPacket(packet, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgRecvPacket)
 		s.Require().NoError(err)
@@ -178,7 +179,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_Localhost(
 	})
 
 	t.Run("acknowledge packet localhost interchain accounts", func(t *testing.T) {
-		msgAcknowledgement := channeltypes.NewMsgAcknowledgement(packet, ack, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
+		msgAcknowledgement := channeltypes.NewMsgAcknowledgement(packet, ack, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgAcknowledgement)
 		s.Require().NoError(err)
@@ -236,7 +237,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 			icatypes.HostPortID, icatypes.Version,
 			channeltypes.ORDERED, []string{connectiontypes.LocalhostID},
 			controllerPortID, msgChanOpenInitRes.GetChannelId(),
-			version, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			version, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenTry)
@@ -250,7 +251,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 		msgChanOpenAck := channeltypes.NewMsgChannelOpenAck(
 			controllerPortID, msgChanOpenInitRes.GetChannelId(),
 			msgChanOpenTryRes.GetChannelId(), msgChanOpenTryRes.GetVersion(),
-			nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenAck)
@@ -261,7 +262,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 	t.Run("channel open confirm localhost", func(t *testing.T) {
 		msgChanOpenConfirm := channeltypes.NewMsgChannelOpenConfirm(
 			icatypes.HostPortID, msgChanOpenTryRes.GetChannelId(),
-			nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenConfirm)
@@ -329,7 +330,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 	})
 
 	t.Run("timeout localhost interchain accounts packet", func(t *testing.T) {
-		msgTimeout := channeltypes.NewMsgTimeout(packet, 1, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
+		msgTimeout := channeltypes.NewMsgTimeout(packet, 1, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgTimeout)
 		s.Require().NoError(err)
@@ -337,7 +338,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 	})
 
 	t.Run("close interchain accounts host channel end", func(t *testing.T) {
-		msgCloseConfirm := channeltypes.NewMsgChannelCloseConfirm(icatypes.HostPortID, msgChanOpenTryRes.ChannelId, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
+		msgCloseConfirm := channeltypes.NewMsgChannelCloseConfirm(icatypes.HostPortID, msgChanOpenTryRes.ChannelId, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgCloseConfirm)
 		s.Require().NoError(err)
@@ -372,7 +373,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 			icatypes.HostPortID, icatypes.Version,
 			channeltypes.ORDERED, []string{connectiontypes.LocalhostID},
 			controllerPortID, msgChanOpenInitRes.GetChannelId(),
-			version, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			version, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenTry)
@@ -387,7 +388,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 		msgChanOpenAck := channeltypes.NewMsgChannelOpenAck(
 			controllerPortID, msgChanOpenInitRes.GetChannelId(),
 			msgChanOpenTryRes.GetChannelId(), msgChanOpenTryRes.GetVersion(),
-			nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenAck)
@@ -398,7 +399,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 	t.Run("channel open confirm localhost", func(t *testing.T) {
 		msgChanOpenConfirm := channeltypes.NewMsgChannelOpenConfirm(
 			icatypes.HostPortID, msgChanOpenTryRes.GetChannelId(),
-			nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenConfirm)
@@ -464,7 +465,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 	})
 
 	t.Run("recv packet localhost interchain accounts", func(t *testing.T) {
-		msgRecvPacket := channeltypes.NewMsgRecvPacket(packet, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
+		msgRecvPacket := channeltypes.NewMsgRecvPacket(packet, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgRecvPacket)
 		s.Require().NoError(err)
@@ -477,7 +478,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 	})
 
 	t.Run("acknowledge packet localhost interchain accounts", func(t *testing.T) {
-		msgAcknowledgement := channeltypes.NewMsgAcknowledgement(packet, ack, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
+		msgAcknowledgement := channeltypes.NewMsgAcknowledgement(packet, ack, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgAcknowledgement)
 		s.Require().NoError(err)

--- a/e2e/tests/transfer/localhost_test.go
+++ b/e2e/tests/transfer/localhost_test.go
@@ -10,6 +10,7 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	connectiontypes "github.com/cosmos/ibc-go/v7/modules/core/03-connection/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	localhost "github.com/cosmos/ibc-go/v7/modules/light-clients/09-localhost"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"
 	test "github.com/strangelove-ventures/interchaintest/v7/testutil"
 
@@ -71,7 +72,7 @@ func (s *LocalhostTransferTestSuite) TestMsgTransfer_Localhost() {
 			transfertypes.PortID, transfertypes.Version,
 			channeltypes.UNORDERED, []string{connectiontypes.LocalhostID},
 			transfertypes.PortID, msgChanOpenInitRes.GetChannelId(),
-			transfertypes.Version, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			transfertypes.Version, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenTry)
@@ -85,7 +86,7 @@ func (s *LocalhostTransferTestSuite) TestMsgTransfer_Localhost() {
 		msgChanOpenAck := channeltypes.NewMsgChannelOpenAck(
 			transfertypes.PortID, msgChanOpenInitRes.GetChannelId(),
 			msgChanOpenTryRes.GetChannelId(), transfertypes.Version,
-			nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenAck)
@@ -96,7 +97,7 @@ func (s *LocalhostTransferTestSuite) TestMsgTransfer_Localhost() {
 	t.Run("channel open confirm localhost", func(t *testing.T) {
 		msgChanOpenConfirm := channeltypes.NewMsgChannelOpenConfirm(
 			transfertypes.PortID, msgChanOpenTryRes.GetChannelId(),
-			nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
+			localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress(),
 		)
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgChanOpenConfirm)
@@ -136,7 +137,7 @@ func (s *LocalhostTransferTestSuite) TestMsgTransfer_Localhost() {
 	})
 
 	t.Run("recv packet localhost ibc transfer", func(t *testing.T) {
-		msgRecvPacket := channeltypes.NewMsgRecvPacket(packet, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
+		msgRecvPacket := channeltypes.NewMsgRecvPacket(packet, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgRecvPacket)
 		s.Require().NoError(err)
@@ -149,7 +150,7 @@ func (s *LocalhostTransferTestSuite) TestMsgTransfer_Localhost() {
 	})
 
 	t.Run("acknowledge packet localhost ibc transfer", func(t *testing.T) {
-		msgAcknowledgement := channeltypes.NewMsgAcknowledgement(packet, ack, nil, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
+		msgAcknowledgement := channeltypes.NewMsgAcknowledgement(packet, ack, localhost.SentinelProof, clienttypes.ZeroHeight(), rlyWallet.FormattedAddress())
 
 		txResp, err := s.BroadcastMessages(ctx, chainA, rlyWallet, msgAcknowledgement)
 		s.Require().NoError(err)

--- a/modules/core/04-channel/types/msgs.go
+++ b/modules/core/04-channel/types/msgs.go
@@ -7,6 +7,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	commitmenttypes "github.com/cosmos/ibc-go/v7/modules/core/23-commitment/types"
 	host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
 )
 
@@ -91,6 +92,9 @@ func (msg MsgChannelOpenTry) ValidateBasic() error {
 	if msg.PreviousChannelId != "" {
 		return sdkerrors.Wrap(ErrInvalidChannelIdentifier, "previous channel identifier must be empty, this field has been deprecated as crossing hellos are no longer supported")
 	}
+	if len(msg.ProofInit) == 0 {
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof init")
+	}
 	if msg.Channel.State != TRYOPEN {
 		return sdkerrors.Wrapf(ErrInvalidChannelState,
 			"channel state must be TRYOPEN in MsgChannelOpenTry. expected: %s, got: %s",
@@ -149,6 +153,9 @@ func (msg MsgChannelOpenAck) ValidateBasic() error {
 	if err := host.ChannelIdentifierValidator(msg.CounterpartyChannelId); err != nil {
 		return sdkerrors.Wrap(err, "invalid counterparty channel ID")
 	}
+	if len(msg.ProofTry) == 0 {
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof try")
+	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
@@ -190,6 +197,9 @@ func (msg MsgChannelOpenConfirm) ValidateBasic() error {
 	}
 	if !IsValidChannelID(msg.ChannelId) {
 		return ErrInvalidChannelIdentifier
+	}
+	if len(msg.ProofAck) == 0 {
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof ack")
 	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
@@ -272,6 +282,9 @@ func (msg MsgChannelCloseConfirm) ValidateBasic() error {
 	if !IsValidChannelID(msg.ChannelId) {
 		return ErrInvalidChannelIdentifier
 	}
+	if len(msg.ProofInit) == 0 {
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof init")
+	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
@@ -307,6 +320,9 @@ func NewMsgRecvPacket(
 
 // ValidateBasic implements sdk.Msg
 func (msg MsgRecvPacket) ValidateBasic() error {
+	if len(msg.ProofCommitment) == 0 {
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
+	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
@@ -350,6 +366,9 @@ func NewMsgTimeout(
 
 // ValidateBasic implements sdk.Msg
 func (msg MsgTimeout) ValidateBasic() error {
+	if len(msg.ProofUnreceived) == 0 {
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty unreceived proof")
+	}
 	if msg.NextSequenceRecv == 0 {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidSequence, "next sequence receive cannot be 0")
 	}
@@ -392,6 +411,12 @@ func (msg MsgTimeoutOnClose) ValidateBasic() error {
 	if msg.NextSequenceRecv == 0 {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidSequence, "next sequence receive cannot be 0")
 	}
+	if len(msg.ProofUnreceived) == 0 {
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
+	}
+	if len(msg.ProofClose) == 0 {
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof of closed counterparty channel end")
+	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
@@ -430,6 +455,9 @@ func NewMsgAcknowledgement(
 
 // ValidateBasic implements sdk.Msg
 func (msg MsgAcknowledgement) ValidateBasic() error {
+	if len(msg.ProofAcked) == 0 {
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
+	}
 	if len(msg.Acknowledgement) == 0 {
 		return sdkerrors.Wrap(ErrInvalidAcknowledgement, "ack bytes cannot be empty")
 	}

--- a/modules/core/04-channel/types/msgs.go
+++ b/modules/core/04-channel/types/msgs.go
@@ -93,7 +93,7 @@ func (msg MsgChannelOpenTry) ValidateBasic() error {
 		return sdkerrors.Wrap(ErrInvalidChannelIdentifier, "previous channel identifier must be empty, this field has been deprecated as crossing hellos are no longer supported")
 	}
 	if len(msg.ProofInit) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof init")
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty init proof")
 	}
 	if msg.Channel.State != TRYOPEN {
 		return sdkerrors.Wrapf(ErrInvalidChannelState,
@@ -154,7 +154,7 @@ func (msg MsgChannelOpenAck) ValidateBasic() error {
 		return sdkerrors.Wrap(err, "invalid counterparty channel ID")
 	}
 	if len(msg.ProofTry) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof try")
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty try proof")
 	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
@@ -199,7 +199,7 @@ func (msg MsgChannelOpenConfirm) ValidateBasic() error {
 		return ErrInvalidChannelIdentifier
 	}
 	if len(msg.ProofAck) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof ack")
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty acknowledgement proof")
 	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
@@ -283,7 +283,7 @@ func (msg MsgChannelCloseConfirm) ValidateBasic() error {
 		return ErrInvalidChannelIdentifier
 	}
 	if len(msg.ProofInit) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof init")
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty init proof")
 	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
@@ -321,7 +321,7 @@ func NewMsgRecvPacket(
 // ValidateBasic implements sdk.Msg
 func (msg MsgRecvPacket) ValidateBasic() error {
 	if len(msg.ProofCommitment) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty commitment proof")
 	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
@@ -412,7 +412,7 @@ func (msg MsgTimeoutOnClose) ValidateBasic() error {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidSequence, "next sequence receive cannot be 0")
 	}
 	if len(msg.ProofUnreceived) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty unreceived proof")
 	}
 	if len(msg.ProofClose) == 0 {
 		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof of closed counterparty channel end")
@@ -456,7 +456,7 @@ func NewMsgAcknowledgement(
 // ValidateBasic implements sdk.Msg
 func (msg MsgAcknowledgement) ValidateBasic() error {
 	if len(msg.ProofAcked) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
+		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty acknowledgement proof")
 	}
 	if len(msg.Acknowledgement) == 0 {
 		return sdkerrors.Wrap(ErrInvalidAcknowledgement, "ack bytes cannot be empty")

--- a/modules/core/04-channel/types/msgs_test.go
+++ b/modules/core/04-channel/types/msgs_test.go
@@ -55,6 +55,8 @@ var (
 	packet        = types.NewPacket(validPacketData, 1, portid, chanid, cpportid, cpchanid, timeoutHeight, timeoutTimestamp)
 	invalidPacket = types.NewPacket(unknownPacketData, 0, portid, chanid, cpportid, cpchanid, timeoutHeight, timeoutTimestamp)
 
+	emptyProof = []byte{}
+
 	addr      = sdk.AccAddress("testaddr111111111111").String()
 	emptyAddr string
 
@@ -162,6 +164,7 @@ func (suite *TypesTestSuite) TestMsgChannelOpenTryValidateBasic() {
 		{"", types.NewMsgChannelOpenTry(portid, "", types.UNORDERED, connHops, cpportid, cpchanid, version, suite.proof, height, addr), true},
 		{"invalid counterparty port id", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, connHops, invalidPort, cpchanid, version, suite.proof, height, addr), false},
 		{"invalid counterparty channel id", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, connHops, cpportid, invalidChannel, version, suite.proof, height, addr), false},
+		{"empty proof", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, connHops, cpportid, cpchanid, version, emptyProof, height, addr), false},
 		{"channel not in TRYOPEN state", &types.MsgChannelOpenTry{portid, "", initChannel, version, suite.proof, height, addr}, false},
 		{"previous channel id is not empty", &types.MsgChannelOpenTry{portid, chanid, initChannel, version, suite.proof, height, addr}, false},
 	}
@@ -195,6 +198,7 @@ func (suite *TypesTestSuite) TestMsgChannelOpenAckValidateBasic() {
 		{"too long channel id", types.NewMsgChannelOpenAck(portid, invalidLongChannel, chanid, version, suite.proof, height, addr), false},
 		{"channel id contains non-alpha", types.NewMsgChannelOpenAck(portid, invalidChannel, chanid, version, suite.proof, height, addr), false},
 		{"", types.NewMsgChannelOpenAck(portid, chanid, chanid, "", suite.proof, height, addr), true},
+		{"empty proof", types.NewMsgChannelOpenAck(portid, chanid, chanid, version, emptyProof, height, addr), false},
 		{"invalid counterparty channel id", types.NewMsgChannelOpenAck(portid, chanid, invalidShortChannel, version, suite.proof, height, addr), false},
 	}
 
@@ -226,6 +230,7 @@ func (suite *TypesTestSuite) TestMsgChannelOpenConfirmValidateBasic() {
 		{"too short channel id", types.NewMsgChannelOpenConfirm(portid, invalidShortChannel, suite.proof, height, addr), false},
 		{"too long channel id", types.NewMsgChannelOpenConfirm(portid, invalidLongChannel, suite.proof, height, addr), false},
 		{"channel id contains non-alpha", types.NewMsgChannelOpenConfirm(portid, invalidChannel, suite.proof, height, addr), false},
+		{"empty proof", types.NewMsgChannelOpenConfirm(portid, chanid, emptyProof, height, addr), false},
 	}
 
 	for _, tc := range testCases {
@@ -286,6 +291,7 @@ func (suite *TypesTestSuite) TestMsgChannelCloseConfirmValidateBasic() {
 		{"too short channel id", types.NewMsgChannelCloseConfirm(portid, invalidShortChannel, suite.proof, height, addr), false},
 		{"too long channel id", types.NewMsgChannelCloseConfirm(portid, invalidLongChannel, suite.proof, height, addr), false},
 		{"channel id contains non-alpha", types.NewMsgChannelCloseConfirm(portid, invalidChannel, suite.proof, height, addr), false},
+		{"empty proof", types.NewMsgChannelCloseConfirm(portid, chanid, emptyProof, height, addr), false},
 	}
 
 	for _, tc := range testCases {
@@ -311,6 +317,7 @@ func (suite *TypesTestSuite) TestMsgRecvPacketValidateBasic() {
 	}{
 		{"success", types.NewMsgRecvPacket(packet, suite.proof, height, addr), true},
 		{"missing signer address", types.NewMsgRecvPacket(packet, suite.proof, height, emptyAddr), false},
+		{"proof contain empty proof", types.NewMsgRecvPacket(packet, emptyProof, height, addr), false},
 		{"invalid packet", types.NewMsgRecvPacket(invalidPacket, suite.proof, height, addr), false},
 	}
 
@@ -346,6 +353,7 @@ func (suite *TypesTestSuite) TestMsgTimeoutValidateBasic() {
 		{"success", types.NewMsgTimeout(packet, 1, suite.proof, height, addr), true},
 		{"seq 0", types.NewMsgTimeout(packet, 0, suite.proof, height, addr), false},
 		{"missing signer address", types.NewMsgTimeout(packet, 1, suite.proof, height, emptyAddr), false},
+		{"cannot submit an empty proof", types.NewMsgTimeout(packet, 1, emptyProof, height, addr), false},
 		{"invalid packet", types.NewMsgTimeout(invalidPacket, 1, suite.proof, height, addr), false},
 	}
 
@@ -373,6 +381,8 @@ func (suite *TypesTestSuite) TestMsgTimeoutOnCloseValidateBasic() {
 		{"success", types.NewMsgTimeoutOnClose(packet, 1, suite.proof, suite.proof, height, addr), true},
 		{"seq 0", types.NewMsgTimeoutOnClose(packet, 0, suite.proof, suite.proof, height, addr), false},
 		{"signer address is empty", types.NewMsgTimeoutOnClose(packet, 1, suite.proof, suite.proof, height, emptyAddr), false},
+		{"empty proof", types.NewMsgTimeoutOnClose(packet, 1, emptyProof, suite.proof, height, addr), false},
+		{"empty proof close", types.NewMsgTimeoutOnClose(packet, 1, suite.proof, emptyProof, height, addr), false},
 		{"invalid packet", types.NewMsgTimeoutOnClose(invalidPacket, 1, suite.proof, suite.proof, height, addr), false},
 	}
 
@@ -400,6 +410,7 @@ func (suite *TypesTestSuite) TestMsgAcknowledgementValidateBasic() {
 		{"success", types.NewMsgAcknowledgement(packet, packet.GetData(), suite.proof, height, addr), true},
 		{"empty ack", types.NewMsgAcknowledgement(packet, nil, suite.proof, height, addr), false},
 		{"missing signer address", types.NewMsgAcknowledgement(packet, packet.GetData(), suite.proof, height, emptyAddr), false},
+		{"cannot submit an empty proof", types.NewMsgAcknowledgement(packet, packet.GetData(), emptyProof, height, addr), false},
 		{"invalid packet", types.NewMsgAcknowledgement(invalidPacket, packet.GetData(), suite.proof, height, addr), false},
 	}
 

--- a/modules/light-clients/09-localhost/client_state.go
+++ b/modules/light-clients/09-localhost/client_state.go
@@ -84,6 +84,10 @@ func (cs ClientState) VerifyMembership(
 	path exported.Path,
 	value []byte,
 ) error {
+	if !bytes.Equal(proof, SentinelProof) {
+		return sdkerrors.Wrapf(commitmenttypes.ErrInvalidProof, "expected %s, got %s", string(SentinelProof), string(proof))
+	}
+
 	merklePath, ok := path.(commitmenttypes.MerklePath)
 	if !ok {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "expected %T, got %T", commitmenttypes.MerklePath{}, path)
@@ -118,6 +122,10 @@ func (cs ClientState) VerifyNonMembership(
 	proof []byte,
 	path exported.Path,
 ) error {
+	if !bytes.Equal(proof, SentinelProof) {
+		return sdkerrors.Wrapf(commitmenttypes.ErrInvalidProof, "expected %s, got %s", string(SentinelProof), string(proof))
+	}
+
 	merklePath, ok := path.(commitmenttypes.MerklePath)
 	if !ok {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "expected %T, got %T", commitmenttypes.MerklePath{}, path)

--- a/modules/light-clients/09-localhost/client_state.go
+++ b/modules/light-clients/09-localhost/client_state.go
@@ -86,6 +86,7 @@ func (cs ClientState) VerifyMembership(
 	path exported.Path,
 	value []byte,
 ) error {
+	// ensure the proof provided is the expected sentintel localhost client proof
 	if !bytes.Equal(proof, SentinelProof) {
 		return sdkerrors.Wrapf(commitmenttypes.ErrInvalidProof, "expected %s, got %s", string(SentinelProof), string(proof))
 	}
@@ -125,6 +126,7 @@ func (cs ClientState) VerifyNonMembership(
 	proof []byte,
 	path exported.Path,
 ) error {
+	// ensure the proof provided is the expected sentintel localhost client proof
 	if !bytes.Equal(proof, SentinelProof) {
 		return sdkerrors.Wrapf(commitmenttypes.ErrInvalidProof, "expected %s, got %s", string(SentinelProof), string(proof))
 	}

--- a/modules/light-clients/09-localhost/client_state_test.go
+++ b/modules/light-clients/09-localhost/client_state_test.go
@@ -299,7 +299,7 @@ func (suite *LocalhostTestSuite) TestVerifyMembership() {
 				suite.chain.Codec,
 				clienttypes.ZeroHeight(),
 				0, 0, // use zero values for delay periods
-				nil, // localhost proofs are nil
+				localhost.SentinelProof,
 				path,
 				value,
 			)
@@ -378,7 +378,7 @@ func (suite *LocalhostTestSuite) TestVerifyNonMembership() {
 				suite.chain.Codec,
 				clienttypes.ZeroHeight(),
 				0, 0, // use zero values for delay periods
-				nil, // localhost proofs are nil
+				localhost.SentinelProof,
 				path,
 			)
 

--- a/modules/light-clients/09-localhost/keys.go
+++ b/modules/light-clients/09-localhost/keys.go
@@ -6,7 +6,7 @@ const (
 )
 
 // SentinelProof defines the 09-localhost sentinel proof.
-// Core IBC disallows submission of empty or nil proofs in messaging.
+// Submission of nil or empty proofs is disallowed in core IBC messaging.
 // This serves as a placeholder value for relayers to leverage as the proof field in various message types.
 // Localhost client state verification will fail if the sentintel proof value is not provided.
-var SentinelProof = []byte("proof_localhost")
+var SentinelProof = []byte{0x01}

--- a/modules/light-clients/09-localhost/keys.go
+++ b/modules/light-clients/09-localhost/keys.go
@@ -1,0 +1,11 @@
+package localhost
+
+const (
+	// ModuleName defines the 09-localhost light client module name
+	ModuleName = "09-localhost"
+)
+
+var (
+	// SentinelProof defines the 09-localhost sentintel proof
+	SentinelProof = []byte("proof_localhost")
+)

--- a/modules/light-clients/09-localhost/keys.go
+++ b/modules/light-clients/09-localhost/keys.go
@@ -5,5 +5,5 @@ const (
 	ModuleName = "09-localhost"
 )
 
-// SentinelProof defines the 09-localhost sentintel proof
+// SentinelProof defines the 09-localhost sentinel proof
 var SentinelProof = []byte("proof_localhost")

--- a/modules/light-clients/09-localhost/keys.go
+++ b/modules/light-clients/09-localhost/keys.go
@@ -5,7 +5,5 @@ const (
 	ModuleName = "09-localhost"
 )
 
-var (
-	// SentinelProof defines the 09-localhost sentintel proof
-	SentinelProof = []byte("proof_localhost")
-)
+// SentinelProof defines the 09-localhost sentintel proof
+var SentinelProof = []byte("proof_localhost")

--- a/modules/light-clients/09-localhost/keys.go
+++ b/modules/light-clients/09-localhost/keys.go
@@ -5,5 +5,8 @@ const (
 	ModuleName = "09-localhost"
 )
 
-// SentinelProof defines the 09-localhost sentinel proof
+// SentinelProof defines the 09-localhost sentinel proof.
+// Core IBC disallows submission of empty or nil proofs in messaging.
+// This serves as a placeholder value for relayers to leverage as the proof field in various message types.
+// Localhost client state verification will fail if the sentintel proof value is not provided.
 var SentinelProof = []byte("proof_localhost")

--- a/modules/light-clients/09-localhost/module.go
+++ b/modules/light-clients/09-localhost/module.go
@@ -11,10 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	ModuleName = "09-localhost"
-)
-
 var _ module.AppModuleBasic = AppModuleBasic{}
 
 // AppModuleBasic defines the basic application module used by the localhost light client.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Creates a sentinel proof used for localhost channels. 
- Re-add validation of proof lengths in 04-channel msg validate basic methods

closes: #3194 


### Commit Message / Changelog Entry

**NA**

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
