### PR TITLE
Update v6-to-v7.md

### DIFF
--- a/docs/migrations/v6-to-v7.md
+++ b/docs/migrations/v6-to-v7.md
@@ -22,7 +22,7 @@ Add the following to the function call to the upgrade handler in `app/app.go`, t
 ```go
 import (
   // ...
-  ibctmmigrations "github.com/cosmos/ibc-go/v6/modules/light-clients/07-tendermint/migrations"
+  ibctmmigrations "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint/migrations"
 )
 
 // ...
@@ -54,7 +54,7 @@ To register the tendermint client, modify the `app.go` file to include the tende
 ```diff
 import (
   // ...
-+ ibctm "github.com/cosmos/ibc-go/v6/modules/light-clients/07-tendermint"
++ ibctm "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 )
 
 // ...
@@ -76,7 +76,7 @@ To register the solo machine client, modify the `app.go` file to include the sol
 ```diff
 import (
   // ...
-+ solomachine "github.com/cosmos/ibc-go/v6/modules/light-clients/06-solomachine"
++ solomachine "github.com/cosmos/ibc-go/v7/modules/light-clients/06-solomachine"
 )
 
 // ...
@@ -274,8 +274,8 @@ IBC module constants have been moved from the `host` package to the `exported` p
 ```diff
 import (
   // ...
-- host "github.com/cosmos/ibc-go/v6/modules/core/24-host"
-+ ibcexported "github.com/cosmos/ibc-go/v6/modules/core/exported"
+- host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
++ ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
   // ...
 )
 


### PR DESCRIPTION
## Description

Corrects the module paths presented in the migrations.md document


### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
