### PR TITLE
Amend AcknowledgePacket to handle flushing

### DIFF
--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -374,7 +374,7 @@ func (k Keeper) AcknowledgePacket(
 		)
 	}
 
-	if channel.State != types.OPEN {
+	if channel.State != types.OPEN && channel.FlushStatus != types.FLUSHING {
 		return errorsmod.Wrapf(
 			types.ErrInvalidChannelState,
 			"channel state is not OPEN (got %s)", channel.State.String(),
@@ -470,6 +470,11 @@ func (k Keeper) AcknowledgePacket(
 
 	// Delete packet commitment, since the packet has been acknowledged, the commitement is no longer necessary
 	k.deletePacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+
+	if channel.FlushStatus == types.FLUSHING && !k.hasInflightPackets(ctx, packet.GetSourcePort(), packet.GetSourceChannel()) {
+		channel.FlushStatus = types.FLUSHCOMPLETE
+		k.SetChannel(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), channel)
+	}
 
 	// log that a packet has been acknowledged
 	k.Logger(ctx).Info(

--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -377,7 +377,7 @@ func (k Keeper) AcknowledgePacket(
 	if channel.State != types.OPEN && channel.FlushStatus != types.FLUSHING {
 		return errorsmod.Wrapf(
 			types.ErrInvalidChannelState,
-			"channel state is not OPEN (got %s)", channel.State.String(),
+			"packets cannot be acknowledged on channel with state (%s) and flush status (%s)", channel.State, channel.FlushStatus,
 		)
 	}
 

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -791,11 +791,6 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 
 			err = path.EndpointA.ChanUpgradeAck()
 			suite.Require().NoError(err)
-
-			// TODO: Manually set until #3929 is implemented.
-			channel := path.EndpointA.GetChannel()
-			channel.FlushStatus = types.FLUSHCOMPLETE
-			path.EndpointA.SetChannel(channel)
 		}, false},
 		{"capability authentication failed ORDERED", func() {
 			expError = types.ErrInvalidChannelCapability

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -789,6 +789,7 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 
 			// Move channel to correct state.
+			path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
 			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
 
 			err = path.EndpointB.ChanUpgradeInit()
@@ -854,7 +855,7 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 			suite.Require().NoError(err)
 			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 		}, false},
-		{"channel in tryupgrade and flush status not in flush", func() {
+		{"channel in ackupgrade and flush status flush complete", func() {
 			expError = types.ErrInvalidChannelState
 
 			suite.coordinator.Setup(path)
@@ -863,6 +864,7 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 
 			// Move channel to correct state.
 			path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
+			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
 
 			err := path.EndpointA.ChanUpgradeInit()
 			suite.Require().NoError(err)
@@ -1112,6 +1114,7 @@ func (suite *KeeperTestSuite) TestAcknowledgeFlushStatus() {
 
 			// Move channel to UPGRADE_ACK, flush status set to flushing due to previous SendPacket
 			path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
+			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
 
 			err = path.EndpointA.ChanUpgradeInit()
 			suite.Require().NoError(err)

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -692,6 +692,26 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 
 			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 		}, true},
+		{"channel in ackupgrade flush status in flushing", func() {
+			// setup uses an UNORDERED channel
+			suite.coordinator.Setup(path)
+
+			// create packet commitment
+			sequence, err := path.EndpointA.SendPacket(defaultTimeoutHeight, disabledTimeoutTimestamp, ibctesting.MockPacketData)
+			suite.Require().NoError(err)
+
+			channel := path.EndpointA.GetChannel()
+			channel.State = types.ACKUPGRADE
+			channel.FlushStatus = types.FLUSHING
+			path.EndpointA.SetChannel(channel)
+
+			// create packet receipt and acknowledgement
+			packet = types.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, defaultTimeoutHeight, disabledTimeoutTimestamp)
+			err = path.EndpointB.RecvPacket(packet)
+			suite.Require().NoError(err)
+
+			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+		}, true},
 		{"packet already acknowledged ordered channel (no-op)", func() {
 			expError = types.ErrNoOpMsg
 
@@ -747,6 +767,18 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 
 			err := path.EndpointA.SetChannelState(types.CLOSED)
 			suite.Require().NoError(err)
+			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+		}, false},
+		{"channel in ackupgrade flush status not in flush", func() {
+			expError = types.ErrInvalidChannelState
+
+			suite.coordinator.Setup(path)
+			packet = types.NewPacket(ibctesting.MockPacketData, 1, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, defaultTimeoutHeight, disabledTimeoutTimestamp)
+
+			channel := path.EndpointA.GetChannel()
+			channel.State = types.ACKUPGRADE
+			channel.FlushStatus = types.NOTINFLUSH
+			path.EndpointA.SetChannel(channel)
 			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 		}, false},
 		{"capability authentication failed ORDERED", func() {

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -708,6 +708,8 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 
 			// Move channel to correct state.
+			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
+
 			err = path.EndpointB.ChanUpgradeInit()
 			suite.Require().NoError(err)
 
@@ -780,7 +782,6 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 
 			// Move channel to correct state.
 			path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
-			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
 
 			err := path.EndpointA.ChanUpgradeInit()
 			suite.Require().NoError(err)
@@ -1010,7 +1011,6 @@ func (suite *KeeperTestSuite) TestAcknowledgeFlushStatus() {
 
 	// Move channel to UPGRADE_ACK, flush status set to flushing due to previous SendPacket
 	path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
-	path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
 
 	err = path.EndpointA.ChanUpgradeInit()
 	suite.Require().NoError(err)


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #3878 and #3877

pending spec merge.

### Commit Message / Changelog Entry

```bash
chore: amend AcknowledgePacket to allow flushing of pre-upgrade packets
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
