### PR TITLE
e2e: fix authz invalid transfer authorisations test

### DIFF
--- a/e2e/tests/transfer/authz_test.go
+++ b/e2e/tests/transfer/authz_test.go
@@ -6,6 +6,7 @@ import (
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	test "github.com/strangelove-ventures/interchaintest/v7/testutil"
 	"github.com/stretchr/testify/suite"
@@ -180,6 +181,7 @@ func (suite *AuthzTransferTestSuite) TestAuthz_InvalidTransferAuthorizations() {
 	relayer, channelA := suite.SetupChainsRelayerAndChannel(ctx, suite.TransferChannelOptions())
 	chainA, chainB := suite.GetChains()
 
+	chainAVersion := chainA.Config().Images[0].Version
 	chainADenom := chainA.Config().Denom
 
 	granterWallet := suite.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount)
@@ -248,7 +250,11 @@ func (suite *AuthzTransferTestSuite) TestAuthz_InvalidTransferAuthorizations() {
 			}
 
 			resp := suite.BroadcastMessages(context.TODO(), chainA, granteeWallet, msgExec)
-			suite.AssertTxFailure(resp, ibcerrors.ErrInsufficientFunds)
+			if testvalues.IbcErrorsFeatureReleases.IsSupported(chainAVersion) {
+				suite.AssertTxFailure(resp, ibcerrors.ErrInsufficientFunds)
+			} else {
+				suite.AssertTxFailure(resp, sdkerrors.ErrInsufficientFunds)
+			}
 		})
 
 		t.Run("verify granter wallet amount", func(t *testing.T) {
@@ -300,7 +306,11 @@ func (suite *AuthzTransferTestSuite) TestAuthz_InvalidTransferAuthorizations() {
 			}
 
 			resp := suite.BroadcastMessages(context.TODO(), chainA, granteeWallet, msgExec)
-			suite.AssertTxFailure(resp, ibcerrors.ErrInvalidAddress)
+			if testvalues.IbcErrorsFeatureReleases.IsSupported(chainAVersion) {
+				suite.AssertTxFailure(resp, ibcerrors.ErrInvalidAddress)
+			} else {
+				suite.AssertTxFailure(resp, sdkerrors.ErrInvalidAddress)
+			}
 		})
 	})
 }

--- a/e2e/testvalues/values.go
+++ b/e2e/testvalues/values.go
@@ -88,3 +88,8 @@ var TotalEscrowFeatureReleases = semverutil.FeatureReleases{
 		"v7.1",
 	},
 }
+
+// IbcErrorsFeatureReleases represents the releases the IBC module level errors was released in.
+var IbcErrorsFeatureReleases = semverutil.FeatureReleases{
+	MajorVersion: "v8.0",
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX


### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
