### PR TITLE
chore: make UpgradeError a reference type instead of value type

### DIFF
--- a/modules/core/03-connection/keeper/verify_test.go
+++ b/modules/core/03-connection/keeper/verify_test.go
@@ -685,7 +685,7 @@ func (suite *KeeperTestSuite) TestVerifyNextSequenceRecv() {
 func (suite *KeeperTestSuite) TestVerifyUpgradeErrorReceipt() {
 	var (
 		path         *ibctesting.Path
-		upgradeError channeltypes.UpgradeError
+		upgradeError *channeltypes.UpgradeError
 	)
 
 	cases := []struct {

--- a/modules/core/04-channel/keeper/grpc_query_test.go
+++ b/modules/core/04-channel/keeper/grpc_query_test.go
@@ -1460,7 +1460,7 @@ func (suite *KeeperTestSuite) TestQueryNextSequenceReceive() {
 func (suite *KeeperTestSuite) TestQueryUpgradeError() {
 	var (
 		req        *types.QueryUpgradeErrorRequest
-		upgradeErr types.UpgradeError
+		upgradeErr *types.UpgradeError
 	)
 
 	testCases := []struct {

--- a/modules/core/04-channel/types/upgrade.go
+++ b/modules/core/04-channel/types/upgrade.go
@@ -81,31 +81,34 @@ type UpgradeError struct {
 	sequence uint64
 }
 
+var _ error = &UpgradeError{}
+
 // NewUpgradeError returns a new UpgradeError instance.
-func NewUpgradeError(upgradeSequence uint64, err error) UpgradeError {
-	return UpgradeError{
+func NewUpgradeError(upgradeSequence uint64, err error) *UpgradeError {
+	return &UpgradeError{
 		err:      err,
 		sequence: upgradeSequence,
 	}
 }
 
 // Error implements the error interface, returning the underlying error which caused the upgrade to fail.
-func (u UpgradeError) Error() string {
+func (u *UpgradeError) Error() string {
 	return u.err.Error()
 }
 
 // Is returns true if the underlying error is of the given err type.
-func (u UpgradeError) Is(err error) bool {
+func (u *UpgradeError) Is(err error) bool {
 	return errors.Is(u.err, err)
 }
 
 // Unwrap returns the base error that caused the upgrade to fail.
-func (u UpgradeError) Unwrap() error {
+func (u *UpgradeError) Unwrap() error {
+	var baseError = u.err
 	for {
-		if err := errors.Unwrap(u.err); err != nil {
-			u.err = err
+		if err := errors.Unwrap(baseError); err != nil {
+			baseError = err
 		} else {
-			return u.err
+			return baseError
 		}
 	}
 }

--- a/modules/core/04-channel/types/upgrade_test.go
+++ b/modules/core/04-channel/types/upgrade_test.go
@@ -8,7 +8,7 @@ import (
 
 func (suite *TypesTestSuite) TestUpgradeErrorIsOf() {
 	var (
-		upgradeError channeltypes.UpgradeError
+		upgradeError *channeltypes.UpgradeError
 		intputErr    error
 	)
 
@@ -25,7 +25,7 @@ func (suite *TypesTestSuite) TestUpgradeErrorIsOf() {
 		{
 			msg: "not equal to nil error",
 			malleate: func() {
-				upgradeError = channeltypes.UpgradeError{}
+				upgradeError = &channeltypes.UpgradeError{}
 			},
 			expPass: false,
 		},
@@ -38,17 +38,9 @@ func (suite *TypesTestSuite) TestUpgradeErrorIsOf() {
 			expPass: true,
 		},
 		{
-			msg: "nil underlying error and target",
-			malleate: func() {
-				upgradeError = channeltypes.UpgradeError{}
-				intputErr = channeltypes.UpgradeError{}
-			},
-			expPass: true,
-		},
-		{
 			msg: "empty upgrade and non nil target",
 			malleate: func() {
-				upgradeError = channeltypes.UpgradeError{}
+				upgradeError = &channeltypes.UpgradeError{}
 			},
 			expPass: false,
 		},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

There is a small issue with leaving the `UpgradeError` as a value type.

Since we want the method signature of the  keeper functions to be `error`, we would need to return a struct value instead of a method receiver. This would in turn break any `err != nil` checks. My moving the functions to methods, nil checks should work as expected.

I made a small modification to the `Unwrap` function so as to not accidentally mutate state (`u.err`).


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
