### PR TITLE
update 04-channel expected keepers, update method signature for verify functions

### DIFF
--- a/modules/core/03-connection/keeper/verify.go
+++ b/modules/core/03-connection/keeper/verify.go
@@ -367,12 +367,12 @@ func (k Keeper) VerifyNextSequenceRecv(
 // VerifyChannelUpgradeError verifies a proof of the provided upgrade error receipt.
 func (k Keeper) VerifyChannelUpgradeError(
 	ctx sdk.Context,
-	connection exported.ConnectionI,
-	height exported.Height,
-	proof []byte,
 	portID,
 	channelID string,
+	connection exported.ConnectionI,
 	errorReceipt channeltypes.ErrorReceipt,
+	proofErrorReceipt []byte,
+	proofHeight exported.Height,
 ) error {
 	clientID := connection.GetClientID()
 	clientState, clientStore, err := k.getClientStateAndVerificationStore(ctx, clientID)
@@ -396,9 +396,9 @@ func (k Keeper) VerifyChannelUpgradeError(
 	}
 
 	if err := clientState.VerifyMembership(
-		ctx, clientStore, k.cdc, height,
+		ctx, clientStore, k.cdc, proofHeight,
 		0, 0, // skip delay period checks for non-packet processing verification
-		proof, merklePath, bz,
+		proofErrorReceipt, merklePath, bz,
 	); err != nil {
 		return errorsmod.Wrapf(err, "failed upgrade error receipt verification for client (%s)", clientID)
 	}
@@ -410,11 +410,11 @@ func (k Keeper) VerifyChannelUpgradeError(
 // channel upgrade error.
 func (k Keeper) VerifyChannelUpgradeErrorAbsence(
 	ctx sdk.Context,
-	connection exported.ConnectionI,
-	height exported.Height,
-	proof []byte,
 	portID,
 	channelID string,
+	connection exported.ConnectionI,
+	proofErrorReceiptAbsence []byte,
+	proofHeight exported.Height,
 ) error {
 	clientID := connection.GetClientID()
 	clientState, clientStore, err := k.getClientStateAndVerificationStore(ctx, clientID)
@@ -433,9 +433,9 @@ func (k Keeper) VerifyChannelUpgradeErrorAbsence(
 	}
 
 	if err := clientState.VerifyNonMembership(
-		ctx, clientStore, k.cdc, height,
+		ctx, clientStore, k.cdc, proofHeight,
 		0, 0,
-		proof, merklePath,
+		proofErrorReceiptAbsence, merklePath,
 	); err != nil {
 		return errorsmod.Wrapf(err, "failed upgrade error receipt absence verification for client (%s)", clientID)
 	}
@@ -446,12 +446,12 @@ func (k Keeper) VerifyChannelUpgradeErrorAbsence(
 // VerifyChannelUpgrade verifies the proof that a particular proposed upgrade has been stored in the upgrade path.
 func (k Keeper) VerifyChannelUpgrade(
 	ctx sdk.Context,
-	connection exported.ConnectionI,
-	height exported.Height,
-	proof []byte,
 	portID,
 	channelID string,
+	connection exported.ConnectionI,
 	upgrade channeltypes.Upgrade,
+	proofUpgrade []byte,
+	proofHeight exported.Height,
 ) error {
 	clientID := connection.GetClientID()
 	clientState, clientStore, err := k.getClientStateAndVerificationStore(ctx, clientID)
@@ -475,9 +475,9 @@ func (k Keeper) VerifyChannelUpgrade(
 	}
 
 	if err := clientState.VerifyMembership(
-		ctx, clientStore, k.cdc, height,
+		ctx, clientStore, k.cdc, proofHeight,
 		0, 0, // skip delay period checks for non-packet processing verification
-		proof, merklePath, bz,
+		proofUpgrade, merklePath, bz,
 	); err != nil {
 		return errorsmod.Wrapf(err, "failed upgrade verification for client (%s) on channel (%s)", clientID, channelID)
 	}

--- a/modules/core/03-connection/keeper/verify_test.go
+++ b/modules/core/03-connection/keeper/verify_test.go
@@ -754,7 +754,7 @@ func (suite *KeeperTestSuite) TestVerifyUpgradeErrorReceipt() {
 			upgradeErrorReceiptKey := host.ChannelUpgradeErrorKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 			proof, proofHeight := suite.chainA.QueryProof(upgradeErrorReceiptKey)
 
-			err := suite.chainB.GetSimApp().IBCKeeper.ConnectionKeeper.VerifyChannelUpgradeError(suite.chainB.GetContext(), path.EndpointB.GetConnection(), proofHeight, proof, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, upgradeError.GetErrorReceipt())
+			err := suite.chainB.GetSimApp().IBCKeeper.ConnectionKeeper.VerifyChannelUpgradeError(suite.chainB.GetContext(), path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, path.EndpointB.GetConnection(), upgradeError.GetErrorReceipt(), proof, proofHeight)
 
 			if tc.expPass {
 				suite.Require().NoError(err)
@@ -825,7 +825,7 @@ func (suite *KeeperTestSuite) TestVerifyUpgradeErrorReceiptAbsence() {
 			upgradeErrorReceiptKey := host.ChannelUpgradeErrorKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 			proof, proofHeight := suite.chainA.QueryProof(upgradeErrorReceiptKey)
 
-			err := suite.chainB.GetSimApp().IBCKeeper.ConnectionKeeper.VerifyChannelUpgradeErrorAbsence(suite.chainB.GetContext(), path.EndpointB.GetConnection(), proofHeight, proof, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID)
+			err := suite.chainB.GetSimApp().IBCKeeper.ConnectionKeeper.VerifyChannelUpgradeErrorAbsence(suite.chainB.GetContext(), path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, path.EndpointB.GetConnection(), proof, proofHeight)
 
 			if tc.expPass {
 				suite.Require().NoError(err)
@@ -904,7 +904,7 @@ func (suite *KeeperTestSuite) TestVerifyUpgrade() {
 			channelUpgradeKey := host.ChannelUpgradeKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 			proof, proofHeight := suite.chainA.QueryProof(channelUpgradeKey)
 
-			err := suite.chainB.GetSimApp().IBCKeeper.ConnectionKeeper.VerifyChannelUpgrade(suite.chainB.GetContext(), path.EndpointB.GetConnection(), proofHeight, proof, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, upgrade)
+			err := suite.chainB.GetSimApp().IBCKeeper.ConnectionKeeper.VerifyChannelUpgrade(suite.chainB.GetContext(), path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, path.EndpointB.GetConnection(), upgrade, proof, proofHeight)
 
 			if tc.expPass {
 				suite.Require().NoError(err)

--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -250,11 +250,11 @@ func (k Keeper) startFlushUpgradeHandshake(
 	// verifies the proof that a particular proposed upgrade has been stored in the upgrade path of the counterparty
 	if err := k.connectionKeeper.VerifyChannelUpgrade(
 		ctx,
-		connection,
-		proofHeight, proofCounterpartyUpgrade,
 		channel.Counterparty.PortId,
 		channel.Counterparty.ChannelId,
+		connection,
 		counterpartyUpgrade,
+		proofCounterpartyUpgrade, proofHeight,
 	); err != nil {
 		return errorsmod.Wrap(err, "failed to verify counterparty upgrade")
 	}

--- a/modules/core/04-channel/types/expected_keepers.go
+++ b/modules/core/04-channel/types/expected_keepers.go
@@ -73,12 +73,29 @@ type ConnectionKeeper interface {
 	) error
 	VerifyChannelUpgrade(
 		ctx sdk.Context,
-		connection exported.ConnectionI,
-		height exported.Height,
-		proof []byte,
 		portID,
 		channelID string,
+		connection exported.ConnectionI,
 		upgrade Upgrade,
+		proof []byte,
+		height exported.Height,
+	) error
+	VerifyChannelUpgradeError(
+		ctx sdk.Context,
+		portID,
+		channelID string,
+		connection exported.ConnectionI,
+		errorReceipt ErrorReceipt,
+		proofErrorReceipt []byte,
+		proofHeight exported.Height,
+	) error
+	VerifyChannelUpgradeErrorAbsence(
+		ctx sdk.Context,
+		portID,
+		channelID string,
+		connection exported.ConnectionI,
+		proofErrorReceiptAbsence []byte,
+		proofHeight exported.Height,
 	) error
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

in the process of working on https://github.com/cosmos/ibc-go/issues/3747, i noticed that the param ordering of the verify functions could be updated for readability while moving these functions to the `expected_keeper` of `04-channel`.

there are still left a few method signatures left to update, see https://github.com/cosmos/ibc-go/issues/3801.

### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
