### PR TITLE
chore(tm): use the second return value of GetConsensusState to check if consensus state exists

### DIFF
--- a/modules/light-clients/07-tendermint/misbehaviour_handle.go
+++ b/modules/light-clients/07-tendermint/misbehaviour_handle.go
@@ -25,8 +25,7 @@ func (cs ClientState) CheckForMisbehaviour(ctx sdk.Context, cdc codec.BinaryCode
 		// Check if the Client store already has a consensus state for the header's height
 		// If the consensus state exists, and it matches the header then we return early
 		// since header has already been submitted in a previous UpdateClient.
-		existingConsState, _ := GetConsensusState(clientStore, cdc, tmHeader.GetHeight())
-		if existingConsState != nil {
+		if existingConsState, found := GetConsensusState(clientStore, cdc, tmHeader.GetHeight()); found {
 			// This header has already been submitted and the necessary state is already stored
 			// in client store, thus we can return early without further validation.
 			if reflect.DeepEqual(existingConsState, tmHeader.ConsensusState()) { //nolint:gosimple

--- a/modules/light-clients/07-tendermint/update.go
+++ b/modules/light-clients/07-tendermint/update.go
@@ -137,7 +137,7 @@ func (cs ClientState) UpdateState(ctx sdk.Context, cdc codec.BinaryCodec, client
 	cs.pruneOldestConsensusState(ctx, cdc, clientStore)
 
 	// check for duplicate update
-	if consensusState, _ := GetConsensusState(clientStore, cdc, header.GetHeight()); consensusState != nil {
+	if _, found := GetConsensusState(clientStore, cdc, header.GetHeight()); found {
 		// perform no-op
 		return []exported.Height{header.GetHeight()}
 	}


### PR DESCRIPTION
## Description

In some places, codes like below are used to check whether a consensus state exists or not.
I think this is not a bug, but a bit different from the intention of `GetConsensusState`.
Probably, callers of this function should see the second return value to check it.
```go
if cons, _ := GetConsensusState(....); cons == nil {
    ....
}
```

### Commit Message / Changelog Entry

```bash
chore(tm): use the second return value of GetConsensusState to check if consensus state exists
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
