### PR TITLE
chore: use sdkmath alias for cosmossdk.io/math

### DIFF
--- a/e2e/tests/transfer/base_test.go
+++ b/e2e/tests/transfer/base_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	paramsproposaltypes "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
@@ -75,7 +75,7 @@ func (s *TransferTestSuite) TestMsgTransfer_Succeeds_Nonincentivized() {
 			actualTotalEscrow, err := s.QueryTotalEscrowForDenom(ctx, chainA, chainADenom)
 			s.Require().NoError(err)
 
-			expectedTotalEscrow := sdk.NewCoin(chainADenom, math.NewInt(testvalues.IBCTransferAmount))
+			expectedTotalEscrow := sdk.NewCoin(chainADenom, sdkmath.NewInt(testvalues.IBCTransferAmount))
 			s.Require().Equal(expectedTotalEscrow, actualTotalEscrow)
 		}
 	})

--- a/e2e/tests/upgrades/upgrade_test.go
+++ b/e2e/tests/upgrades/upgrade_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
@@ -668,7 +668,7 @@ func (s *UpgradeTestSuite) TestV7ToV7_1ChainUpgrade() {
 		actualTotalEscrow, err := s.QueryTotalEscrowForDenom(ctx, chainA, chainADenom)
 		s.Require().NoError(err)
 
-		expectedTotalEscrow := sdk.NewCoin(chainADenom, math.NewInt(testvalues.IBCTransferAmount))
+		expectedTotalEscrow := sdk.NewCoin(chainADenom, sdkmath.NewInt(testvalues.IBCTransferAmount))
 		s.Require().Equal(expectedTotalEscrow, actualTotalEscrow) // migration has run and total escrow amount has been set
 	})
 }

--- a/modules/apps/27-interchain-accounts/simulation/genesis_test.go
+++ b/modules/apps/27-interchain-accounts/simulation/genesis_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -34,7 +34,7 @@ func TestRandomizedGenState(t *testing.T) {
 		Rand:         r,
 		NumBonded:    3,
 		Accounts:     simtypes.RandomAccounts(r, 3),
-		InitialStake: math.NewInt(1000),
+		InitialStake: sdkmath.NewInt(1000),
 		GenState:     make(map[string]json.RawMessage),
 	}
 

