### PR TITLE
Only run e2e on R4R

### DIFF
--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -25,12 +25,11 @@ jobs:
         run: echo "matrix=$(go run cmd/build_test_matrix/main.go)" >> $GITHUB_OUTPUT
         env:
           TEST_EXCLUSIONS: "TestInterTxTestSuite,TestIncentivizedInterTxTestSuite,TestUpgradeTestSuite"
-
   e2e:
     env:
       CHAIN_A_TAG: latest
       CHAIN_IMAGE: ibc-go-simd
-    if: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (!github.event.pull_request.draft && github.event.pull_request.head.repo.fork) || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     needs:
       - build-test-matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -2,7 +2,6 @@ name: Tests / E2E Fork
 on:
   workflow_dispatch:
   pull_request:
-    types: [ ready_for_review ]
     branches:
       - main
     paths-ignore:
@@ -26,6 +25,7 @@ jobs:
         run: echo "matrix=$(go run cmd/build_test_matrix/main.go)" >> $GITHUB_OUTPUT
         env:
           TEST_EXCLUSIONS: "TestInterTxTestSuite,TestIncentivizedInterTxTestSuite,TestUpgradeTestSuite"
+
   e2e:
     env:
       CHAIN_A_TAG: latest

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -2,6 +2,7 @@ name: Tests / E2E Fork
 on:
   workflow_dispatch:
   pull_request:
+    types: [ ready_for_review ]
     branches:
       - main
     paths-ignore:
@@ -29,7 +30,7 @@ jobs:
     env:
       CHAIN_A_TAG: latest
       CHAIN_IMAGE: ibc-go-simd
-    if: ${{ (!github.event.pull_request.draft && github.event.pull_request.head.repo.fork) || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     needs:
       - build-test-matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
     determine-image-tag:
-      if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+      if: ${{ !github.event.pull_request.draft && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
       runs-on: ubuntu-latest
       outputs:
         simd-tag: ${{ steps.get-tag.outputs.simd-tag }}
@@ -42,7 +42,7 @@ jobs:
             fi
 
     build-e2e:
-      if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+      if: ${{ !github.event.pull_request.draft && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v3

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,7 +54,7 @@ jobs:
             done
 
     e2e:
-      if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+      if: ${{ !github.event.pull_request.draft && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
       needs:
         - determine-image-tag
         - build-e2e # don't attempt any tests unless the e2e code compiles successfully.

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
   pull_request:
     types:
-#      - opened
-#      - reopened
-#      - synchronize
+      # trigger workflow if changes are pushed to the branch.
+      - synchronize
+      # trigger workflow if PR is marked ready for review.
       - ready_for_review
     paths-ignore:
       - "docs/**"
@@ -59,7 +59,9 @@ jobs:
             done
 
     e2e:
-      if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+      # we will be running this job if the PR has not yet been marked for review, and we push additional changes.
+      # we skip the job in this case.
+      if: ${{ !github.event.pull_request.draft && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
       needs:
         - determine-image-tag
         - build-e2e # don't attempt any tests unless the e2e code compiles successfully.

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,8 +1,12 @@
 name: Tests / E2E
 on:
   workflow_dispatch:
-  pull_request_target:
-    types: [ ready_for_review ]
+  pull_request:
+    types:
+#      - opened
+#      - reopened
+#      - synchronize
+      - ready_for_review
     paths-ignore:
       - "docs/**"
       - "**.md"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,7 +1,7 @@
 name: Tests / E2E
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [ ready_for_review ]
     paths-ignore:
       - "docs/**"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,7 +55,7 @@ jobs:
             done
 
     e2e:
-      if: ${{ && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+      if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
       needs:
         - determine-image-tag
         - build-e2e # don't attempt any tests unless the e2e code compiles successfully.

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,6 +2,7 @@ name: Tests / E2E
 on:
   workflow_dispatch:
   pull_request:
+    types: [ ready_for_review ]
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -54,7 +55,7 @@ jobs:
             done
 
     e2e:
-      if: ${{ !github.event.pull_request.draft && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+      if: ${{ && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
       needs:
         - determine-image-tag
         - build-e2e # don't attempt any tests unless the e2e code compiles successfully.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

part of: #3329

This PR makes it so e2es only run when a PR is R4R

<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
