### PR TITLE
nit: Create ordered matrix output, remove duplicate suite method.

### DIFF
--- a/cmd/build_test_matrix/main.go
+++ b/cmd/build_test_matrix/main.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -136,8 +137,9 @@ func getGithubActionMatrixForTests(e2eRootDirectory, testName string, suite stri
 		Include: []TestSuitePair{},
 	}
 
-	for testSuiteName, testCases := range testSuiteMapping {
-		for _, testCaseName := range testCases {
+	suites := sortedSuiteNames(testSuiteMapping)
+	for _, testSuiteName := range suites {
+		for _, testCaseName := range testSuiteMapping[testSuiteName] {
 			gh.Include = append(gh.Include, TestSuitePair{
 				Test:       testCaseName,
 				EntryPoint: testSuiteName,
@@ -177,6 +179,16 @@ func extractSuiteAndTestNames(file *ast.File) (string, []string, error) {
 		return "", nil, fmt.Errorf("file %s had no test suite test case", file.Name.Name)
 	}
 	return suiteNameForFile, testCases, nil
+}
+
+// sortedSuiteNames returns a sorted list of suite names.
+func sortedSuiteNames(suiteMapping map[string][]string) []string {
+	var suiteNames []string
+	for suiteName := range suiteMapping {
+		suiteNames = append(suiteNames, suiteName)
+	}
+	sort.Strings(suiteNames)
+	return suiteNames
 }
 
 // isTestSuiteMethod returns true if the function is a test suite function.

--- a/cmd/build_test_matrix/main.go
+++ b/cmd/build_test_matrix/main.go
@@ -137,15 +137,18 @@ func getGithubActionMatrixForTests(e2eRootDirectory, testName string, suite stri
 		Include: []TestSuitePair{},
 	}
 
-	suites := sortedSuiteNames(testSuiteMapping)
-	for _, testSuiteName := range suites {
-		for _, testCaseName := range testSuiteMapping[testSuiteName] {
+	for testSuiteName, testCases := range testSuiteMapping {
+		for _, testCaseName := range testCases {
 			gh.Include = append(gh.Include, TestSuitePair{
 				Test:       testCaseName,
 				EntryPoint: testSuiteName,
 			})
 		}
 	}
+	// Sort the test cases by name so that the order is consistent.
+	sort.SliceStable(gh.Include, func(i, j int) bool {
+		return gh.Include[i].Test < gh.Include[j].Test
+	})
 
 	if testName != "" && len(gh.Include) != 1 {
 		return GithubActionTestMatrix{}, fmt.Errorf("expected exactly 1 test in the output matrix but got %d", len(gh.Include))
@@ -179,16 +182,6 @@ func extractSuiteAndTestNames(file *ast.File) (string, []string, error) {
 		return "", nil, fmt.Errorf("file %s had no test suite test case", file.Name.Name)
 	}
 	return suiteNameForFile, testCases, nil
-}
-
-// sortedSuiteNames returns a sorted list of suite names.
-func sortedSuiteNames(suiteMapping map[string][]string) []string {
-	var suiteNames []string
-	for suiteName := range suiteMapping {
-		suiteNames = append(suiteNames, suiteName)
-	}
-	sort.Strings(suiteNames)
-	return suiteNames
 }
 
 // isTestSuiteMethod returns true if the function is a test suite function.

--- a/e2e/tests/interchain_accounts/incentivized_test.go
+++ b/e2e/tests/interchain_accounts/incentivized_test.go
@@ -31,14 +31,6 @@ type IncentivizedInterchainAccountsTestSuite struct {
 	InterchainAccountsTestSuite
 }
 
-// RegisterCounterPartyPayee broadcasts a MsgRegisterCounterpartyPayee message.
-func (s *IncentivizedInterchainAccountsTestSuite) RegisterCounterPartyPayee(ctx context.Context, chain *cosmos.CosmosChain,
-	user ibc.Wallet, portID, channelID, relayerAddr, counterpartyPayeeAddr string,
-) (sdk.TxResponse, error) {
-	msg := feetypes.NewMsgRegisterCounterpartyPayee(portID, channelID, relayerAddr, counterpartyPayeeAddr)
-	return s.BroadcastMessages(ctx, chain, user, msg)
-}
-
 func (s *IncentivizedInterchainAccountsTestSuite) TestMsgSendTx_SuccessfulBankSend_Incentivized() {
 	t := s.T()
 	ctx := context.TODO()

--- a/e2e/tests/interchain_accounts/incentivized_test.go
+++ b/e2e/tests/interchain_accounts/incentivized_test.go
@@ -9,7 +9,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/gogoproto/proto"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
-	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	test "github.com/strangelove-ventures/interchaintest/v7/testutil"
 	"github.com/stretchr/testify/suite"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Removes `RegisterCounterPartyPayee` which was duplicated on `E2ETestSuite` and makes the generation of the github matrix ordered.

closes: #XXXX

### Commit Message / Changelog Entry

```bash
nit: Create ordered matrix output, remove duplicate suite method `RegisterCounterPartyPayee`
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
