### PR TITLE
Set channel state to NOTINFLUSH when Closing

### DIFF
--- a/modules/core/04-channel/keeper/handshake.go
+++ b/modules/core/04-channel/keeper/handshake.go
@@ -413,7 +413,7 @@ func (k Keeper) ChanCloseInit(
 
 	defer telemetry.IncrCounter(1, "ibc", "channel", "close-init")
 
-	types.CloseChannel(&channel)
+	channel.Close()
 	k.SetChannel(ctx, portID, channelID, channel)
 
 	emitChannelCloseInitEvent(ctx, portID, channelID, channel)
@@ -476,7 +476,7 @@ func (k Keeper) ChanCloseConfirm(
 
 	defer telemetry.IncrCounter(1, "ibc", "channel", "close-confirm")
 
-	types.CloseChannel(&channel)
+	channel.Close()
 	k.SetChannel(ctx, portID, channelID, channel)
 
 	emitChannelCloseConfirmEvent(ctx, portID, channelID, channel)

--- a/modules/core/04-channel/keeper/handshake.go
+++ b/modules/core/04-channel/keeper/handshake.go
@@ -413,7 +413,7 @@ func (k Keeper) ChanCloseInit(
 
 	defer telemetry.IncrCounter(1, "ibc", "channel", "close-init")
 
-	channel.State = types.CLOSED
+	types.CloseChannel(&channel)
 	k.SetChannel(ctx, portID, channelID, channel)
 
 	emitChannelCloseInitEvent(ctx, portID, channelID, channel)
@@ -476,7 +476,7 @@ func (k Keeper) ChanCloseConfirm(
 
 	defer telemetry.IncrCounter(1, "ibc", "channel", "close-confirm")
 
-	channel.State = types.CLOSED
+	types.CloseChannel(&channel)
 	k.SetChannel(ctx, portID, channelID, channel)
 
 	emitChannelCloseConfirmEvent(ctx, portID, channelID, channel)

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -154,7 +154,7 @@ func (k Keeper) TimeoutExecuted(
 	k.deletePacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 	if channel.Ordering == types.ORDERED {
-		types.CloseChannel(&channel)
+		channel.Close()
 		k.SetChannel(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), channel)
 	}
 

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -154,7 +154,7 @@ func (k Keeper) TimeoutExecuted(
 	k.deletePacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 	if channel.Ordering == types.ORDERED {
-		channel.State = types.CLOSED
+		types.CloseChannel(&channel)
 		k.SetChannel(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), channel)
 	}
 

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -991,7 +991,7 @@ func (suite *KeeperTestSuite) TestStartFlushUpgradeHandshake() {
 		{
 			"failed verification for counterparty channel state due to incorrectly constructed counterparty channel",
 			func() {
-				counterpartyChannel.State = types.CLOSED
+				types.CloseChannel(&counterpartyChannel)
 			},
 			commitmenttypes.ErrInvalidProof,
 		},

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -991,7 +991,7 @@ func (suite *KeeperTestSuite) TestStartFlushUpgradeHandshake() {
 		{
 			"failed verification for counterparty channel state due to incorrectly constructed counterparty channel",
 			func() {
-				types.CloseChannel(&counterpartyChannel)
+				counterpartyChannel.Close()
 			},
 			commitmenttypes.ErrInvalidProof,
 		},

--- a/modules/core/04-channel/types/channel.go
+++ b/modules/core/04-channel/types/channel.go
@@ -75,7 +75,6 @@ func (ch Channel) ValidateBasic() error {
 	return ch.Counterparty.ValidateBasic()
 }
 
-
 // CloseChannel modifies the Channel with the new State set to CLOSED and FlushStatus set to NOTINFLUSH.
 func CloseChannel(channel *Channel) {
 	channel.State = CLOSED

--- a/modules/core/04-channel/types/channel.go
+++ b/modules/core/04-channel/types/channel.go
@@ -75,6 +75,13 @@ func (ch Channel) ValidateBasic() error {
 	return ch.Counterparty.ValidateBasic()
 }
 
+
+// CloseChannel modifies the Channel with the new State set to CLOSED and FlushStatus set to NOTINFLUSH.
+func CloseChannel(channel *Channel) {
+	channel.State = CLOSED
+	channel.FlushStatus = NOTINFLUSH
+}
+
 // NewCounterparty returns a new Counterparty instance
 func NewCounterparty(portID, channelID string) Counterparty {
 	return Counterparty{

--- a/modules/core/04-channel/types/channel.go
+++ b/modules/core/04-channel/types/channel.go
@@ -75,10 +75,10 @@ func (ch Channel) ValidateBasic() error {
 	return ch.Counterparty.ValidateBasic()
 }
 
-// CloseChannel modifies the Channel with the new State set to CLOSED and FlushStatus set to NOTINFLUSH.
-func CloseChannel(channel *Channel) {
-	channel.State = CLOSED
-	channel.FlushStatus = NOTINFLUSH
+// Close modifies the Channel with the new State set to CLOSED and FlushStatus set to NOTINFLUSH.
+func (ch *Channel) Close() {
+	ch.State = CLOSED
+	ch.FlushStatus = NOTINFLUSH
 }
 
 // NewCounterparty returns a new Counterparty instance

--- a/modules/core/04-channel/types/channel_test.go
+++ b/modules/core/04-channel/types/channel_test.go
@@ -57,3 +57,13 @@ func TestCounterpartyValidateBasic(t *testing.T) {
 		}
 	}
 }
+
+func TestCloseChannel(t *testing.T) {
+	ch := types.NewChannel(types.OPEN, types.ORDERED, types.Counterparty{"portidone", "channelidone"}, connHops, version)
+	ch.FlushStatus = types.FLUSHING
+
+	types.CloseChannel(&ch)
+
+	require.Equal(t, types.CLOSED, ch.State)
+	require.Equal(t, types.NOTINFLUSH, ch.FlushStatus)
+}

--- a/modules/core/04-channel/types/channel_test.go
+++ b/modules/core/04-channel/types/channel_test.go
@@ -62,7 +62,7 @@ func TestCloseChannel(t *testing.T) {
 	ch := types.NewChannel(types.OPEN, types.ORDERED, types.Counterparty{"portidone", "channelidone"}, connHops, version)
 	ch.FlushStatus = types.FLUSHING
 
-	types.CloseChannel(&ch)
+	ch.Close()
 
 	require.Equal(t, types.CLOSED, ch.State)
 	require.Equal(t, types.NOTINFLUSH, ch.FlushStatus)

--- a/modules/light-clients/09-localhost/client_state_test.go
+++ b/modules/light-clients/09-localhost/client_state_test.go
@@ -275,7 +275,8 @@ func (suite *LocalhostTestSuite) TestVerifyMembership() {
 
 				path = merklePath
 
-				channel.State = channeltypes.CLOSED // modify the channel before marshalling to value bz
+				// modify the channel before marshalling to value bz
+				channeltypes.CloseChannel(&channel)
 				value = suite.chain.Codec.MustMarshal(&channel)
 			},
 			false,

--- a/modules/light-clients/09-localhost/client_state_test.go
+++ b/modules/light-clients/09-localhost/client_state_test.go
@@ -276,7 +276,7 @@ func (suite *LocalhostTestSuite) TestVerifyMembership() {
 				path = merklePath
 
 				// modify the channel before marshalling to value bz
-				channeltypes.CloseChannel(&channel)
+				channel.Close()
 				value = suite.chain.Codec.MustMarshal(&channel)
 			},
 			false,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #3987

Since we close the channel in several places, I created a helper function for this behaviour. There are a few other ways that we could do it that might be nicer.

```go
// don't mutate the channel, but instead return a new one
func (c Channel) Close() Channel {
        c.State = CLOSED
	c.FlushStatus = NOTINFLUSH
        return c
}

// no modification
func CloseChannel(channel Channel) Channel {
	channel.State = CLOSED
	channel.FlushStatus = NOTINFLUSH
	return channel
}
```

If people think this is overkill, we can just keep the re-assignments directly in-line. My concern is that it is now no longer sufficient to just modify the channel state to "close" the channel so it seems beneficial to create a function for this.


### Commit Message / Changelog Entry

N/A Feature branch

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
