### PR TITLE
update app, middleware and 05-port modules with `ChanUpgradeTimeout` function

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/ibc_middleware.go
+++ b/modules/apps/27-interchain-accounts/controller/ibc_middleware.go
@@ -250,6 +250,19 @@ func (im IBCMiddleware) OnChanUpgradeRestore(ctx sdk.Context, portID, channelID 
 	return nil
 }
 
+// OnChanUpgradeTimeout implements the IBCModule interface
+func (im IBCMiddleware) OnChanUpgradeTimeout(
+	ctx sdk.Context,
+	portID, channelID string,
+	counterpartyChannel channeltypes.Channel,
+	prevErrorReceipt channeltypes.ErrorReceipt,
+	proofCounterpartyChannel,
+	proofErrorReceipt []byte,
+	proofHeight ibcexported.Height,
+) error {
+	return im.app.OnChanUpgradeTimeout(ctx, portID, channelID, counterpartyChannel, prevErrorReceipt, proofCounterpartyChannel, proofErrorReceipt, proofHeight)
+}
+
 // SendPacket implements the ICS4 Wrapper interface
 func (im IBCMiddleware) SendPacket(
 	ctx sdk.Context,

--- a/modules/apps/27-interchain-accounts/host/ibc_module.go
+++ b/modules/apps/27-interchain-accounts/host/ibc_module.go
@@ -173,3 +173,16 @@ func (im IBCModule) OnChanUpgradeOpen(ctx sdk.Context, portID, channelID string)
 func (im IBCModule) OnChanUpgradeRestore(ctx sdk.Context, portID, channelID string) error {
 	return nil
 }
+
+// OnChanUpgradeTimeout implements the IBCModule interface
+func (im IBCModule) OnChanUpgradeTimeout(
+	ctx sdk.Context,
+	portID, channelID string,
+	counterpartyChannel channeltypes.Channel,
+	prevErrorReceipt channeltypes.ErrorReceipt,
+	proofCounterpartyChannel,
+	proofErrorReceipt []byte,
+	proofHeight ibcexported.Height,
+) error {
+	return nil
+}

--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -345,6 +345,19 @@ func (im IBCMiddleware) OnChanUpgradeRestore(ctx sdk.Context, portID, channelID 
 	return im.app.OnChanUpgradeRestore(ctx, portID, channelID)
 }
 
+// OnChanUpgradeTimeout implements the IBCModule interface
+func (im IBCMiddleware) OnChanUpgradeTimeout(
+	ctx sdk.Context,
+	portID, channelID string,
+	counterpartyChannel channeltypes.Channel,
+	prevErrorReceipt channeltypes.ErrorReceipt,
+	proofCounterpartyChannel,
+	proofErrorReceipt []byte,
+	proofHeight exported.Height,
+) error {
+	return im.app.OnChanUpgradeTimeout(ctx, portID, channelID, counterpartyChannel, prevErrorReceipt, proofCounterpartyChannel, proofErrorReceipt, proofHeight)
+}
+
 // SendPacket implements the ICS4 Wrapper interface
 func (im IBCMiddleware) SendPacket(
 	ctx sdk.Context,

--- a/modules/apps/transfer/ibc_module.go
+++ b/modules/apps/transfer/ibc_module.go
@@ -325,3 +325,16 @@ func (im IBCModule) OnChanUpgradeOpen(ctx sdk.Context, portID, channelID string)
 func (im IBCModule) OnChanUpgradeRestore(ctx sdk.Context, portID, channelID string) error {
 	return nil
 }
+
+// OnChanUpgradeTimeout implements the IBCModule interface
+func (im IBCModule) OnChanUpgradeTimeout(
+	ctx sdk.Context,
+	portID, channelID string,
+	counterpartyChannel channeltypes.Channel,
+	prevErrorReceipt channeltypes.ErrorReceipt,
+	proofCounterpartyChannel,
+	proofErrorReceipt []byte,
+	proofHeight ibcexported.Height,
+) error {
+	return nil
+}

--- a/modules/core/04-channel/keeper/keeper.go
+++ b/modules/core/04-channel/keeper/keeper.go
@@ -570,3 +570,14 @@ func (k Keeper) iterateHashes(ctx sdk.Context, iterator db.Iterator, cb func(por
 		}
 	}
 }
+
+// hasInflightPackets returns true if there are packet commitments stored at the specified
+// port and channel, and false otherwise.
+//
+//lint:ignore U1000 Ignore unused function temporarily for debugging
+func (k Keeper) hasInflightPackets(ctx sdk.Context, portID, channelID string) bool {
+	iterator := sdk.KVStorePrefixIterator(ctx.KVStore(k.storeKey), []byte(host.PacketCommitmentPrefixPath(portID, channelID)))
+	defer sdk.LogDeferred(ctx.Logger(), func() error { return iterator.Close() })
+
+	return iterator.Valid()
+}

--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -13,6 +13,7 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	connectiontypes "github.com/cosmos/ibc-go/v7/modules/core/03-connection/types"
 	"github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 )
 
 // ChanUpgradeInit is called by a module to initiate a channel upgrade handshake with
@@ -310,6 +311,20 @@ func (k Keeper) ChanUpgradeAck(
 		}
 	}
 
