### PR TITLE
Write docker inspect output to diagnostics

### DIFF
--- a/e2e/testsuite/diagnostics/diagnostics.go
+++ b/e2e/testsuite/diagnostics/diagnostics.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	e2eDir = "e2e"
+	e2eDir          = "e2e"
+	defaultFilePerm = 0750
 )
 
 // Collect can be used in `t.Cleanup` and will copy all the of the container logs and relevant files
@@ -42,7 +43,7 @@ func Collect(t *testing.T, dc *dockerclient.Client, cfg testconfig.ChainOptions)
 
 	logsDir := fmt.Sprintf("%s/diagnostics", e2eDir)
 
-	if err := os.MkdirAll(fmt.Sprintf("%s/%s", logsDir, t.Name()), 0750); err != nil {
+	if err := os.MkdirAll(fmt.Sprintf("%s/%s", logsDir, t.Name()), defaultFilePerm); err != nil {
 		t.Logf("failed creating logs directory in test cleanup: %s", err)
 		return
 	}
@@ -56,7 +57,7 @@ func Collect(t *testing.T, dc *dockerclient.Client, cfg testconfig.ChainOptions)
 	for _, container := range testContainers {
 		containerName := getContainerName(t, container)
 		containerDir := fmt.Sprintf("%s/%s/%s", logsDir, t.Name(), containerName)
-		if err := os.MkdirAll(containerDir, 0750); err != nil {
+		if err := os.MkdirAll(containerDir, defaultFilePerm); err != nil {
 			t.Logf("failed creating logs directory for container %s: %s", containerDir, err)
 			continue
 		}
@@ -113,16 +114,6 @@ func getContainerName(t *testing.T, container dockertypes.Container) string {
 	return containerName
 }
 
-// writeLocalFile writes the provided contents to the specified path.
-func writeLocalFile(fileBz []byte, localPath string) error {
-	filePath := ospath.Join(localPath)
-	if err := os.WriteFile(filePath, fileBz, 0750); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // fetchAndWriteDiagnosticsFile fetches the contents of a single file from the given container id and writes
 // the contents of the file to a local path provided.
 func fetchAndWriteDiagnosticsFile(ctx context.Context, dc *dockerclient.Client, containerID, localPath, absoluteFilePathInContainer string) error {
@@ -131,7 +122,7 @@ func fetchAndWriteDiagnosticsFile(ctx context.Context, dc *dockerclient.Client, 
 		return err
 	}
 
-	return writeLocalFile(fileBz, localPath)
+	return os.WriteFile(localPath, fileBz, defaultFilePerm)
 }
 
 // fetchAndWriteDockerInspectOutput writes the contents of docker inspect to the specified file.
@@ -146,7 +137,7 @@ func fetchAndWriteDockerInspectOutput(ctx context.Context, dc *dockerclient.Clie
 		return err
 	}
 
-	return writeLocalFile(fileBz, localPath)
+	return os.WriteFile(localPath, fileBz, defaultFilePerm)
 }
 
 // chainDiagnosticAbsoluteFilePaths returns a slice of absolute file paths (in the containers) which are the files that should be


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

As discussed with @colin-axner , we can add additional diagnostics (output of `docker inspect <containerID>`) to the collected diagnostics. This allows us to further debug docker specific issues such as ports/volumes etc.


Here is the sample output of the file that gets created

```json
{
	"Id": "9482d26e7767ef39d0a41cccf37dc6def2092c9ee6827ac070b00ee3ec61b91a",
	"Created": "2023-03-14T12:15:51.897440552Z",
	"Path": "simd",
	"Args": [
		"start",
		"--home",
		"/var/cosmos-chain/simapp-a",
		"--x-crisis-skip-assert-invariants"
	],
	"State": {
		"Status": "running",
		"Running": true,
		"Paused": false,
		"Restarting": false,
		"OOMKilled": false,
		"Dead": false,
		"Pid": 56421,
		"ExitCode": 0,
		"Error": "",
		"StartedAt": "2023-03-14T12:15:52.917082178Z",
		"FinishedAt": "0001-01-01T00:00:00Z"
	},
	"Image": "sha256:6f5829eb0d5addab294b79919b19d122cbc068311126bb052c0a26ae7bba56ff",
	"ResolvConfPath": "/var/lib/docker/containers/9482d26e7767ef39d0a41cccf37dc6def2092c9ee6827ac070b00ee3ec61b91a/resolv.conf",
	"HostnamePath": "/var/lib/docker/containers/9482d26e7767ef39d0a41cccf37dc6def2092c9ee6827ac070b00ee3ec61b91a/hostname",
	"HostsPath": "/var/lib/docker/containers/9482d26e7767ef39d0a41cccf37dc6def2092c9ee6827ac070b00ee3ec61b91a/hosts",
	"LogPath": "/var/lib/docker/containers/9482d26e7767ef39d0a41cccf37dc6def2092c9ee6827ac070b00ee3ec61b91a/9482d26e7767ef39d0a41cccf37dc6def2092c9ee6827ac070b00ee3ec61b91a-json.log",
	"Name": "/chain-a-val-0-TestTransferTestSuite_TestMsgTransfer_Succeeds_Nonincentivized",
	"RestartCount": 0,
	"Driver": "overlay2",
	"Platform": "linux",
	"MountLabel": "",
	"ProcessLabel": "",
	"AppArmorProfile": "",
	"ExecIDs": null,
	"HostConfig": {
		"Binds": [
			"9ab70a566f58baea39af02cce83d6b06f8cf45bba4dbe9dd3a43f283e5ee914e:/var/cosmos-chain/simapp-a"
		],
		"ContainerIDFile": "",
		"LogConfig": {
			"Type": "json-file",
			"Config": {}
		},
		"NetworkMode": "default",
		"PortBindings": null,
		"RestartPolicy": {
			"Name": "",
			"MaximumRetryCount": 0
		},
		"AutoRemove": false,
		"VolumeDriver": "",
		"VolumesFrom": null,
		"CapAdd": null,
		"CapDrop": null,
		"CgroupnsMode": "private",
		"Dns": [],
		"DnsOptions": null,
		"DnsSearch": null,
		"ExtraHosts": null,
		"GroupAdd": null,
		"IpcMode": "private",
		"Cgroup": "",
		"Links": null,
		"OomScoreAdj": 0,
		"PidMode": "",
		"Privileged": false,
		"PublishAllPorts": true,
		"ReadonlyRootfs": false,
		"SecurityOpt": null,
		"UTSMode": "",
		"UsernsMode": "",
		"ShmSize": 67108864,
		"Runtime": "runc",
		"ConsoleSize": [
			0,
			0
		],
		"Isolation": "",
		"CpuShares": 0,
		"Memory": 0,
		"NanoCpus": 0,
		"CgroupParent": "",
		"BlkioWeight": 0,
		"BlkioWeightDevice": null,
		"BlkioDeviceReadBps": null,
		"BlkioDeviceWriteBps": null,
		"BlkioDeviceReadIOps": null,
		"BlkioDeviceWriteIOps": null,
		"CpuPeriod": 0,
		"CpuQuota": 0,
		"CpuRealtimePeriod": 0,
		"CpuRealtimeRuntime": 0,
		"CpusetCpus": "",
		"CpusetMems": "",
		"Devices": null,
		"DeviceCgroupRules": null,
		"DeviceRequests": null,
		"KernelMemory": 0,
		"KernelMemoryTCP": 0,
		"MemoryReservation": 0,
		"MemorySwap": 0,
		"MemorySwappiness": null,
		"OomKillDisable": null,
		"PidsLimit": null,
		"Ulimits": null,
		"CpuCount": 0,
		"CpuPercent": 0,
		"IOMaximumIOps": 0,
		"IOMaximumBandwidth": 0,
		"MaskedPaths": [
			"/proc/asound",
			"/proc/acpi",
			"/proc/kcore",
			"/proc/keys",
			"/proc/latency_stats",
			"/proc/timer_list",
			"/proc/timer_stats",
			"/proc/sched_debug",
			"/proc/scsi",
			"/sys/firmware"
		],
		"ReadonlyPaths": [
			"/proc/bus",
			"/proc/fs",
			"/proc/irq",
			"/proc/sys",
			"/proc/sysrq-trigger"
		]
	},
	"GraphDriver": {
		"Data": {
			"LowerDir": "/var/lib/docker/overlay2/11829cfae424a71f85f6077af53df3b7ab004876fc2b98cb8119c97c4485ecf6-init/diff:/var/lib/docker/overlay2/944eb9efedbaca02f6b81e2d8d3b4bdb8cd62f1344fd92c44a368d0aa7c91592/diff:/var/lib/docker/overlay2/e956c63bea4bbea1ee35c79e49210029b73c6b83e2c4280258de9c5e7deb3586/diff",
			"MergedDir": "/var/lib/docker/overlay2/11829cfae424a71f85f6077af53df3b7ab004876fc2b98cb8119c97c4485ecf6/merged",
			"UpperDir": "/var/lib/docker/overlay2/11829cfae424a71f85f6077af53df3b7ab004876fc2b98cb8119c97c4485ecf6/diff",
			"WorkDir": "/var/lib/docker/overlay2/11829cfae424a71f85f6077af53df3b7ab004876fc2b98cb8119c97c4485ecf6/work"
		},
		"Name": "overlay2"
	},
	"Mounts": [
		{
			"Type": "volume",
			"Name": "9ab70a566f58baea39af02cce83d6b06f8cf45bba4dbe9dd3a43f283e5ee914e",
			"Source": "/var/lib/docker/volumes/9ab70a566f58baea39af02cce83d6b06f8cf45bba4dbe9dd3a43f283e5ee914e/_data",
			"Destination": "/var/cosmos-chain/simapp-a",
			"Driver": "local",
			"Mode": "z",
			"RW": true,
			"Propagation": ""
		}
	],
	"Config": {
		"Hostname": "chain-a-val-0-TestTransferTest_._nsfer_Succeeds_Nonincentivized",
		"Domainname": "",
		"User": "",
		"AttachStdin": false,
		"AttachStdout": false,
		"AttachStderr": false,
		"ExposedPorts": {
			"1234/tcp": {},
			"1317/tcp": {},
			"26656/tcp": {},
			"26657/tcp": {},
			"9090/tcp": {}
		},
		"Tty": false,
		"OpenStdin": false,
		"StdinOnce": false,
		"Env": [
			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
		],
		"Cmd": [
			"simd",
			"start",
			"--home",
			"/var/cosmos-chain/simapp-a",
			"--x-crisis-skip-assert-invariants"
		],
		"Image": "ghcr.io/cosmos/ibc-go-simd:main",
		"Volumes": null,
		"WorkingDir": "",
		"Entrypoint": [],
		"OnBuild": null,
		"Labels": {
			"ibc-test": "TestTransferTestSuite/TestMsgTransfer_Succeeds_Nonincentivized",
			"org.cosmos.ibc-go": "main",
			"org.opencontainers.image.ref.name": "ubuntu",
			"org.opencontainers.image.version": "20.04"
		}
	},
	"NetworkSettings": {
		"Bridge": "",
		"SandboxID": "03f59aaaa4a9f5c648f4bf0e1022c82f4f70ea9b0e1117586c81b8d0a807478d",
		"HairpinMode": false,
		"LinkLocalIPv6Address": "",
		"LinkLocalIPv6PrefixLen": 0,
		"Ports": {
			"1234/tcp": [
				{
					"HostIp": "0.0.0.0",
					"HostPort": "55430"
				}
			],
			"1317/tcp": [
				{
					"HostIp": "0.0.0.0",
					"HostPort": "55429"
				}
			],
			"26656/tcp": [
				{
					"HostIp": "0.0.0.0",
					"HostPort": "55425"
				}
			],
			"26657/tcp": [
				{
					"HostIp": "0.0.0.0",
					"HostPort": "55424"
				}
			],
			"9090/tcp": [
				{
					"HostIp": "0.0.0.0",
					"HostPort": "55428"
				}
			]
		},
		"SandboxKey": "/var/run/docker/netns/03f59aaaa4a9",
		"SecondaryIPAddresses": null,
		"SecondaryIPv6Addresses": null,
		"EndpointID": "",
		"Gateway": "",
		"GlobalIPv6Address": "",
		"GlobalIPv6PrefixLen": 0,
		"IPAddress": "",
		"IPPrefixLen": 0,
		"IPv6Gateway": "",
		"MacAddress": "",
		"Networks": {
			"interchaintest-smqjrikx": {
				"IPAMConfig": null,
				"Links": null,
				"Aliases": [
					"9482d26e7767",
					"chain-a-val-0-TestTransferTest_._nsfer_Succeeds_Nonincentivized"
				],
				"NetworkID": "8003905a789ff01ff76a8ef5403975d7f9417ffcf4b1a0d2b010e12f613c38fe",
				"EndpointID": "14d2a3752be27d8cb294ecd386728b4191f46feef5402cc33ff88924e83e75f8",
				"Gateway": "192.168.16.1",
				"IPAddress": "192.168.16.3",
				"IPPrefixLen": 20,
				"IPv6Gateway": "",
				"GlobalIPv6Address": "",
				"GlobalIPv6PrefixLen": 0,
				"MacAddress": "02:42:c0:a8:10:03",
				"DriverOpts": null
			}
		}
	}
}
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/10-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
