### PR TITLE
nit(fee.test): fix unused parameter in 'buildInterchainAccountsPacket'

### DIFF
--- a/modules/apps/29-fee/ica_test.go
+++ b/modules/apps/29-fee/ica_test.go
@@ -184,7 +184,7 @@ func (suite *FeeTestSuite) TestFeeInterchainAccounts() {
 func buildInterchainAccountsPacket(path *ibctesting.Path, data []byte, seq uint64) channeltypes.Packet {
 	packet := channeltypes.NewPacket(
 		data,
-		1,
+		seq,
 		path.EndpointA.ChannelConfig.PortID,
 		path.EndpointA.ChannelID,
 		path.EndpointB.ChannelConfig.PortID,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

`buildInterchainAccountsPacket` has an unused `seq` parameter. This PR implements the use of this parameter in the intended manner.

### Commit Message / Changelog Entry

```bash
nit(fee.test): fix unused parameter in 'buildInterchainAccountsPacket'
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] ~Linked to Github issue with discussion and accepted design OR link to spec that describes this work.~
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [x] ~Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).~
- [x] ~Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).~
- [x] ~Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).~
- [x] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Review `Codecov Report` in the comment section below once CI passes.
