### PR TITLE
chore: remove proof height validation in channel upgrades msgs

### DIFF
--- a/modules/core/04-channel/types/msgs.go
+++ b/modules/core/04-channel/types/msgs.go
@@ -596,9 +596,6 @@ func (msg MsgChannelUpgradeTry) ValidateBasic() error {
 	if len(msg.ProofUpgradeSequence) == 0 {
 		return errorsmod.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty upgrade sequence proof")
 	}
-	if msg.ProofHeight.IsZero() {
-		return errorsmod.Wrap(ibcerrors.ErrInvalidHeight, "proof height must be non-zero")
-	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		return errorsmod.Wrapf(ibcerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
@@ -646,9 +643,6 @@ func (msg MsgChannelUpgradeAck) ValidateBasic() error {
 	}
 	if len(msg.ProofUpgradeSequence) == 0 {
 		return errorsmod.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty upgrade sequence proof")
-	}
-	if msg.ProofHeight.IsZero() {
-		return errorsmod.Wrap(ibcerrors.ErrInvalidHeight, "proof height must be non-zero")
 	}
 	if msg.CounterpartyChannel.State != TRYUPGRADE {
 		return errorsmod.Wrapf(ErrInvalidChannelState, "expected: %s, got: %s", "TRYUPGRADE", msg.CounterpartyChannel.State)
@@ -718,10 +712,6 @@ func (msg MsgChannelUpgradeConfirm) ValidateBasic() error {
 		return errorsmod.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty upgrade sequence proof")
 	}
 
-	if msg.ProofHeight.IsZero() {
-		return errorsmod.Wrap(ibcerrors.ErrInvalidHeight, "proof height must be non-zero")
-	}
-
 	if msg.CounterpartyChannel.State != OPEN {
 		return errorsmod.Wrapf(ErrInvalidChannelState, "expected: %s, got: %s", OPEN, msg.CounterpartyChannel.State)
 	}
@@ -781,10 +771,6 @@ func (msg MsgChannelUpgradeTimeout) ValidateBasic() error {
 		return errorsmod.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
 	}
 
-	if msg.ProofHeight.IsZero() {
-		return errorsmod.Wrap(ibcerrors.ErrInvalidHeight, "proof height must be non-zero")
-	}
-
 	if msg.CounterpartyChannel.State != OPEN {
 		return errorsmod.Wrapf(ErrInvalidChannelState, "expected: %s, got: %s", OPEN, msg.CounterpartyChannel.State)
 	}
@@ -840,10 +826,6 @@ func (msg MsgChannelUpgradeCancel) ValidateBasic() error {
 
 	if len(msg.ProofErrorReceipt) == 0 {
 		return errorsmod.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
-	}
-
-	if msg.ProofHeight.IsZero() {
-		return errorsmod.Wrap(ibcerrors.ErrInvalidHeight, "proof height must be non-zero")
 	}
 
 	if msg.ErrorReceipt.Sequence == 0 {

--- a/modules/core/04-channel/types/msgs_test.go
+++ b/modules/core/04-channel/types/msgs_test.go
@@ -582,13 +582,6 @@ func (suite *TypesTestSuite) TestMsgChannelUpgradeTryValidateBasic() {
 			false,
 		},
 		{
-			"proof height must be > 0",
-			func() {
-				msg.ProofHeight = clienttypes.ZeroHeight()
-			},
-			false,
-		},
-		{
 			"missing signer address",
 			func() {
 				msg.Signer = emptyAddr
@@ -661,13 +654,6 @@ func (suite *TypesTestSuite) TestMsgChannelUpgradeAckValidateBasic() {
 			"cannot submit an empty upgrade sequence proof",
 			func() {
 				msg.ProofUpgradeSequence = emptyProof
-			},
-			false,
-		},
-		{
-			"proof height must be > 0",
-			func() {
-				msg.ProofHeight = clienttypes.ZeroHeight()
 			},
 			false,
 		},
@@ -765,13 +751,6 @@ func (suite *TypesTestSuite) TestMsgChannelUpgradeConfirmValidateBasic() {
 			false,
 		},
 		{
-			"proof height must be > 0",
-			func() {
-				msg.ProofHeight = clienttypes.ZeroHeight()
-			},
-			false,
-		},
-		{
 			"missing signer address",
 			func() {
 				msg.Signer = emptyAddr
@@ -833,13 +812,6 @@ func (suite *TypesTestSuite) TestMsgChannelUpgradeTimeoutValidateBasic() {
 			"cannot submit an empty proof",
 			func() {
 				msg.ProofChannel = emptyProof
-			},
-			false,
-		},
-		{
-			"proof height must be > 0",
-			func() {
-				msg.ProofHeight = clienttypes.ZeroHeight()
 			},
 			false,
 		},
@@ -926,13 +898,6 @@ func (suite *TypesTestSuite) TestMsgChannelUpgradeCancelValidateBasic() {
 			"cannot submit an empty proof",
 			func() {
 				msg.ProofErrorReceipt = emptyProof
-			},
-			false,
-		},
-		{
-			"proof height must be > 0",
-			func() {
-				msg.ProofHeight = clienttypes.ZeroHeight()
 			},
 			false,
 		},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Removing proof height validation to align with adaptations made to other 04-channel msgs.
Enables support for localhost and solomachine clients

closes: #3340

<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
