### PR TITLE
chore: Remove nolint directives for interfacer.

### DIFF
--- a/modules/apps/transfer/types/msgs.go
+++ b/modules/apps/transfer/types/msgs.go
@@ -14,8 +14,6 @@ import (
 var _ sdk.Msg = (*MsgUpdateParams)(nil)
 
 // NewMsgUpdateParams creates a new MsgUpdateParams instance
-//
-//nolint:interfacer
 func NewMsgUpdateParams(authority string, params Params) *MsgUpdateParams {
 	return &MsgUpdateParams{
 		Authority: authority,
@@ -44,8 +42,6 @@ func (msg MsgUpdateParams) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgTransfer creates a new MsgTransfer instance
-//
-//nolint:interfacer
 func NewMsgTransfer(
 	sourcePort, sourceChannel string,
 	token sdk.Coin, sender, receiver string,

--- a/modules/core/02-client/types/msgs.go
+++ b/modules/core/02-client/types/msgs.go
@@ -24,8 +24,6 @@ var (
 )
 
 // NewMsgCreateClient creates a new MsgCreateClient instance
-//
-//nolint:interfacer
 func NewMsgCreateClient(
 	clientState exported.ClientState, consensusState exported.ConsensusState, signer string,
 ) (*MsgCreateClient, error) {
@@ -94,8 +92,6 @@ func (msg MsgCreateClient) UnpackInterfaces(unpacker codectypes.AnyUnpacker) err
 }
 
 // NewMsgUpdateClient creates a new MsgUpdateClient instance
-//
-//nolint:interfacer
 func NewMsgUpdateClient(id string, clientMsg exported.ClientMessage, signer string) (*MsgUpdateClient, error) {
 	anyClientMsg, err := PackClientMessage(clientMsg)
 	if err != nil {
@@ -141,8 +137,6 @@ func (msg MsgUpdateClient) UnpackInterfaces(unpacker codectypes.AnyUnpacker) err
 }
 
 // NewMsgUpgradeClient creates a new MsgUpgradeClient instance
-//
-//nolint:interfacer
 func NewMsgUpgradeClient(clientID string, clientState exported.ClientState, consState exported.ConsensusState,
 	proofUpgradeClient, proofUpgradeConsState []byte, signer string,
 ) (*MsgUpgradeClient, error) {
@@ -219,8 +213,6 @@ func (msg MsgUpgradeClient) UnpackInterfaces(unpacker codectypes.AnyUnpacker) er
 }
 
 // NewMsgSubmitMisbehaviour creates a new MsgSubmitMisbehaviour instance.
-//
-//nolint:interfacer
 func NewMsgSubmitMisbehaviour(clientID string, misbehaviour exported.ClientMessage, signer string) (*MsgSubmitMisbehaviour, error) {
 	anyMisbehaviour, err := PackClientMessage(misbehaviour)
 	if err != nil {

--- a/modules/core/03-connection/types/msgs.go
+++ b/modules/core/03-connection/types/msgs.go
@@ -25,8 +25,6 @@ var (
 
 // NewMsgConnectionOpenInit creates a new MsgConnectionOpenInit instance. It sets the
 // counterparty connection identifier to be empty.
-//
-//nolint:interfacer
 func NewMsgConnectionOpenInit(
 	clientID, counterpartyClientID string,
 	counterpartyPrefix commitmenttypes.MerklePrefix,
@@ -79,8 +77,6 @@ func (msg MsgConnectionOpenInit) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgConnectionOpenTry creates a new MsgConnectionOpenTry instance
-//
-//nolint:interfacer
 func NewMsgConnectionOpenTry(
 	clientID, counterpartyConnectionID, counterpartyClientID string,
 	counterpartyClient exported.ClientState,
@@ -174,8 +170,6 @@ func (msg MsgConnectionOpenTry) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgConnectionOpenAck creates a new MsgConnectionOpenAck instance
-//
-//nolint:interfacer
 func NewMsgConnectionOpenAck(
 	connectionID, counterpartyConnectionID string, counterpartyClient exported.ClientState,
 	proofTry, proofClient, proofConsensus []byte,
@@ -253,8 +247,6 @@ func (msg MsgConnectionOpenAck) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgConnectionOpenConfirm creates a new MsgConnectionOpenConfirm instance
-//
-//nolint:interfacer
 func NewMsgConnectionOpenConfirm(
 	connectionID string, proofAck []byte, proofHeight clienttypes.Height,
 	signer string,

--- a/modules/core/04-channel/types/msgs.go
+++ b/modules/core/04-channel/types/msgs.go
@@ -26,8 +26,6 @@ var (
 
 // NewMsgChannelOpenInit creates a new MsgChannelOpenInit. It sets the counterparty channel
 // identifier to be empty.
-//
-//nolint:interfacer
 func NewMsgChannelOpenInit(
 	portID, version string, channelOrder Order, connectionHops []string,
 	counterpartyPortID string, signer string,
@@ -74,8 +72,6 @@ func (msg MsgChannelOpenInit) GetSigners() []sdk.AccAddress {
 // NewMsgChannelOpenTry creates a new MsgChannelOpenTry instance
 // The version string is deprecated and will be ignored by core IBC.
 // It is left as an argument for go API backwards compatibility.
-//
-//nolint:interfacer
 func NewMsgChannelOpenTry(
 	portID, version string, channelOrder Order, connectionHops []string,
 	counterpartyPortID, counterpartyChannelID, counterpartyVersion string,
@@ -132,8 +128,6 @@ func (msg MsgChannelOpenTry) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgChannelOpenAck creates a new MsgChannelOpenAck instance
-//
-//nolint:interfacer
 func NewMsgChannelOpenAck(
 	portID, channelID, counterpartyChannelID string, cpv string, proofTry []byte, proofHeight clienttypes.Height,
 	signer string,
@@ -180,8 +174,6 @@ func (msg MsgChannelOpenAck) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgChannelOpenConfirm creates a new MsgChannelOpenConfirm instance
-//
-//nolint:interfacer
 func NewMsgChannelOpenConfirm(
 	portID, channelID string, proofAck []byte, proofHeight clienttypes.Height,
 	signer string,
@@ -223,8 +215,6 @@ func (msg MsgChannelOpenConfirm) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgChannelCloseInit creates a new MsgChannelCloseInit instance
-//
-//nolint:interfacer
 func NewMsgChannelCloseInit(
 	portID string, channelID string, signer string,
 ) *MsgChannelCloseInit {
@@ -260,8 +250,6 @@ func (msg MsgChannelCloseInit) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgChannelCloseConfirm creates a new MsgChannelCloseConfirm instance
-//
-//nolint:interfacer
 func NewMsgChannelCloseConfirm(
 	portID, channelID string, proofInit []byte, proofHeight clienttypes.Height,
 	signer string,
@@ -303,8 +291,6 @@ func (msg MsgChannelCloseConfirm) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgRecvPacket constructs new MsgRecvPacket
-//
-//nolint:interfacer
 func NewMsgRecvPacket(
 	packet Packet, proofCommitment []byte, proofHeight clienttypes.Height,
 	signer string,
@@ -346,8 +332,6 @@ func (msg MsgRecvPacket) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgTimeout constructs new MsgTimeout
-//
-//nolint:interfacer
 func NewMsgTimeout(
 	packet Packet, nextSequenceRecv uint64, proofUnreceived []byte,
 	proofHeight clienttypes.Height, signer string,
@@ -386,8 +370,6 @@ func (msg MsgTimeout) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgTimeoutOnClose constructs new MsgTimeoutOnClose
-//
-//nolint:interfacer
 func NewMsgTimeoutOnClose(
 	packet Packet, nextSequenceRecv uint64,
 	proofUnreceived, proofClose []byte,
@@ -431,8 +413,6 @@ func (msg MsgTimeoutOnClose) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgAcknowledgement constructs a new MsgAcknowledgement
-//
-//nolint:interfacer
 func NewMsgAcknowledgement(
 	packet Packet,
 	ack, proofAcked []byte,


### PR DESCRIPTION
## Description

interfacer has been [deprecated](https://github.com/mvdan/interfacer) for a good while now and it isn't even included in the list
of linters enabled.

Removes the directives which are not needed.

closes: #XXXX


### Commit Message / Changelog Entry

```bash
chore: Remove nolint directives for interfacer.
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
