### PR TITLE
feat: changes for ics

### DIFF
--- a/modules/core/keeper/keeper.go
+++ b/modules/core/keeper/keeper.go
@@ -50,7 +50,7 @@ func NewKeeper(
 	}
 
 	// panic if any of the keepers passed in is empty
-	if isEmpty(stakingKeeper) {
+	if reflect.ValueOf(stakingKeeper).IsZero() {
 		panic(fmt.Errorf("cannot initialize IBC keeper: empty staking keeper"))
 	}
 	if isEmpty(upgradeKeeper) {


### PR DESCRIPTION
## Description

This PR is part of an effort to support sdk 47 and ibc7 without forks.  We 
would love review and feedback, but it shouldn't be considered for merging 
at this time. 

It relates to this PR on ICS:

https://github.com/cosmos/interchain-security/pull/817

### Commit Message / Changelog Entry

pending. We don't even know if this should be merged, and the pr is being 
made so that we can get advice.

<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
