### PR TITLE
Update make e2e test so that you only need the test name

### DIFF
--- a/.github/workflows/e2e-compatibility-workflow-call.yaml
+++ b/.github/workflows/e2e-compatibility-workflow-call.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Run e2e Test
         run: |
           cd e2e
-          make e2e-test entrypoint=${{ matrix.entrypoint }} test=${{ matrix.test }}
+          make e2e-test test=${{ matrix.test }}
         env:
           # each test has its own set of variables to specify which images are used.
           CHAIN_IMAGE: "${{ matrix.chain-image }}"

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -48,4 +48,4 @@ jobs:
       - name: Run e2e Test
         run: |
           cd e2e
-          make e2e-test entrypoint=${{ matrix.entrypoint }} test=${{ matrix.test }}
+          make e2e-test test=${{ matrix.test }}

--- a/.github/workflows/e2e-test-workflow-call.yml
+++ b/.github/workflows/e2e-test-workflow-call.yml
@@ -168,7 +168,7 @@ jobs:
         id: e2e_test
         run: |
           cd e2e
-          make e2e-test entrypoint=${{ matrix.entrypoint }} test=${{ matrix.test }}
+          make e2e-test test=${{ matrix.test }}
       - name: Upload Diagnostics
         uses: actions/upload-artifact@v3
         if: ${{ failure() && inputs.upload-logs }}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -8,7 +8,7 @@ cleanup-ibc-test-containers:
 	done
 
 e2e-test: cleanup-ibc-test-containers
-	./scripts/run-e2e.sh $(entrypoint) $(test)
+	./scripts/run-e2e.sh $(test) $(entrypoint)
 
 compatibility-tests:
 	./scripts/run-compatibility-tests.sh $(release_branch)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -72,6 +72,12 @@ export RELAYER_TAG="v2.0.0"
 make e2e-test entrypoint=TestInterchainAccountsTestSuite test=TestMsgSubmitTx_SuccessfulTransfer
 ```
 
+If `jq` is installed, you only need to specify the `test`.
+
+```sh
+make e2e-test test=TestMsgSubmitTx_SuccessfulTransfer
+```
+
 > Note: sometimes it can be useful to make changes to [ibctest](https://github.com/strangelove-ventures/interchaintest) when running tests locally. In order to do this, add the following line to
 e2e/go.mod
 

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -13,12 +13,12 @@ export CHAIN_BINARY="${CHAIN_BINARY:-simd}"
 if command -v jq > /dev/null; then
    cd ..
    ENTRY_POINT="$(go run -mod=readonly cmd/build_test_matrix/main.go | jq -r --arg TEST "${TEST}" '.include[] | select( .test == $TEST)  | .entrypoint')"
-   cd -
+   cd - > /dev/null
 fi
 
 
 # find the name of the file that has this test in it.
-test_file="$(grep --recursive --files-with-matches './' -e "${TEST}")"
+test_file="$(grep --recursive --files-with-matches './' -e "${TEST}()")"
 
 # we run the test on the directory as specific files may reference types in other files but within the package.
 test_dir="$(dirname $test_file)"

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -20,6 +20,9 @@ fi
 # find the name of the file that has this test in it.
 test_file="$(grep --recursive --files-with-matches './' -e "${TEST}")"
 
+# we run the test on the directory as specific files may reference types in other files but within the package.
+test_dir="$(dirname $test_file)"
+
 # run the test file directly, this allows log output to be streamed directly in the terminal sessions
 # without needed to wait for the test to finish.
-go test -v "${test_file}" --run ${ENTRY_POINT} -testify.m ^${TEST}$
+go test -v "${test_dir}" --run ${ENTRY_POINT} -testify.m ^${TEST}$

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 TEST="${1}"
 ENTRY_POINT="${2:-}"
 
-export CHAIN_A_TAG="${CHAIN_A_TAG:-latest}"
-export CHAIN_IMAGE="${CHAIN_IMAGE:-ibc-go-simd}"
+export CHAIN_A_TAG="${CHAIN_A_TAG:-main}"
+export CHAIN_IMAGE="${CHAIN_IMAGE:-ghcr.io/cosmos/ibc-go-simd}"
 export CHAIN_BINARY="${CHAIN_BINARY:-simd}"
 
 # if jq is installed, we can automatically determine the test entrypoint.

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
-ENTRY_POINT="${1}"
-TEST="${2}"
+TEST="${1}"
+ENTRY_POINT="${2:-}"
 
-export CHAIN_A_TAG="${CHAIN_A_TAG:-main}"
-export CHAIN_IMAGE="${CHAIN_IMAGE:-ghcr.io/cosmos/ibc-go-simd}"
+export CHAIN_A_TAG="${CHAIN_A_TAG:-latest}"
+export CHAIN_IMAGE="${CHAIN_IMAGE:-ibc-go-simd}"
 export CHAIN_BINARY="${CHAIN_BINARY:-simd}"
+
+# if jq is installed, we can automatically determine the test entrypoint.
+if command -v jq; then
+   cd ..
+   ENTRY_POINT="$(go run -mod=readonly cmd/build_test_matrix/main.go | jq -r --arg TEST "${TEST}" '.include[] | select( .test == $TEST)  | .entrypoint')"
+   cd e2e
+fi
+
+echo $ENTRY_POINT
 
 go test -v ./tests/... --run ${ENTRY_POINT} -testify.m ^${TEST}$


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


This PR fixes two small things with the e2e running script.

1. You now only need to provide a single argument to `make e2e-test` 

e.g.

```bash
make e2e-test test=TestMaxExpectedTimePerBlockParam
```

The entrypoint will be automatically be determined using `jq`. If `jq` is not present it will require the entrypoint to be specified as usual.


2. The logs now display as the test is running, instead of after the test finishes. This is achieved by providing a single file name rather than `./...` to `go test`.

closes: #3255



<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
