### PR TITLE
Add e2e test for modifying clientparams

### DIFF
--- a/.github/compatibility-test-matrices/main/client-chain-a.json
+++ b/.github/compatibility-test-matrices/main/client-chain-a.json
@@ -3,7 +3,8 @@
   "chain-b": ["main", "v7.0.1", "v6.2.0", "v6.1.1", "v5.3.1", "v5.2.1", "v5.0.1", "v4.4.2", "v4.3.1", "v4.2.2", "v4.1.3"],
   "entrypoint": ["TestClientTestSuite"],
   "test": [
-    "TestClientUpdateProposal_Succeeds"
+    "TestClientUpdateProposal_Succeeds",
+    "TestAllowedClientsParam"
   ],
   "relayer-type": ["rly"],
   "chain-binary": ["simd"],

--- a/.github/compatibility-test-matrices/main/client-chain-b.json
+++ b/.github/compatibility-test-matrices/main/client-chain-b.json
@@ -3,7 +3,8 @@
   "chain-b": ["main"],
   "entrypoint": ["TestClientTestSuite"],
   "test": [
-    "TestClientUpdateProposal_Succeeds"
+    "TestClientUpdateProposal_Succeeds",
+    "TestAllowedClientsParam"
   ],
   "relayer-type": ["rly"],
   "chain-binary": ["simd"],

--- a/e2e/tests/core/02-client/client_test.go
+++ b/e2e/tests/core/02-client/client_test.go
@@ -272,7 +272,7 @@ func (s *ClientTestSuite) TestAllowedClientsParam() {
 	})
 
 	allowedClient := ibcexported.Solomachine
-	t.Run("change the allowed client to only allow localhost clients", func(t *testing.T) {
+	t.Run("change the allowed client to only allow solomachine clients", func(t *testing.T) {
 		if testvalues.SelfParamsFeatureReleases.IsSupported(chainAVersion) {
 			authority, err := s.QueryModuleAccountAddress(ctx, govtypes.ModuleName, chainA)
 			s.Require().NoError(err)

--- a/e2e/tests/core/02-client/client_test.go
+++ b/e2e/tests/core/02-client/client_test.go
@@ -1,4 +1,4 @@
-package e2e
+package client
 
 import (
 	"context"
@@ -23,6 +23,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	paramsproposaltypes "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	"github.com/cosmos/ibc-go/e2e/dockerutil"
 	"github.com/cosmos/ibc-go/e2e/testsuite"
 	"github.com/cosmos/ibc-go/e2e/testvalues"
@@ -56,6 +58,15 @@ func (s *ClientTestSuite) Status(ctx context.Context, chain ibc.Chain, clientID 
 	}
 
 	return res.Status, nil
+}
+
+// QueryAllowedClients queries the on-chain AllowedClients parameter for 02-client
+func (s *ClientTestSuite) QueryAllowedClients(ctx context.Context, chain ibc.Chain) []string {
+	queryClient := s.GetChainGRCPClients(chain).ClientQueryClient
+	res, err := queryClient.ClientParams(ctx, &clienttypes.QueryClientParamsRequest{})
+	s.Require().NoError(err)
+
+	return res.Params.AllowedClients
 }
 
 func (s *ClientTestSuite) TestClientUpdateProposal_Succeeds() {
@@ -239,6 +250,57 @@ func (s *ClientTestSuite) TestClient_Update_Misbehaviour() {
 		status, err := s.QueryClientStatus(ctx, chainA, ibctesting.FirstClientID)
 		s.Require().NoError(err)
 		s.Require().Equal(ibcexported.Frozen.String(), status)
+	})
+}
+
+// TestAllowedClientsParam tests changing the AllowedClients parameter using a governance proposal
+func (s *ClientTestSuite) TestAllowedClientsParam() {
+	t := s.T()
+	ctx := context.TODO()
+
+	_, _ = s.SetupChainsRelayerAndChannel(ctx, s.TransferChannelOptions())
+	chainA, chainB := s.GetChains()
+	chainAVersion := chainA.Config().Images[0].Version
+
+	chainAWallet := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount)
+
+	s.Require().NoError(test.WaitForBlocks(ctx, 1, chainA, chainB), "failed to wait for blocks")
+
+	t.Run("ensure allowed clients are set to the default", func(t *testing.T) {
+		allowedClients := s.QueryAllowedClients(ctx, chainA)
+		s.Require().Equal(clienttypes.DefaultAllowedClients, allowedClients)
+	})
+
+	allowedClient := ibcexported.Solomachine
+	t.Run("change the allowed client to only allow localhost clients", func(t *testing.T) {
+		if testvalues.SelfParamsFeatureReleases.IsSupported(chainAVersion) {
+			authority, err := s.QueryModuleAccountAddress(ctx, govtypes.ModuleName, chainA)
+			s.Require().NoError(err)
+			s.Require().NotNil(authority)
+
+			msg := clienttypes.NewMsgUpdateParams(authority.String(), clienttypes.NewParams(allowedClient))
+			s.ExecuteGovProposalV1(ctx, msg, chainA, chainAWallet, 1)
+		} else {
+			value, err := tmjson.Marshal([]string{allowedClient})
+			s.Require().NoError(err)
+			changes := []paramsproposaltypes.ParamChange{
+				paramsproposaltypes.NewParamChange(ibcexported.ModuleName, string(clienttypes.KeyAllowedClients), string(value)),
+			}
+
+			proposal := paramsproposaltypes.NewParameterChangeProposal(ibctesting.Title, ibctesting.Description, changes)
+			s.ExecuteGovProposal(ctx, chainA, chainAWallet, proposal)
+		}
+	})
+
+	t.Run("validate the param was successfully changed", func(t *testing.T) {
+		allowedClients := s.QueryAllowedClients(ctx, chainA)
+		s.Require().Equal([]string{allowedClient}, allowedClients)
+	})
+
+	t.Run("ensure querying non-allowed client's status returns Unauthorized Status", func(t *testing.T) {
+		status, err := s.QueryClientStatus(ctx, chainA, ibctesting.FirstClientID)
+		s.Require().NoError(err)
+		s.Require().Equal(ibcexported.Unauthorized.String(), status)
 	})
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #2120


### Commit Message / Changelog Entry

```bash
e2e: add e2e test for modifying client params
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
