### PR TITLE
feat: adding `OnChanUpgradeInit` handler implementation to `29-fee`

### DIFF
--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -324,9 +324,8 @@ func (im IBCMiddleware) OnTimeoutPacket(
 func (im IBCMiddleware) OnChanUpgradeInit(ctx sdk.Context, portID, channelID string, order channeltypes.Order, connectionHops []string, sequence uint64, version, previousVersion string) (string, error) {
 	var versionMetadata types.Metadata
 	if err := types.ModuleCdc.UnmarshalJSON([]byte(version), &versionMetadata); err != nil {
-		// Since it is valid for fee version to not be specified, the above middleware version may be for a middleware
-		// lower down in the stack. Thus, if it is not a fee version we pass the entire version string onto the underlying
-		// application.
+		// Since it is valid for fee version to not be specified, the above upgrade version may be for a middleware
+		// or application further down in the stack. Thus, if it is not a fee version we pass the entire version string onto the underlying application.
 		return im.app.OnChanUpgradeInit(ctx, portID, channelID, order, connectionHops, sequence, version, previousVersion)
 	}
 

--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -352,7 +352,7 @@ func (im IBCMiddleware) OnChanUpgradeInit(ctx sdk.Context, portID, channelID str
 
 // OnChanUpgradeTry implement s the IBCModule interface
 func (im IBCMiddleware) OnChanUpgradeTry(ctx sdk.Context, portID, channelID string, order channeltypes.Order, connectionHops []string, counterpartyVersion string) (string, error) {
-	return counterpartyVersion, nil
+	return im.app.OnChanUpgradeTry(ctx, portID, channelID, order, connectionHops, counterpartyVersion)
 }
 
 // OnChanUpgradeAck implements the IBCModule interface

--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -352,33 +352,7 @@ func (im IBCMiddleware) OnChanUpgradeInit(ctx sdk.Context, portID, channelID str
 
 // OnChanUpgradeTry implement s the IBCModule interface
 func (im IBCMiddleware) OnChanUpgradeTry(ctx sdk.Context, portID, channelID string, order channeltypes.Order, connectionHops []string, counterpartyVersion string) (string, error) {
-	var versionMetadata types.Metadata
-	if err := types.ModuleCdc.UnmarshalJSON([]byte(counterpartyVersion), &versionMetadata); err != nil {
-		// Since it is valid for fee version to not be specified, the above middleware version may be for a middleware
-		// lower down in the stack. Thus, if it is not a fee version we pass the entire version string onto the underlying
-		// application.
-		return im.app.OnChanUpgradeTry(ctx, portID, channelID, order, connectionHops, counterpartyVersion)
-	}
-
-	if versionMetadata.FeeVersion != types.Version {
-		return "", errorsmod.Wrapf(types.ErrInvalidVersion, "expected %s, got %s", types.Version, versionMetadata.FeeVersion)
-	}
-
-	// call underlying app's OnChanOpenTry callback with the app versions
-	appVersion, err := im.app.OnChanUpgradeTry(ctx, portID, channelID, order, connectionHops, versionMetadata.AppVersion)
-	if err != nil {
-		return "", err
-	}
-
-	versionMetadata.AppVersion = appVersion
-	versionBz, err := types.ModuleCdc.MarshalJSON(&versionMetadata)
-	if err != nil {
-		return "", err
-	}
-
-	im.keeper.SetFeeEnabled(ctx, portID, channelID)
-
-	return string(versionBz), nil
+	return counterpartyVersion, nil
 }
 
 // OnChanUpgradeAck implements the IBCModule interface

--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -321,19 +321,30 @@ func (im IBCMiddleware) OnTimeoutPacket(
 }
 
 // OnChanUpgradeInit implements the IBCModule interface
-func (im IBCMiddleware) OnChanUpgradeInit(ctx sdk.Context, portID, channelID string, order channeltypes.Order, connectionHops []string, sequence uint64, version, previousVersion string) (string, error) {
-	var versionMetadata types.Metadata
-	if err := types.ModuleCdc.UnmarshalJSON([]byte(version), &versionMetadata); err != nil {
-		// Since it is valid for fee version to not be specified, the above upgrade version may be for a middleware
-		// or application further down in the stack. Thus, if it is not a fee version we pass the entire version string onto the underlying application.
-		return im.app.OnChanUpgradeInit(ctx, portID, channelID, order, connectionHops, sequence, version, previousVersion)
+func (im IBCMiddleware) OnChanUpgradeInit(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+	order channeltypes.Order,
+	connectionHops []string,
+	upgradeSequence uint64,
+	upgradeVersion string,
+	previousVersion string,
+) (string, error) {
+	versionMetadata, err := types.MetadataFromVersion(upgradeVersion)
+	if err != nil {
+		// fee version is unable to be parsed from upgrade version, disable fee
+		im.keeper.DeleteFeeEnabled(ctx, portID, channelID)
+		// since it is valid for fee version to not be specified, the upgrade version may be for a middleware
+		// or application further down in the stack. Thus, passthrough to next middleware or application in callstack.
+		return im.app.OnChanUpgradeInit(ctx, portID, channelID, order, connectionHops, upgradeSequence, upgradeVersion, previousVersion)
 	}
 
 	if versionMetadata.FeeVersion != types.Version {
 		return "", errorsmod.Wrapf(types.ErrInvalidVersion, "expected %s, got %s", types.Version, versionMetadata.FeeVersion)
 	}
 
-	appVersion, err := im.app.OnChanUpgradeInit(ctx, portID, channelID, order, connectionHops, sequence, versionMetadata.AppVersion, previousVersion)
+	appVersion, err := im.app.OnChanUpgradeInit(ctx, portID, channelID, order, connectionHops, upgradeSequence, versionMetadata.AppVersion, previousVersion)
 	if err != nil {
 		return "", err
 	}

--- a/modules/apps/29-fee/ibc_middleware_test.go
+++ b/modules/apps/29-fee/ibc_middleware_test.go
@@ -1103,13 +1103,12 @@ func (suite *FeeTestSuite) TestOnChanUpgradeInit() {
 			err := path.EndpointA.ChanUpgradeInit()
 
 			isFeeEnabled := suite.chainA.GetSimApp().IBCFeeKeeper.IsFeeEnabled(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+			suite.Require().Equal(expFeeEnabled, isFeeEnabled)
 
 			expPass := tc.expError == nil
 			if expPass {
-				suite.Require().Equal(expFeeEnabled, isFeeEnabled)
 				suite.Require().NoError(err)
 			} else {
-				suite.Require().Equal(expFeeEnabled, isFeeEnabled)
 				suite.Require().Error(err)
 				suite.Require().ErrorIs(err, tc.expError)
 			}

--- a/modules/apps/29-fee/ibc_middleware_test.go
+++ b/modules/apps/29-fee/ibc_middleware_test.go
@@ -1005,7 +1005,10 @@ func (suite *FeeTestSuite) TestOnTimeoutPacket() {
 }
 
 func (suite *FeeTestSuite) TestOnChanUpgradeInit() {
-	var path *ibctesting.Path
+	var (
+		expFeeEnabled bool
+		path          *ibctesting.Path
+	)
 
 	testCases := []struct {
 		name     string
@@ -1018,12 +1021,35 @@ func (suite *FeeTestSuite) TestOnChanUpgradeInit() {
 			nil,
 		},
 		{
+			"success disable fees",
+			func() {
+				// create a new path using a fee enabled channel and downgrade it to disable fees
+				expFeeEnabled = false
+				path = ibctesting.NewPath(suite.chainA, suite.chainB)
+
+				mockFeeVersion := string(types.ModuleCdc.MustMarshalJSON(&types.Metadata{FeeVersion: types.Version, AppVersion: ibcmock.Version}))
+				path.EndpointA.ChannelConfig.PortID = ibctesting.MockFeePort
+				path.EndpointB.ChannelConfig.PortID = ibctesting.MockFeePort
+				path.EndpointA.ChannelConfig.Version = mockFeeVersion
+				path.EndpointB.ChannelConfig.Version = mockFeeVersion
+
+				upgradeVersion := ibcmock.Version
+				path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = upgradeVersion
+				path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = upgradeVersion
+
+				suite.coordinator.Setup(path)
+			},
+			nil,
+		},
+		{
 			"invalid upgrade version",
 			func() {
+				expFeeEnabled = false
 				path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = "invalid-version"
 				path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = "invalid-version"
 
 				suite.chainA.GetSimApp().FeeMockModule.IBCApp.OnChanUpgradeInit = func(_ sdk.Context, _, _ string, _ channeltypes.Order, _ []string, _ uint64, _, _ string) (string, error) {
+					// intentionally force the error here so we can assert that a passthrough results in isFeeEnabled == false
 					return "", ibcmock.MockApplicationCallbackError
 				}
 			},
@@ -1032,6 +1058,7 @@ func (suite *FeeTestSuite) TestOnChanUpgradeInit() {
 		{
 			"invalid fee version",
 			func() {
+				expFeeEnabled = false
 				upgradeVersion := string(types.ModuleCdc.MustMarshalJSON(&types.Metadata{FeeVersion: "invalid-version", AppVersion: ibcmock.Version}))
 				path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = upgradeVersion
 				path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = upgradeVersion
@@ -1041,6 +1068,7 @@ func (suite *FeeTestSuite) TestOnChanUpgradeInit() {
 		{
 			"underlying app callback returns error",
 			func() {
+				expFeeEnabled = false
 				suite.chainA.GetSimApp().FeeMockModule.IBCApp.OnChanUpgradeInit = func(_ sdk.Context, _, _ string, _ channeltypes.Order, _ []string, _ uint64, _, _ string) (string, error) {
 					return "", ibcmock.MockApplicationCallbackError
 				}
@@ -1065,6 +1093,7 @@ func (suite *FeeTestSuite) TestOnChanUpgradeInit() {
 			suite.coordinator.Setup(path)
 
 			// configure the channel upgrade version to enabled ics29 fee middleware
+			expFeeEnabled = true
 			upgradeVersion := string(types.ModuleCdc.MustMarshalJSON(&types.Metadata{FeeVersion: types.Version, AppVersion: ibcmock.Version}))
 			path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = upgradeVersion
 			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = upgradeVersion
@@ -1077,10 +1106,10 @@ func (suite *FeeTestSuite) TestOnChanUpgradeInit() {
 
 			expPass := tc.expError == nil
 			if expPass {
-				suite.Require().True(isFeeEnabled)
+				suite.Require().Equal(expFeeEnabled, isFeeEnabled)
 				suite.Require().NoError(err)
 			} else {
-				suite.Require().False(isFeeEnabled)
+				suite.Require().Equal(expFeeEnabled, isFeeEnabled)
 				suite.Require().Error(err)
 				suite.Require().ErrorIs(err, tc.expError)
 			}

--- a/modules/apps/29-fee/ibc_middleware_test.go
+++ b/modules/apps/29-fee/ibc_middleware_test.go
@@ -1049,7 +1049,7 @@ func (suite *FeeTestSuite) TestOnChanUpgradeInit() {
 				path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = "invalid-version"
 
 				suite.chainA.GetSimApp().FeeMockModule.IBCApp.OnChanUpgradeInit = func(_ sdk.Context, _, _ string, _ channeltypes.Order, _ []string, _ uint64, _, _ string) (string, error) {
-					// intentionally force the error here so we can assert that a passthrough results in isFeeEnabled == false
+					// intentionally force the error here so we can assert that a passthrough occurs when fees should not be enabled for this channel
 					return "", ibcmock.MockApplicationCallbackError
 				}
 			},

--- a/modules/apps/29-fee/types/metadata.go
+++ b/modules/apps/29-fee/types/metadata.go
@@ -1,0 +1,13 @@
+package types
+
+// MetadataFromVersion attempts to parse the given string into a fee version Metadata,
+// an error is returned if it fails to do so.
+func MetadataFromVersion(version string) (Metadata, error) {
+	var metadata Metadata
+	err := ModuleCdc.UnmarshalJSON([]byte(version), &metadata)
+	if err != nil {
+		return Metadata{}, ErrInvalidVersion
+	}
+
+	return metadata, nil
+}

--- a/modules/apps/29-fee/types/metadata.go
+++ b/modules/apps/29-fee/types/metadata.go
@@ -1,12 +1,14 @@
 package types
 
+import errorsmod "cosmossdk.io/errors"
+
 // MetadataFromVersion attempts to parse the given string into a fee version Metadata,
 // an error is returned if it fails to do so.
 func MetadataFromVersion(version string) (Metadata, error) {
 	var metadata Metadata
 	err := ModuleCdc.UnmarshalJSON([]byte(version), &metadata)
 	if err != nil {
-		return Metadata{}, ErrInvalidVersion
+		return Metadata{}, errorsmod.Wrapf(ErrInvalidVersion, "failed to unmarshal metadata from version: %s", version)
 	}
 
 	return metadata, nil

--- a/modules/apps/29-fee/types/metadata_test.go
+++ b/modules/apps/29-fee/types/metadata_test.go
@@ -1,0 +1,29 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
+	ibcmock "github.com/cosmos/ibc-go/v7/testing/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataFromVersion(t *testing.T) {
+	testMetadata := types.Metadata{
+		AppVersion: ibcmock.Version,
+		FeeVersion: types.Version,
+	}
+
+	versionBz, err := types.ModuleCdc.MarshalJSON(&testMetadata)
+	require.NoError(t, err)
+
+	metadata, err := types.MetadataFromVersion(string(versionBz))
+	require.NoError(t, err)
+	require.Equal(t, ibcmock.Version, metadata.AppVersion)
+	require.Equal(t, types.Version, metadata.FeeVersion)
+
+	metadata, err = types.MetadataFromVersion("")
+	require.Error(t, err)
+	require.ErrorIs(t, err, types.ErrInvalidVersion)
+	require.Empty(t, metadata)
+}

--- a/testing/chain.go
+++ b/testing/chain.go
@@ -318,14 +318,13 @@ func (chain *TestChain) SendMsgs(msgs ...sdk.Msg) (*sdk.Result, error) {
 	chain.Coordinator.UpdateTimeForChain(chain)
 
 	_, r, err := simapp.SignAndDeliver(
-		chain.TB,
 		chain.TxConfig,
 		chain.App.GetBaseApp(),
 		msgs,
 		chain.ChainID,
 		[]uint64{chain.SenderAccount.GetAccountNumber()},
 		[]uint64{chain.SenderAccount.GetSequence()},
-		true, chain.SenderPrivKey,
+		chain.SenderPrivKey,
 	)
 	if err != nil {
 		return nil, err

--- a/testing/simapp/test_helpers.go
+++ b/testing/simapp/test_helpers.go
@@ -209,8 +209,8 @@ func SetupWithGenesisAccounts(genAccs []authtypes.GenesisAccount, balances ...ba
 //
 // CONTRACT: BeginBlock must be called before this function.
 func SignAndDeliver(
-	tb testing.TB, txCfg client.TxConfig, app *bam.BaseApp, msgs []sdk.Msg,
-	chainID string, accNums, accSeqs []uint64, expPass bool, priv ...cryptotypes.PrivKey,
+	txCfg client.TxConfig, app *bam.BaseApp, msgs []sdk.Msg,
+	chainID string, accNums, accSeqs []uint64, priv ...cryptotypes.PrivKey,
 ) (sdk.GasInfo, *sdk.Result, error) {
 	tx, err := simtestutil.GenSignedMockTx(
 		rand.New(rand.NewSource(time.Now().UnixNano())),
@@ -223,18 +223,9 @@ func SignAndDeliver(
 		accSeqs,
 		priv...,
 	)
-	require.NoError(tb, err)
-
-	// Simulate a sending a transaction
-	gInfo, res, err := app.SimDeliver(txCfg.TxEncoder(), tx)
-
-	if expPass {
-		require.NoError(tb, err)
-		require.NotNil(tb, res)
-	} else {
-		require.Error(tb, err)
-		require.Nil(tb, res)
+	if err != nil {
+		return sdk.GasInfo{}, nil, err
 	}
 
-	return gInfo, res, err
+	return app.SimDeliver(txCfg.TxEncoder(), tx)
 }

--- a/testing/simapp/test_helpers.go
+++ b/testing/simapp/test_helpers.go
@@ -3,7 +3,6 @@ package simapp
 import (
 	"encoding/json"
 	"math/rand"
-	"testing"
 	"time"
 
 	dbm "github.com/cometbft/cometbft-db"
@@ -22,7 +21,6 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/ibc-go/v7/testing/mock"
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Adds the `OnChanUpgradeInit` handler to `29-fee`.
- Testing library changes are cherry-picked from #4018 

**NOTE**: this omits the allowance of the empty string which is used in the opening handshake to automatically select the version if none is provided by the client.

ref: #1900

<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