--- a/modules/apps/transfer/keeper/genesis_test.go
+++ b/modules/apps/transfer/keeper/genesis_test.go
@@ -3,7 +3,7 @@ package keeper_test
 import (
 	"fmt"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
@@ -38,7 +38,7 @@ func (suite *KeeperTestSuite) TestGenesis() {
 		suite.chainA.GetSimApp().TransferKeeper.SetDenomTrace(suite.chainA.GetContext(), denomTrace)
 
 		denom := denomTrace.IBCDenom()
-		amount, ok := math.NewIntFromString(pathAndEscrowAmount.escrow)
+		amount, ok := sdkmath.NewIntFromString(pathAndEscrowAmount.escrow)
 		suite.Require().True(ok)
 		escrows = append(sdk.NewCoins(sdk.NewCoin(denom, amount)), escrows...)
 		suite.chainA.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainA.GetContext(), sdk.NewCoin(denom, amount))

--- a/modules/apps/transfer/keeper/grpc_query_test.go
+++ b/modules/apps/transfer/keeper/grpc_query_test.go
@@ -3,7 +3,7 @@ package keeper_test
 import (
 	"fmt"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
@@ -266,7 +266,7 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 func (suite *KeeperTestSuite) TestTotalEscrowForDenom() {
 	var (
 		req             *types.QueryTotalEscrowForDenomRequest
-		expEscrowAmount math.Int
+		expEscrowAmount sdkmath.Int
 	)
 
 	testCases := []struct {
@@ -281,7 +281,7 @@ func (suite *KeeperTestSuite) TestTotalEscrowForDenom() {
 					Denom: sdk.DefaultBondDenom,
 				}
 
-				expEscrowAmount = math.NewInt(100)
+				expEscrowAmount = sdkmath.NewInt(100)
 				suite.chainA.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainA.GetContext(), sdk.NewCoin(sdk.DefaultBondDenom, expEscrowAmount))
 			},
 			true,
@@ -295,7 +295,7 @@ func (suite *KeeperTestSuite) TestTotalEscrowForDenom() {
 				}
 
 				suite.chainA.GetSimApp().TransferKeeper.SetDenomTrace(suite.chainA.GetContext(), denomTrace)
-				expEscrowAmount, ok := math.NewIntFromString("100000000000000000000")
+				expEscrowAmount, ok := sdkmath.NewIntFromString("100000000000000000000")
 				suite.Require().True(ok)
 				suite.chainA.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainA.GetContext(), sdk.NewCoin(sdk.DefaultBondDenom, expEscrowAmount))
 

--- a/modules/apps/transfer/keeper/invariants_test.go
+++ b/modules/apps/transfer/keeper/invariants_test.go
@@ -1,9 +1,9 @@
 package keeper_test
 
 import (
-	"cosmossdk.io/math"
-
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/cosmos/ibc-go/v7/modules/apps/transfer/keeper"
 	"github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 )
@@ -23,7 +23,7 @@ func (suite *KeeperTestSuite) TestTotalEscrowPerDenomInvariant() {
 			"fails with broken invariant",
 			func() {
 				// set amount for denom higher than actual value in escrow
-				amount := math.NewInt(200)
+				amount := sdkmath.NewInt(200)
 				suite.chainA.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainA.GetContext(), sdk.NewCoin(sdk.DefaultBondDenom, amount))
 			},
 			false,
@@ -38,7 +38,7 @@ func (suite *KeeperTestSuite) TestTotalEscrowPerDenomInvariant() {
 			path := NewTransferPath(suite.chainA, suite.chainB)
 			suite.coordinator.Setup(path)
 
-			amount := math.NewInt(100)
+			amount := sdkmath.NewInt(100)
 
 			// send coins from chain A to chain B so that we have them in escrow
 			coin := sdk.NewCoin(sdk.DefaultBondDenom, amount)

--- a/modules/apps/transfer/keeper/keeper_test.go
+++ b/modules/apps/transfer/keeper/keeper_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -52,7 +52,7 @@ func TestKeeperTestSuite(t *testing.T) {
 
 func (suite *KeeperTestSuite) TestSetGetTotalEscrowForDenom() {
 	const denom = "atom"
-	var expAmount math.Int
+	var expAmount sdkmath.Int
 
 	testCases := []struct {
 		name     string
@@ -67,21 +67,21 @@ func (suite *KeeperTestSuite) TestSetGetTotalEscrowForDenom() {
 		{
 			"success: with escrow amount > 2^63",
 			func() {
-				expAmount, _ = math.NewIntFromString("100000000000000000000")
+				expAmount, _ = sdkmath.NewIntFromString("100000000000000000000")
 			},
 			true,
 		},
 		{
 			"success: escrow amount 0 is not stored",
 			func() {
-				expAmount = math.ZeroInt()
+				expAmount = sdkmath.ZeroInt()
 			},
 			true,
 		},
 		{
 			"failure: setter panics with negative escrow amount",
 			func() {
-				expAmount = math.NewInt(-1)
+				expAmount = sdkmath.NewInt(-1)
 			},
 			false,
 		},
@@ -92,7 +92,7 @@ func (suite *KeeperTestSuite) TestSetGetTotalEscrowForDenom() {
 
 		suite.Run(tc.name, func() {
 			suite.SetupTest() // reset
-			expAmount = math.NewInt(100)
+			expAmount = sdkmath.NewInt(100)
 			ctx := suite.chainA.GetContext()
 
 			tc.malleate()
@@ -115,7 +115,7 @@ func (suite *KeeperTestSuite) TestSetGetTotalEscrowForDenom() {
 					suite.chainA.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(ctx, sdk.NewCoin(denom, expAmount))
 				})
 				total := suite.chainA.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(ctx, denom)
-				suite.Require().Equal(math.ZeroInt(), total.Amount)
+				suite.Require().Equal(sdkmath.ZeroInt(), total.Amount)
 			}
 		})
 	}
@@ -137,7 +137,7 @@ func (suite *KeeperTestSuite) TestGetAllDenomEscrows() {
 			"success",
 			func() {
 				denom := "uatom"
-				amount := math.NewInt(100)
+				amount := sdkmath.NewInt(100)
 				expDenomEscrows = append(expDenomEscrows, sdk.NewCoin(denom, amount))
 
 				bz := cdc.MustMarshal(&sdk.IntProto{Int: amount})
@@ -149,14 +149,14 @@ func (suite *KeeperTestSuite) TestGetAllDenomEscrows() {
 			"success: multiple denoms",
 			func() {
 				denom := "uatom"
-				amount := math.NewInt(100)
+				amount := sdkmath.NewInt(100)
 				expDenomEscrows = append(expDenomEscrows, sdk.NewCoin(denom, amount))
 
 				bz := cdc.MustMarshal(&sdk.IntProto{Int: amount})
 				store.Set(types.TotalEscrowForDenomKey(denom), bz)
 
 				denom = "bar/foo"
-				amount = math.NewInt(50)
+				amount = sdkmath.NewInt(50)
 				expDenomEscrows = append(expDenomEscrows, sdk.NewCoin(denom, amount))
 
 				bz = cdc.MustMarshal(&sdk.IntProto{Int: amount})
@@ -168,7 +168,7 @@ func (suite *KeeperTestSuite) TestGetAllDenomEscrows() {
 			"success: denom with non-alphanumeric characters",
 			func() {
 				denom := "ibc/123-456"
-				amount := math.NewInt(100)
+				amount := sdkmath.NewInt(100)
 				expDenomEscrows = append(expDenomEscrows, sdk.NewCoin(denom, amount))
 
 				bz := cdc.MustMarshal(&sdk.IntProto{Int: amount})
@@ -180,7 +180,7 @@ func (suite *KeeperTestSuite) TestGetAllDenomEscrows() {
 			"failure: empty denom",
 			func() {
 				denom := ""
-				amount := math.ZeroInt()
+				amount := sdkmath.ZeroInt()
 
 				bz := cdc.MustMarshal(&sdk.IntProto{Int: amount})
 				store.Set(types.TotalEscrowForDenomKey(denom), bz)
@@ -191,7 +191,7 @@ func (suite *KeeperTestSuite) TestGetAllDenomEscrows() {
 			"failure: wrong prefix key",
 			func() {
 				denom := "uatom"
-				amount := math.ZeroInt()
+				amount := sdkmath.ZeroInt()
 
 				bz := cdc.MustMarshal(&sdk.IntProto{Int: amount})
 				store.Set([]byte(fmt.Sprintf("wrong-prefix/%s", denom)), bz)

--- a/modules/apps/transfer/keeper/mbt_relay_test.go
+++ b/modules/apps/transfer/keeper/mbt_relay_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	"github.com/cometbft/cometbft/crypto"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -88,7 +88,7 @@ type Balance struct {
 	ID      string
 	Address string
 	Denom   string
-	Amount  math.Int
+	Amount  sdkmath.Int
 }
 
 func AddressFromString(address string) string {
@@ -168,12 +168,12 @@ func OnRecvPacketTestCaseFromTla(tc TlaOnRecvPacketTestCase) OnRecvPacketTestCas
 var addressMap = make(map[string]string)
 
 type Bank struct {
-	balances map[OwnedCoin]math.Int
+	balances map[OwnedCoin]sdkmath.Int
 }
 
 // Make an empty bank
 func MakeBank() Bank {
-	return Bank{balances: make(map[OwnedCoin]math.Int)}
+	return Bank{balances: make(map[OwnedCoin]sdkmath.Int)}
 }
 
 // Subtract other bank from this bank
@@ -196,7 +196,7 @@ func (bank *Bank) Sub(other *Bank) Bank {
 }
 
 // Set specific bank balance
-func (bank *Bank) SetBalance(address string, denom string, amount math.Int) {
+func (bank *Bank) SetBalance(address string, denom string, amount sdkmath.Int) {
 	bank.balances[OwnedCoin{address, denom}] = amount
 }
 

--- a/modules/apps/transfer/keeper/migrations_test.go
+++ b/modules/apps/transfer/keeper/migrations_test.go
@@ -3,7 +3,7 @@ package keeper_test
 import (
 	"fmt"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktestutil "github.com/cosmos/cosmos-sdk/x/bank/testutil"
 
@@ -167,7 +167,7 @@ func (suite *KeeperTestSuite) TestMigrateTotalEscrowForDenom() {
 	testCases := []struct {
 		msg               string
 		malleate          func()
-		expectedEscrowAmt math.Int
+		expectedEscrowAmt sdkmath.Int
 	}{
 		{
 			"success: one native denom escrowed in one channel",
@@ -179,7 +179,7 @@ func (suite *KeeperTestSuite) TestMigrateTotalEscrowForDenom() {
 				// funds the escrow account to have balance
 				suite.Require().NoError(banktestutil.FundAccount(suite.chainA.GetSimApp().BankKeeper, suite.chainA.GetContext(), escrowAddress, sdk.NewCoins(coin)))
 			},
-			math.NewInt(100),
+			sdkmath.NewInt(100),
 		},
 		{
 			"success: one native denom escrowed in two channels",
@@ -197,7 +197,7 @@ func (suite *KeeperTestSuite) TestMigrateTotalEscrowForDenom() {
 				suite.Require().NoError(banktestutil.FundAccount(suite.chainA.GetSimApp().BankKeeper, suite.chainA.GetContext(), escrowAddress1, sdk.NewCoins(coin1)))
 				suite.Require().NoError(banktestutil.FundAccount(suite.chainA.GetSimApp().BankKeeper, suite.chainA.GetContext(), escrowAddress2, sdk.NewCoins(coin2)))
 			},
-			math.NewInt(200),
+			sdkmath.NewInt(200),
 		},
 		{
 			"success: valid ibc denom escrowed in one channel",

--- a/modules/apps/transfer/keeper/relay_test.go
+++ b/modules/apps/transfer/keeper/relay_test.go
@@ -3,7 +3,7 @@ package keeper_test
 import (
 	"fmt"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktestutil "github.com/cosmos/cosmos-sdk/x/bank/testutil"
 
@@ -22,7 +22,7 @@ func (suite *KeeperTestSuite) TestSendTransfer() {
 		sender          sdk.AccAddress
 		timeoutHeight   clienttypes.Height
 		memo            string
-		expEscrowAmount math.Int // total amount in escrow for denom on receiving chain
+		expEscrowAmount sdkmath.Int // total amount in escrow for denom on receiving chain
 	)
 
 	testCases := []struct {
@@ -33,14 +33,14 @@ func (suite *KeeperTestSuite) TestSendTransfer() {
 		{
 			"successful transfer with native token",
 			func() {
-				expEscrowAmount = math.NewInt(100)
+				expEscrowAmount = sdkmath.NewInt(100)
 			}, true,
 		},
 		{
 			"successful transfer from source chain with memo",
 			func() {
 				memo = "memo" //nolint:goconst
-				expEscrowAmount = math.NewInt(100)
+				expEscrowAmount = sdkmath.NewInt(100)
 			}, true,
 		},
 		{
@@ -102,7 +102,7 @@ func (suite *KeeperTestSuite) TestSendTransfer() {
 			"SendPacket fails, timeout height and timeout timestamp are zero",
 			func() {
 				timeoutHeight = clienttypes.ZeroHeight()
-				expEscrowAmount = math.NewInt(100)
+				expEscrowAmount = sdkmath.NewInt(100)
 			}, false,
 		},
 	}
@@ -118,7 +118,7 @@ func (suite *KeeperTestSuite) TestSendTransfer() {
 			sender = suite.chainA.SenderAccount.GetAddress()
 			memo = ""
 			timeoutHeight = suite.chainB.GetTimeoutHeight()
-			expEscrowAmount = math.ZeroInt()
+			expEscrowAmount = sdkmath.ZeroInt()
 
 			// create IBC token on chainA
 			transferMsg := types.NewMsgTransfer(path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, coin, suite.chainB.SenderAccount.GetAddress().String(), suite.chainA.SenderAccount.GetAddress().String(), suite.chainA.GetTimeoutHeight(), 0, "")
@@ -233,7 +233,7 @@ func (suite *KeeperTestSuite) TestSendTransferSetsTotalEscrowAmountForSourceIBCT
 
 	// check total amount in escrow of sent token on sending chain
 	totalEscrow := suite.chainB.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainB.GetContext(), coin.GetDenom())
-	suite.Require().Equal(math.NewInt(100), totalEscrow.Amount)
+	suite.Require().Equal(sdkmath.NewInt(100), totalEscrow.Amount)
 }
 
 // test receiving coin on chainB with coin that orignate on chainA and
@@ -243,10 +243,10 @@ func (suite *KeeperTestSuite) TestSendTransferSetsTotalEscrowAmountForSourceIBCT
 func (suite *KeeperTestSuite) TestOnRecvPacket() {
 	var (
 		trace           types.DenomTrace
-		amount          math.Int
+		amount          sdkmath.Int
 		receiver        string
 		memo            string
-		expEscrowAmount math.Int // total amount in escrow for denom on receiving chain
+		expEscrowAmount sdkmath.Int // total amount in escrow for denom on receiving chain
 	)
 
 	testCases := []struct {
@@ -262,8 +262,8 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 		{
 			"success receive on source chain of half the amount",
 			func() {
-				amount = math.NewInt(50)
-				expEscrowAmount = math.NewInt(50)
+				amount = sdkmath.NewInt(50)
+				expEscrowAmount = sdkmath.NewInt(50)
 			}, true, true,
 		},
 		{
@@ -287,14 +287,14 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			func() {
 				trace = types.DenomTrace{}
 				amount = sdk.ZeroInt()
-				expEscrowAmount = math.NewInt(100)
+				expEscrowAmount = sdkmath.NewInt(100)
 			}, true, false,
 		},
 		{
 			"invalid receiver address",
 			func() {
 				receiver = "gaia1scqhwpgsmr6vmztaa7suurfl52my6nd2kmrudl"
-				expEscrowAmount = math.NewInt(100)
+				expEscrowAmount = sdkmath.NewInt(100)
 			}, true, false,
 		},
 
@@ -312,7 +312,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			"tries to unescrow more tokens than allowed",
 			func() {
 				amount = sdk.NewInt(1000000)
-				expEscrowAmount = math.NewInt(100)
+				expEscrowAmount = sdkmath.NewInt(100)
 			}, true, false,
 		},
 
@@ -329,7 +329,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			"failure: receive on module account on source chain",
 			func() {
 				receiver = suite.chainB.GetSimApp().AccountKeeper.GetModuleAddress(types.ModuleName).String()
-				expEscrowAmount = math.NewInt(100)
+				expEscrowAmount = sdkmath.NewInt(100)
 			}, true, false,
 		},
 	}
@@ -344,9 +344,9 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			suite.coordinator.Setup(path)
 			receiver = suite.chainB.SenderAccount.GetAddress().String() // must be explicitly changed in malleate
 
-			memo = ""                        // can be explicitly changed in malleate
-			amount = sdk.NewInt(100)         // must be explicitly changed in malleate
-			expEscrowAmount = math.ZeroInt() // total amount in escrow of voucher denom on receiving chain
+			memo = ""                           // can be explicitly changed in malleate
+			amount = sdk.NewInt(100)            // must be explicitly changed in malleate
+			expEscrowAmount = sdkmath.ZeroInt() // total amount in escrow of voucher denom on receiving chain
 			seq := uint64(1)
 
 			if tc.recvIsSource {
@@ -436,7 +436,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacketSetsTotalEscrowAmountForSourceIBCT
 	*/
 
 	seq := uint64(1)
-	amount := math.NewInt(100)
+	amount := sdkmath.NewInt(100)
 	timeout := suite.chainA.GetTimeoutHeight()
 
 	// setup
@@ -487,7 +487,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacketSetsTotalEscrowAmountForSourceIBCT
 
 	suite.chainB.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainB.GetContext(), coin)
 	totalEscrowChainB := suite.chainB.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainB.GetContext(), coin.GetDenom())
-	suite.Require().Equal(math.NewInt(100), totalEscrowChainB.Amount)
+	suite.Require().Equal(sdkmath.NewInt(100), totalEscrowChainB.Amount)
 
 	// execute onRecvPacket, when chaninB receives the source token the escrow amount should decrease
 	err := suite.chainB.GetSimApp().TransferKeeper.OnRecvPacket(suite.chainB.GetContext(), packet, data)
@@ -495,7 +495,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacketSetsTotalEscrowAmountForSourceIBCT
 
 	// check total amount in escrow of sent token on reveiving chain
 	totalEscrowChainB = suite.chainB.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainB.GetContext(), coin.GetDenom())
-	suite.Require().Equal(math.ZeroInt(), totalEscrowChainB.Amount)
+	suite.Require().Equal(sdkmath.ZeroInt(), totalEscrowChainB.Amount)
 }
 
 // TestOnAcknowledgementPacket tests that successful acknowledgement is a no-op
@@ -507,9 +507,9 @@ func (suite *KeeperTestSuite) TestOnAcknowledgementPacket() {
 		successAck      = channeltypes.NewResultAcknowledgement([]byte{byte(1)})
 		failedAck       = channeltypes.NewErrorAcknowledgement(fmt.Errorf("failed packet transfer"))
 		trace           types.DenomTrace
-		amount          math.Int
+		amount          sdkmath.Int
 		path            *ibctesting.Path
-		expEscrowAmount math.Int
+		expEscrowAmount sdkmath.Int
 	)
 
 	testCases := []struct {
@@ -548,7 +548,7 @@ func (suite *KeeperTestSuite) TestOnAcknowledgementPacket() {
 
 				// set escrow amount that would have been stored after successful execution of MsgTransfer
 				suite.chainA.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainA.GetContext(), sdk.NewCoin(sdk.DefaultBondDenom, amount))
-				expEscrowAmount = math.NewInt(100)
+				expEscrowAmount = sdkmath.NewInt(100)
 			}, false, false,
 		},
 		{
@@ -572,7 +572,7 @@ func (suite *KeeperTestSuite) TestOnAcknowledgementPacket() {
 			path = NewTransferPath(suite.chainA, suite.chainB)
 			suite.coordinator.Setup(path)
 			amount = sdk.NewInt(100) // must be explicitly changed
-			expEscrowAmount = math.ZeroInt()
+			expEscrowAmount = sdkmath.ZeroInt()
 
 			tc.malleate()
 
@@ -633,7 +633,7 @@ func (suite *KeeperTestSuite) TestOnAcknowledgementPacketSetsTotalEscrowAmountFo
 	*/
 
 	seq := uint64(1)
-	amount := math.NewInt(100)
+	amount := sdkmath.NewInt(100)
 	ack := channeltypes.NewErrorAcknowledgement(fmt.Errorf("failed packet transfer"))
 
 	// set up
@@ -679,14 +679,14 @@ func (suite *KeeperTestSuite) TestOnAcknowledgementPacketSetsTotalEscrowAmountFo
 
 	suite.chainB.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainB.GetContext(), coin)
 	totalEscrowChainB := suite.chainB.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainB.GetContext(), coin.GetDenom())
-	suite.Require().Equal(math.NewInt(100), totalEscrowChainB.Amount)
+	suite.Require().Equal(sdkmath.NewInt(100), totalEscrowChainB.Amount)
 
 	err := suite.chainB.GetSimApp().TransferKeeper.OnAcknowledgementPacket(suite.chainB.GetContext(), packet, data, ack)
 	suite.Require().NoError(err)
 
 	// check total amount in escrow of sent token on sending chain
 	totalEscrowChainB = suite.chainB.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainB.GetContext(), coin.GetDenom())
-	suite.Require().Equal(math.ZeroInt(), totalEscrowChainB.Amount)
+	suite.Require().Equal(sdkmath.ZeroInt(), totalEscrowChainB.Amount)
 }
 
 // TestOnTimeoutPacket test private refundPacket function since it is a simple
@@ -697,9 +697,9 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 	var (
 		trace           types.DenomTrace
 		path            *ibctesting.Path
-		amount          math.Int
+		amount          sdkmath.Int
 		sender          string
-		expEscrowAmount math.Int
+		expEscrowAmount sdkmath.Int
 	)
 
 	testCases := []struct {
@@ -713,7 +713,7 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 				escrow := types.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 				trace = types.ParseDenomTrace(sdk.DefaultBondDenom)
 				coin := sdk.NewCoin(trace.IBCDenom(), amount)
-				expEscrowAmount = math.ZeroInt()
+				expEscrowAmount = sdkmath.ZeroInt()
 
 				// funds the escrow account to have balance
 				suite.Require().NoError(banktestutil.FundAccount(suite.chainA.GetSimApp().BankKeeper, suite.chainA.GetContext(), escrow, sdk.NewCoins(coin)))
@@ -727,7 +727,7 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 				escrow := types.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 				trace = types.ParseDenomTrace(types.GetPrefixedDenom(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, sdk.DefaultBondDenom))
 				coin := sdk.NewCoin(trace.IBCDenom(), amount)
-				expEscrowAmount = math.ZeroInt()
+				expEscrowAmount = sdkmath.ZeroInt()
 
 				// funds the escrow account to have balance
 				suite.Require().NoError(banktestutil.FundAccount(suite.chainA.GetSimApp().BankKeeper, suite.chainA.GetContext(), escrow, sdk.NewCoins(coin)))
@@ -773,7 +773,7 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 			suite.coordinator.Setup(path)
 			amount = sdk.NewInt(100) // must be explicitly changed
 			sender = suite.chainA.SenderAccount.GetAddress().String()
-			expEscrowAmount = math.ZeroInt()
+			expEscrowAmount = sdkmath.ZeroInt()
 
 			tc.malleate()
 
@@ -829,7 +829,7 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacketSetsTotalEscrowAmountForSourceI
 	*/
 
 	seq := uint64(1)
-	amount := math.NewInt(100)
+	amount := sdkmath.NewInt(100)
 
 	// set up
 	// 2 transfer channels between chain A and chain B
@@ -873,12 +873,12 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacketSetsTotalEscrowAmountForSourceI
 
 	suite.chainB.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainB.GetContext(), coin)
 	totalEscrowChainB := suite.chainB.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainB.GetContext(), coin.GetDenom())
-	suite.Require().Equal(math.NewInt(100), totalEscrowChainB.Amount)
+	suite.Require().Equal(sdkmath.NewInt(100), totalEscrowChainB.Amount)
 
 	err := suite.chainB.GetSimApp().TransferKeeper.OnTimeoutPacket(suite.chainB.GetContext(), packet, data)
 	suite.Require().NoError(err)
 
 	// check total amount in escrow of sent token on sending chain
 	totalEscrowChainB = suite.chainB.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainB.GetContext(), coin.GetDenom())
-	suite.Require().Equal(math.ZeroInt(), totalEscrowChainB.Amount)
+	suite.Require().Equal(sdkmath.ZeroInt(), totalEscrowChainB.Amount)
 }

--- a/modules/apps/transfer/simulation/genesis_test.go
+++ b/modules/apps/transfer/simulation/genesis_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -33,7 +33,7 @@ func TestRandomizedGenState(t *testing.T) {
 		Rand:         r,
 		NumBonded:    3,
 		Accounts:     simtypes.RandomAccounts(r, 3),
-		InitialStake: math.NewInt(1000),
+		InitialStake: sdkmath.NewInt(1000),
 		GenState:     make(map[string]json.RawMessage),
 	}
 

--- a/modules/apps/transfer/types/coin.go
+++ b/modules/apps/transfer/types/coin.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -42,7 +42,7 @@ func GetPrefixedDenom(portID, channelID, baseDenom string) string {
 
 // GetTransferCoin creates a transfer coin with the port ID and channel ID
 // prefixed to the base denom.
-func GetTransferCoin(portID, channelID, baseDenom string, amount math.Int) sdk.Coin {
+func GetTransferCoin(portID, channelID, baseDenom string, amount sdkmath.Int) sdk.Coin {
 	denomTrace := ParseDenomTrace(GetPrefixedDenom(portID, channelID, baseDenom))
 	return sdk.NewCoin(denomTrace.IBCDenom(), amount)
 }

--- a/modules/core/simulation/genesis_test.go
+++ b/modules/core/simulation/genesis_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -34,7 +34,7 @@ func TestRandomizedGenState(t *testing.T) {
 		Rand:         r,
 		NumBonded:    3,
 		Accounts:     simtypes.RandomAccounts(r, 3),
-		InitialStake: math.NewInt(1000),
+		InitialStake: sdkmath.NewInt(1000),
 		GenState:     make(map[string]json.RawMessage),
 	}
 

--- a/testing/app.go
+++ b/testing/app.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
@@ -61,7 +61,7 @@ func SetupTestingApp() (TestingApp, map[string]json.RawMessage) {
 // that also act as delegators. For simplicity, each validator is bonded with a delegation
 // of one consensus engine unit (10^6) in the default token of the simapp from first genesis
 // account. A Nop logger is set in SimApp.
-func SetupWithGenesisValSet(t testing.TB, valSet *tmtypes.ValidatorSet, genAccs []authtypes.GenesisAccount, chainID string, powerReduction math.Int, balances ...banktypes.Balance) TestingApp {
+func SetupWithGenesisValSet(t testing.TB, valSet *tmtypes.ValidatorSet, genAccs []authtypes.GenesisAccount, chainID string, powerReduction sdkmath.Int, balances ...banktypes.Balance) TestingApp {
 	app, genesisState := DefaultTestingAppInit()
 
 	// ensure baseapp has a chain-id set before running InitChain

--- a/testing/simapp/state.go
+++ b/testing/simapp/state.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	tmjson "github.com/cometbft/cometbft/libs/json"
 	tmtypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -166,7 +166,7 @@ func AppStateRandomizedFn(
 		Rand:         r,
 		GenState:     genesisState,
 		Accounts:     accs,
-		InitialStake: math.NewInt(initialStake),
+		InitialStake: sdkmath.NewInt(initialStake),
 		NumBonded:    numInitiallyBonded,
 		GenTimestamp: genesisTimestamp,
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #3720 


### Commit Message / Changelog Entry

```bash
chore: use sdkmath alias for cosmossdk.io/math
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