+	return nil
+}
+
+// ChanUpgradeTimeout times out an outstanding upgrade.
+// This should be used by the initialising chain when the counterparty chain has not responded to an upgrade proposal within the specified timeout period.
+func (k Keeper) ChanUpgradeTimeout(
+	ctx sdk.Context,
+	portID, channelID string,
+	counterpartyChannel types.Channel,
+	prevErrorReceipt types.ErrorReceipt,
+	proofCounterpartyChannel,
+	proofErrorReceipt []byte,
+	proofHeight exported.Height,
+) error {
 	return nil
 }
 

--- a/modules/core/05-port/types/module.go
+++ b/modules/core/05-port/types/module.go
@@ -149,6 +149,17 @@ type UpgradableModule interface {
 		portID,
 		channelID string,
 	) error
+
+	// OnChanUpgradeTimeout times out an outstanding upgrade when the counterparty chain has not responded.
+	OnChanUpgradeTimeout(
+		ctx sdk.Context,
+		portID, channelID string,
+		counterpartyChannel channeltypes.Channel,
+		prevErrorReceipt channeltypes.ErrorReceipt,
+		proofCounterpartyChannel,
+		proofErrorReceipt []byte,
+		proofHeight exported.Height,
+	) error
 }
 
 // ICS4Wrapper implements the ICS4 interfaces that IBC applications use to send packets and acknowledgements.

--- a/testing/mock/ibc_app.go
+++ b/testing/mock/ibc_app.go
@@ -121,6 +121,16 @@ type IBCApp struct {
 		portID,
 		channelID string,
 	) error
+
+	OnChanUpgradeTimeout func(
+		ctx sdk.Context,
+		portID, channelID string,
+		counterpartyChannel channeltypes.Channel,
+		prevErrorReceipt channeltypes.ErrorReceipt,
+		proofCounterpartyChannel,
+		proofErrorReceipt []byte,
+		proofHeight exported.Height,
+	) error
 }
 
 // NewIBCApp returns a IBCApp. An empty PortID indicates the mock app doesn't bind/claim ports.

--- a/testing/mock/ibc_module.go
+++ b/testing/mock/ibc_module.go
@@ -207,6 +207,23 @@ func (im IBCModule) OnChanUpgradeRestore(ctx sdk.Context, portID, channelID stri
 	return nil
 }
 
+// OnChanUpgradeTimeout implements the IBCModule interface
+func (im IBCModule) OnChanUpgradeTimeout(
+	ctx sdk.Context,
+	portID, channelID string,
+	counterpartyChannel channeltypes.Channel,
+	prevErrorReceipt channeltypes.ErrorReceipt,
+	proofCounterpartyChannel,
+	proofErrorReceipt []byte,
+	proofHeight exported.Height,
+) error {
+	if im.IBCApp.OnChanUpgradeTimeout != nil {
+		return im.IBCApp.OnChanUpgradeTimeout(ctx, portID, channelID, counterpartyChannel, prevErrorReceipt, proofCounterpartyChannel, proofErrorReceipt, proofHeight)
+	}
+
+	return nil
+}
+
 // GetMockRecvCanaryCapabilityName generates a capability name for testing OnRecvPacket functionality.
 func GetMockRecvCanaryCapabilityName(packet channeltypes.Packet) string {
 	return fmt.Sprintf("%s%s%s%s", MockRecvCanaryCapabilityName, packet.GetDestPort(), packet.GetDestChannel(), strconv.Itoa(int(packet.GetSequence())))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

part of the work needed for #3855 

note that this PR does not actually implement the functionality of the app callbacks, it only sets up the blocker

<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
