### PR TITLE
Update footer links on Docs site

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -637,11 +637,11 @@ module.exports = {
         },
         {
           service: "youtube",
-          url: "https://www.youtube.com/c/CosmosProject",
+          url: "https://www.youtube.com/@interchain_io/featured",
         },
       ],
       smallprint:
-        "The development of IBC-Go is led primarily by [Interchain GmbH](https://interchain.berlin/). Funding for this development comes primarily from the Interchain Foundation, a Swiss non-profit.",
+        "The development of IBC-Go is led primarily by Interchain GmbH. Funding for this development comes primarily from the [Interchain Foundation](https://interchain.io/), a Swiss non-profit.",
       links: [
         {
           title: "Documentation",
@@ -655,7 +655,11 @@ module.exports = {
               url: "https://hub.cosmos.network",
             },
             {
-              title: "Tendermint Core",
+              title: "CometBFT",
+              url: "https://docs.cometbft.com/",
+            },
+            {
+              title: "Tendermint Core (archived)",
               url: "https://docs.tendermint.com",
             },
           ],


### PR DESCRIPTION

## Description
Updates are to vuepress's config file to change links in footer of the [docs site](https://ibc.cosmos.network/):
- Updated footer links to add in CometBFT docs, and label Tendermint Core docs as archived (should probably still be linked to for a while still)
- Changed youtube link to https://www.youtube.com/@interchain_io/featured. Cosmos youtube channel is no longer maintained
- Removed link to interchain.berlin. Added link to interchain.io
