### PR TITLE
chore: localhost godocs and nits

### DIFF
--- a/modules/light-clients/09-localhost/client_state.go
+++ b/modules/light-clients/09-localhost/client_state.go
@@ -68,12 +68,13 @@ func (cs ClientState) Initialize(ctx sdk.Context, cdc codec.BinaryCodec, clientS
 
 // GetTimestampAtHeight returns the current block time retrieved from the application context. The localhost client does not store consensus states and thus
 // cannot provide a timestamp for the provided height.
-func (cs ClientState) GetTimestampAtHeight(ctx sdk.Context, clientStore sdk.KVStore, cdc codec.BinaryCodec, height exported.Height) (uint64, error) {
+func (cs ClientState) GetTimestampAtHeight(ctx sdk.Context, _ sdk.KVStore, _ codec.BinaryCodec, _ exported.Height) (uint64, error) {
 	return uint64(ctx.BlockTime().UnixNano()), nil
 }
 
-// VerifyMembership is a generic proof verification method which verifies the existence of a given key and value within the IBC store. The caller is expected to construct the full CommitmentPath from a CommitmentPrefix 
-// and a standardized path (as defined in ICS 24). The caller must provide the full IBC store. 
+// VerifyMembership is a generic proof verification method which verifies the existence of a given key and value within the IBC store.
+// The caller is expected to construct the full CommitmentPath from a CommitmentPrefix and a standardized path (as defined in ICS 24).
+// The caller must provide the full IBC store.
 func (cs ClientState) VerifyMembership(
 	ctx sdk.Context,
 	store sdk.KVStore,
@@ -107,9 +108,9 @@ func (cs ClientState) VerifyMembership(
 	return nil
 }
 
-// VerifyNonMembership is a generic proof verification method which verifies the absence of a given CommitmentPath at a specified height.
+// VerifyNonMembership is a generic proof verification method which verifies the absence of a given CommitmentPath within the IBC store.
 // The caller is expected to construct the full CommitmentPath from a CommitmentPrefix and a standardized path (as defined in ICS 24).
-// Note the store provided to the localhost client is the full IBC core state store.
+// The caller must provide the full IBC store.
 func (cs ClientState) VerifyNonMembership(
 	ctx sdk.Context,
 	store sdk.KVStore,
@@ -138,12 +139,12 @@ func (cs ClientState) VerifyNonMembership(
 }
 
 // VerifyClientMessage is unsupported by the 09-localhost client type and returns an error.
-func (cs ClientState) VerifyClientMessage(ctx sdk.Context, cdc codec.BinaryCodec, clientStore sdk.KVStore, clientMsg exported.ClientMessage) error {
+func (cs ClientState) VerifyClientMessage(_ sdk.Context, _ codec.BinaryCodec, _ sdk.KVStore, _ exported.ClientMessage) error {
 	return sdkerrors.Wrap(clienttypes.ErrUpdateClientFailed, "client message verification is unsupported by the localhost client")
 }
 
 // CheckForMisbehaviour is unsupported by the 09-localhost client type and performs a no-op, returning false.
-func (cs ClientState) CheckForMisbehaviour(ctx sdk.Context, cdc codec.BinaryCodec, clientStore sdk.KVStore, clientMsg exported.ClientMessage) bool {
+func (cs ClientState) CheckForMisbehaviour(_ sdk.Context, _ codec.BinaryCodec, _ sdk.KVStore, _ exported.ClientMessage) bool {
 	return false
 }
 
@@ -153,7 +154,7 @@ func (cs ClientState) UpdateStateOnMisbehaviour(_ sdk.Context, _ codec.BinaryCod
 
 // UpdateState updates and stores as necessary any associated information for an IBC client, such as the ClientState and corresponding ConsensusState.
 // Upon successful update, a list of consensus heights is returned. It assumes the ClientMessage has already been verified.
-func (cs ClientState) UpdateState(ctx sdk.Context, cdc codec.BinaryCodec, clientStore sdk.KVStore, clientMsg exported.ClientMessage) []exported.Height {
+func (cs ClientState) UpdateState(ctx sdk.Context, cdc codec.BinaryCodec, clientStore sdk.KVStore, _ exported.ClientMessage) []exported.Height {
 	height := clienttypes.GetSelfHeight(ctx)
 	cs.LatestHeight = height
 
@@ -169,19 +170,19 @@ func (cs ClientState) ExportMetadata(_ sdk.KVStore) []exported.GenesisMetadata {
 
 // CheckSubstituteAndUpdateState returns an error. The localhost cannot be modified by
 // proposals.
-func (cs ClientState) CheckSubstituteAndUpdateState(ctx sdk.Context, cdc codec.BinaryCodec, subjectClientStore, substituteClientStore sdk.KVStore, substituteClient exported.ClientState) error {
+func (cs ClientState) CheckSubstituteAndUpdateState(_ sdk.Context, _ codec.BinaryCodec, _, _ sdk.KVStore, _ exported.ClientState) error {
 	return sdkerrors.Wrap(clienttypes.ErrUpdateClientFailed, "cannot update localhost client with a proposal")
 }
 
 // VerifyUpgradeAndUpdateState returns an error since localhost cannot be upgraded
 func (cs ClientState) VerifyUpgradeAndUpdateState(
-	ctx sdk.Context,
-	cdc codec.BinaryCodec,
-	store sdk.KVStore,
-	newClient exported.ClientState,
-	newConsState exported.ConsensusState,
-	proofUpgradeClient,
-	proofUpgradeConsState []byte,
+	_ sdk.Context,
+	_ codec.BinaryCodec,
+	_ sdk.KVStore,
+	_ exported.ClientState,
+	_ exported.ConsensusState,
+	_,
+	_ []byte,
 ) error {
 	return sdkerrors.Wrap(clienttypes.ErrInvalidUpgradeClient, "cannot upgrade localhost client")
 }

--- a/modules/light-clients/09-localhost/client_state.go
+++ b/modules/light-clients/09-localhost/client_state.go
@@ -72,9 +72,8 @@ func (cs ClientState) GetTimestampAtHeight(ctx sdk.Context, clientStore sdk.KVSt
 	return uint64(ctx.BlockTime().UnixNano()), nil
 }
 
-// VerifyMembership is a generic proof verification method which verifies a proof of the existence of a value at a given CommitmentPath at the specified height.
-// The caller is expected to construct the full CommitmentPath from a CommitmentPrefix and a standardized path (as defined in ICS 24).
-// Note the store provided to the localhost client is the full IBC core state store.
+// VerifyMembership is a generic proof verification method which verifies the existence of a given key and value within the IBC store. The caller is expected to construct the full CommitmentPath from a CommitmentPrefix 
+// and a standardized path (as defined in ICS 24). The caller must provide the full IBC store. 
 func (cs ClientState) VerifyMembership(
 	ctx sdk.Context,
 	store sdk.KVStore,

--- a/modules/light-clients/09-localhost/client_state.go
+++ b/modules/light-clients/09-localhost/client_state.go
@@ -66,20 +66,22 @@ func (cs ClientState) Initialize(ctx sdk.Context, cdc codec.BinaryCodec, clientS
 	return nil
 }
 
-// GetTimestampAtHeight must return the timestamp for the consensus state associated with the provided height.
+// GetTimestampAtHeight returns the current block time retrieved from the application context. The localhost client does not store consensus states and thus
+// cannot provide a timestamp for the provided height.
 func (cs ClientState) GetTimestampAtHeight(ctx sdk.Context, clientStore sdk.KVStore, cdc codec.BinaryCodec, height exported.Height) (uint64, error) {
 	return uint64(ctx.BlockTime().UnixNano()), nil
 }
 
 // VerifyMembership is a generic proof verification method which verifies a proof of the existence of a value at a given CommitmentPath at the specified height.
 // The caller is expected to construct the full CommitmentPath from a CommitmentPrefix and a standardized path (as defined in ICS 24).
+// Note the store provided to the localhost client is the full IBC core state store.
 func (cs ClientState) VerifyMembership(
 	ctx sdk.Context,
 	store sdk.KVStore,
-	cdc codec.BinaryCodec,
-	height exported.Height,
-	delayTimePeriod uint64,
-	delayBlockPeriod uint64,
+	_ codec.BinaryCodec,
+	_ exported.Height,
+	_ uint64,
+	_ uint64,
 	proof []byte,
 	path exported.Path,
 	value []byte,
@@ -108,13 +110,14 @@ func (cs ClientState) VerifyMembership(
 
 // VerifyNonMembership is a generic proof verification method which verifies the absence of a given CommitmentPath at a specified height.
 // The caller is expected to construct the full CommitmentPath from a CommitmentPrefix and a standardized path (as defined in ICS 24).
+// Note the store provided to the localhost client is the full IBC core state store.
 func (cs ClientState) VerifyNonMembership(
 	ctx sdk.Context,
 	store sdk.KVStore,
-	cdc codec.BinaryCodec,
-	height exported.Height,
-	delayTimePeriod uint64,
-	delayBlockPeriod uint64,
+	_ codec.BinaryCodec,
+	_ exported.Height,
+	_ uint64,
+	_ uint64,
 	proof []byte,
 	path exported.Path,
 ) error {
@@ -128,8 +131,7 @@ func (cs ClientState) VerifyNonMembership(
 	}
 
 	// The commitment prefix (eg: "ibc") is omitted when operating on the core IBC store
-	bz := store.Get([]byte(merklePath.KeyPath[1]))
-	if bz != nil {
+	if store.Has([]byte(merklePath.KeyPath[1])) {
 		return sdkerrors.Wrapf(clienttypes.ErrFailedNonMembershipVerification, "value found for path %s", path)
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Replace the `store.Get` usage in [verifyNonMembership](https://github.com/cosmos/ibc-go/blob/40ca344b124a87eb6238f4162caf96d280b1135a/modules/light-clients/09-localhost/client_state.go#L130-L134) with `store.Has`
- Document in [verifyMembership](https://github.com/cosmos/ibc-go/blob/40ca344b124a87eb6238f4162caf96d280b1135a/modules/light-clients/09-localhost/client_state.go#L76) and [verifyNonMembership](https://github.com/cosmos/ibc-go/blob/40ca344b124a87eb6238f4162caf96d280b1135a/modules/light-clients/09-localhost/client_state.go#L111) that the store passed is the ibc store. 
- In `verifyMembership` and  `verifyNonMembership` use `_` as variable name for unused parameters.
- In [GetTimestampAtHeight](https://github.com/cosmos/ibc-go/blob/40ca344b124a87eb6238f4162caf96d280b1135a/modules/light-clients/09-localhost/client_state.go#L69-L72) Add a comment that this function is not doing exactly the same of what it does for other client types and that it just returns the latest context timestamp.

ref: #3193 

### Commit Message / Changelog Entry

**NA**
see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
