### PR TITLE
chore: adapt the ordering subset of method to add clarity

### DIFF
--- a/modules/core/04-channel/keeper/keeper.go
+++ b/modules/core/04-channel/keeper/keeper.go
@@ -586,7 +586,7 @@ func (k Keeper) ValidateUpgradeFields(ctx sdk.Context, proposedUpgrade types.Upg
 		return errorsmod.Wrap(types.ErrChannelExists, "existing channel end is identical to proposed upgrade channel end")
 	}
 
-	if !currentFields.Ordering.SubsetOf(proposedUpgrade.Ordering) {
+	if !proposedUpgrade.Ordering.SubsetOf(currentFields.Ordering) {
 		return errorsmod.Wrap(types.ErrInvalidChannelOrdering, "channel ordering must be a subset of the new ordering")
 	}
 

--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -65,7 +65,7 @@ func (k Keeper) ChanUpgradeInit(
 		return 0, "", errorsmod.Wrap(types.ErrInvalidCounterparty, "counterparty port ID and channel ID cannot be upgraded")
 	}
 
-	if !channel.Ordering.SubsetOf(proposedUpgradeChannel.Ordering) {
+	if !proposedUpgradeChannel.Ordering.SubsetOf(channel.Ordering) {
 		return 0, "", errorsmod.Wrap(types.ErrInvalidChannelOrdering, "channel ordering must be a subset of the new ordering")
 	}
 

--- a/modules/core/04-channel/types/channel.go
+++ b/modules/core/04-channel/types/channel.go
@@ -144,10 +144,10 @@ var orderSubsets = map[Order][]Order{
 	UNORDERED: {UNORDERED},
 }
 
-// SubsetOf returns true if the provided Order is a valid subset of Order.
-func (o Order) SubsetOf(order Order) bool {
-	if supported, ok := orderSubsets[o]; ok {
-		return collections.Contains(order, supported)
+// SubsetOf returns true if Order is a valid subset of the provided parent Order.
+func (o Order) SubsetOf(parentOrder Order) bool {
+	if supported, ok := orderSubsets[parentOrder]; ok {
+		return collections.Contains(o, supported)
 	}
 
 	return false

--- a/modules/core/04-channel/types/channel_test.go
+++ b/modules/core/04-channel/types/channel_test.go
@@ -60,10 +60,10 @@ func TestCounterpartyValidateBasic(t *testing.T) {
 
 func TestSubsetOf(t *testing.T) {
 	testCases := []struct {
-		name     string
-		order    types.Order
-		newOrder types.Order
-		expPass  bool
+		name        string
+		order       types.Order
+		parentOrder types.Order
+		expPass     bool
 	}{
 		{
 			"ordered -> ordered",
@@ -73,8 +73,8 @@ func TestSubsetOf(t *testing.T) {
 		},
 		{
 			"ordered -> unordered",
-			types.ORDERED,
 			types.UNORDERED,
+			types.ORDERED,
 			true,
 		},
 		{
@@ -85,38 +85,38 @@ func TestSubsetOf(t *testing.T) {
 		},
 		{
 			"unordered -> ordered",
-			types.UNORDERED,
 			types.ORDERED,
+			types.UNORDERED,
 			false,
 		},
 		{
 			"none -> ordered",
-			types.NONE,
 			types.ORDERED,
+			types.NONE,
 			false,
 		},
 		{
 			"none -> unordered",
-			types.NONE,
 			types.UNORDERED,
+			types.NONE,
 			false,
 		},
 		{
 			"ordered -> none",
-			types.ORDERED,
 			types.NONE,
+			types.ORDERED,
 			false,
 		},
 		{
 			"unordered -> none",
-			types.UNORDERED,
 			types.NONE,
+			types.UNORDERED,
 			false,
 		},
 	}
 
 	for _, tc := range testCases {
-		ok := tc.order.SubsetOf(tc.newOrder)
+		ok := tc.order.SubsetOf(tc.parentOrder)
 		if tc.expPass {
 			require.True(t, ok, tc.name)
 		} else {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #3469 



<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
