### PR TITLE
fix: remove api break from SDK v0.47 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (apps) [#3149](https://github.com/cosmos/ibc-go/pull/3149) Remove legacy interface function `RandomizedParams`, which is no longer used.
 * (light-clients/06-solomachine) [#2941](https://github.com/cosmos/ibc-go/pull/2941) Remove solomachine header sequence.
 * (core) [#2982](https://github.com/cosmos/ibc-go/pull/2982) Moved the ibc module name into the exported package.
-* (testing) [\#3295](https://github.com/cosmos/ibc-go/pull/3295) The function to initialize the `TestingApp` takes now the chain ID as parameter.
  
 ### State Machine Breaking
 
@@ -122,6 +121,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (testing) [\#3295](https://github.com/cosmos/ibc-go/pull/3295) The function `SetupWithGenesisValSet` will set the baseapp chainID before running `InitChain`
 * (light-clients/solomachine) [#1839](https://github.com/cosmos/ibc-go/pull/1839) Fixed usage of the new diversifier in validation of changing diversifiers for the solo machine. The current diversifier must sign over the new diversifier.
 * (light-clients/07-tendermint) [\#1674](https://github.com/cosmos/ibc-go/pull/1674) Submitted ClientState is zeroed out before checking the proof in order to prevent the proposal from containing information governance is not actually voting on.
 * (modules/core/02-client)[\#1676](https://github.com/cosmos/ibc-go/pull/1676) ClientState must be zeroed out for `UpgradeProposals` to pass validation. This prevents a proposal containing information governance is not actually voting on.

--- a/docs/migrations/v6-to-v7.md
+++ b/docs/migrations/v6-to-v7.md
@@ -95,15 +95,6 @@ It may be useful to reference the [PR](https://github.com/cosmos/ibc-go/pull/282
 
 The `SetChannelClosed` utility method in `testing/endpoint.go` has been updated to `SetChannelState`, which will take a `channeltypes.State` argument so that the `ChannelState` can be set to any of the possible channel states.
 
-The function to initialize the `TestingApp` takes now the chain ID as parameter:
-
- ```go
-- func SetupTestingApp() (TestingApp, map[string]json.RawMessage)
-+ func SetupTestingApp(chainID string) (TestingApp, map[string]json.RawMessage)
-```
-
-The chain ID should then be pass to `SetChainID` and used as a `baseapp` option in the `NewSimApp` constructor.
-
 ## IBC Apps
 
 - No relevant changes were made in this release.

--- a/testing/README.md
+++ b/testing/README.md
@@ -117,7 +117,7 @@ It is assumed your application contains an embedded BaseApp and thus implements 
 The testing package requires that you provide a function to initialize your TestingApp. This is how ibc-go implements the initialize function with its `SimApp`:
 
 ```go
-func SetupTestingApp(chainID string) (TestingApp, map[string]json.RawMessage) {
+func SetupTestingApp() (TestingApp, map[string]json.RawMessage) {
   db := dbm.NewMemDB()
   encCdc := simapp.MakeTestEncodingConfig()
   app := simapp.NewSimApp(
@@ -130,7 +130,6 @@ func SetupTestingApp(chainID string) (TestingApp, map[string]json.RawMessage) {
     5,
     encCdc, 
     simapp.EmptyAppOptions{},
-    baseapp.SetChainID(chainID),
   )
   return app, simapp.NewDefaultGenesisState(encCdc.Marshaler)
 }
@@ -276,7 +275,7 @@ import (
   ibctesting "github.com/cosmos/ibc-go/v7/testing"
 )
 
-func SetupTransferTestingApp(chainID string) (ibctesting.TestingApp, map[string]json.RawMessage) {
+func SetupTransferTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {
   db := dbm.NewMemDB()
   encCdc := simapp.MakeTestEncodingConfig()
   app := simapp.NewSimApp(
@@ -289,7 +288,6 @@ func SetupTransferTestingApp(chainID string) (ibctesting.TestingApp, map[string]
     5,
     encCdc,
     simapp.EmptyAppOptions{},
-    baseapp.SetChainID(chainID),
   )
   return app, simapp.NewDefaultGenesisState(encCdc.Marshaler)
 }

--- a/testing/app.go
+++ b/testing/app.go
@@ -50,10 +50,10 @@ type TestingApp interface {
 	LastBlockHeight() int64
 }
 
-func SetupTestingApp(chainID string) (TestingApp, map[string]json.RawMessage) {
+func SetupTestingApp() (TestingApp, map[string]json.RawMessage) {
 	db := dbm.NewMemDB()
 	encCdc := simapp.MakeTestEncodingConfig()
-	app := simapp.NewSimApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, simapp.DefaultNodeHome, 5, encCdc, simtestutil.EmptyAppOptions{}, baseapp.SetChainID(chainID))
+	app := simapp.NewSimApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, simapp.DefaultNodeHome, 5, encCdc, simtestutil.EmptyAppOptions{})
 	return app, simapp.NewDefaultGenesisState(encCdc.Marshaler)
 }
 
@@ -62,7 +62,10 @@ func SetupTestingApp(chainID string) (TestingApp, map[string]json.RawMessage) {
 // of one consensus engine unit (10^6) in the default token of the simapp from first genesis
 // account. A Nop logger is set in SimApp.
 func SetupWithGenesisValSet(t testing.TB, valSet *tmtypes.ValidatorSet, genAccs []authtypes.GenesisAccount, chainID string, powerReduction math.Int, balances ...banktypes.Balance) TestingApp {
-	app, genesisState := DefaultTestingAppInit(chainID)
+	app, genesisState := DefaultTestingAppInit()
+
+	// ensure baseapp has a chain-id set before running InitChain
+	baseapp.SetChainID(chainID)(app.GetBaseApp())
 
 	// set genesis accounts
 	authGenesis := authtypes.NewGenesisState(authtypes.DefaultParams(), genAccs)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

I think it makes sense to avoid API breaking change in our rc to final release. If we want to break API, we can do that in v8

closes: #XXXX


### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
