### PR TITLE
fix: update e2e test config to use simapp codec

### DIFF
--- a/e2e/tests/interchain_accounts/intertx_test.go
+++ b/e2e/tests/interchain_accounts/intertx_test.go
@@ -14,7 +14,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	intertxtypes "github.com/cosmos/interchain-accounts/x/inter-tx/types"
 
-	"github.com/cosmos/ibc-go/e2e/testconfig"
 	"github.com/cosmos/ibc-go/e2e/testsuite"
 	"github.com/cosmos/ibc-go/e2e/testvalues"
 
@@ -65,7 +64,7 @@ func (s *InterTxTestSuite) TestMsgSubmitTx_SuccessfulTransfer() {
 	var hostAccount string
 
 	t.Run("register interchain account", func(t *testing.T) {
-		version := getICAVersion(testconfig.GetChainATag(), testconfig.GetChainBTag())
+		version := getICAVersion(testsuite.GetChainATag(), testsuite.GetChainBTag())
 		msgRegisterAccount := intertxtypes.NewMsgRegisterAccount(controllerAccount.FormattedAddress(), ibctesting.FirstConnectionID, version)
 		s.RegisterInterchainAccount(ctx, chainA, controllerAccount, msgRegisterAccount)
 	})
@@ -156,7 +155,7 @@ func (s *InterTxTestSuite) TestMsgSubmitTx_FailedTransfer_InsufficientFunds() {
 	var hostAccount string
 
 	t.Run("register interchain account", func(t *testing.T) {
-		version := getICAVersion(testconfig.GetChainATag(), testconfig.GetChainBTag())
+		version := getICAVersion(testsuite.GetChainATag(), testsuite.GetChainBTag())
 		msgRegisterAccount := intertxtypes.NewMsgRegisterAccount(controllerAccount.FormattedAddress(), ibctesting.FirstConnectionID, version)
 		s.RegisterInterchainAccount(ctx, chainA, controllerAccount, msgRegisterAccount)
 	})

--- a/e2e/tests/upgrades/upgrade_test.go
+++ b/e2e/tests/upgrades/upgrade_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/ibc-go/e2e/semverutil"
-	"github.com/cosmos/ibc-go/e2e/testconfig"
 	"github.com/cosmos/ibc-go/e2e/testsuite"
 	"github.com/cosmos/ibc-go/e2e/testvalues"
 	controllertypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/types"
@@ -38,9 +37,9 @@ const (
 )
 
 func TestUpgradeTestSuite(t *testing.T) {
-	testCfg := testconfig.LoadConfig()
+	testCfg := testsuite.LoadConfig()
 	if testCfg.UpgradeConfig.Tag == "" || testCfg.UpgradeConfig.PlanName == "" {
-		t.Fatalf("%s and %s must be set when running an upgrade test", testconfig.ChainUpgradeTagEnv, testconfig.ChainUpgradePlanEnv)
+		t.Fatalf("%s and %s must be set when running an upgrade test", testsuite.ChainUpgradeTagEnv, testsuite.ChainUpgradePlanEnv)
 	}
 
 	suite.Run(t, new(UpgradeTestSuite))
@@ -97,7 +96,7 @@ func (s *UpgradeTestSuite) UpgradeChain(ctx context.Context, chain *cosmos.Cosmo
 
 func (s *UpgradeTestSuite) TestIBCChainUpgrade() {
 	t := s.T()
-	testCfg := testconfig.LoadConfig()
+	testCfg := testsuite.LoadConfig()
 
 	ctx := context.Background()
 	relayer, channelA := s.SetupChainsRelayerAndChannel(ctx)
@@ -227,7 +226,7 @@ func (s *UpgradeTestSuite) TestChainUpgrade() {
 	})
 
 	t.Run("upgrade chain", func(t *testing.T) {
-		testCfg := testconfig.LoadConfig()
+		testCfg := testsuite.LoadConfig()
 		proposerWallet := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount)
 
 		s.UpgradeChain(ctx, chain, proposerWallet, testCfg.UpgradeConfig.PlanName, testCfg.ChainConfigs[0].Tag, testCfg.UpgradeConfig.Tag)
@@ -253,7 +252,7 @@ func (s *UpgradeTestSuite) TestChainUpgrade() {
 
 func (s *UpgradeTestSuite) TestV5ToV6ChainUpgrade() {
 	t := s.T()
-	testCfg := testconfig.LoadConfig()
+	testCfg := testsuite.LoadConfig()
 
 	ctx := context.Background()
 	relayer, _ := s.SetupChainsRelayerAndChannel(ctx)
@@ -453,7 +452,7 @@ func (s *UpgradeTestSuite) TestV5ToV6ChainUpgrade() {
 // can be sent before and after the upgrade without issue
 func (s *UpgradeTestSuite) TestV6ToV7ChainUpgrade() {
 	t := s.T()
-	testCfg := testconfig.LoadConfig()
+	testCfg := testsuite.LoadConfig()
 
 	ctx := context.Background()
 	relayer, channelA := s.SetupChainsRelayerAndChannel(ctx)
@@ -599,7 +598,7 @@ func (s *UpgradeTestSuite) TestV6ToV7ChainUpgrade() {
 
 func (s *UpgradeTestSuite) TestV7ToV7_1ChainUpgrade() {
 	t := s.T()
-	testCfg := testconfig.LoadConfig()
+	testCfg := testsuite.LoadConfig()
 
 	ctx := context.Background()
 	relayer, channelA := s.SetupChainsRelayerAndChannel(ctx)
@@ -706,7 +705,7 @@ func (s *UpgradeTestSuite) ClientState(ctx context.Context, chain ibc.Chain, cli
 
 // getChainImage returns the image of a given chain.
 func getChainImage(chain *cosmos.CosmosChain) string {
-	tc := testconfig.LoadConfig()
+	tc := testsuite.LoadConfig()
 	for _, c := range tc.ChainConfigs {
 		if c.ChainID == chain.Config().ChainID {
 			return c.Image

--- a/e2e/testsuite/codec.go
+++ b/e2e/testsuite/codec.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -39,6 +40,17 @@ func Codec() *codec.ProtoCodec {
 func EncodingConfig() simappparams.EncodingConfig {
 	_, cfg := codecAndEncodingConfig()
 	return cfg
+}
+
+// SDKEncodingConfig returns the global E2E encoding config.
+func SDKEncodingConfig() *testutil.TestEncodingConfig {
+	_, cfg := codecAndEncodingConfig()
+	return &testutil.TestEncodingConfig{
+		InterfaceRegistry: cfg.InterfaceRegistry,
+		Codec:             cfg.Codec,
+		TxConfig:          cfg.TxConfig,
+		Amino:             cfg.Amino,
+	}
 }
 
 func codecAndEncodingConfig() (*codec.ProtoCodec, simappparams.EncodingConfig) {

--- a/e2e/testsuite/diagnostics/diagnostics.go
+++ b/e2e/testsuite/diagnostics/diagnostics.go
@@ -11,10 +11,8 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 	dockerclient "github.com/docker/docker/client"
-	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 
 	"github.com/cosmos/ibc-go/e2e/dockerutil"
-	"github.com/cosmos/ibc-go/e2e/testconfig"
 )
 
 const (
@@ -25,11 +23,10 @@ const (
 
 // Collect can be used in `t.Cleanup` and will copy all the of the container logs and relevant files
 // into e2e/<test-suite>/<test-name>.log. These log files will be uploaded to GH upon test failure.
-func Collect(t *testing.T, dc *dockerclient.Client, cfg testconfig.ChainOptions) {
+func Collect(t *testing.T, dc *dockerclient.Client, chainNameA, chainNameB string, debugModeEnabled bool) {
 	t.Helper()
 
-	debugCfg := testconfig.LoadConfig().DebugConfig
-	if !debugCfg.DumpLogs {
+	if !debugModeEnabled {
 		// when we are not forcing log collection, we only upload upon test failing.
 		if !t.Failed() {
 			t.Logf("test passed, not uploading logs")
@@ -80,8 +77,8 @@ func Collect(t *testing.T, dc *dockerclient.Client, cfg testconfig.ChainOptions)
 		}
 
 		t.Logf("successfully wrote log file %s", logFile)
-		diagnosticFiles := chainDiagnosticAbsoluteFilePaths(*cfg.ChainAConfig)
-		diagnosticFiles = append(diagnosticFiles, chainDiagnosticAbsoluteFilePaths(*cfg.ChainBConfig)...)
+		diagnosticFiles := chainDiagnosticAbsoluteFilePaths(chainNameA)
+		diagnosticFiles = append(diagnosticFiles, chainDiagnosticAbsoluteFilePaths(chainNameB)...)
 
 		for _, absoluteFilePathInContainer := range diagnosticFiles {
 			localFilePath := ospath.Join(containerDir, ospath.Base(absoluteFilePathInContainer))
@@ -147,12 +144,12 @@ func fetchAndWriteDockerInspectOutput(ctx context.Context, dc *dockerclient.Clie
 
 // chainDiagnosticAbsoluteFilePaths returns a slice of absolute file paths (in the containers) which are the files that should be
 // copied locally when fetching diagnostics.
-func chainDiagnosticAbsoluteFilePaths(cfg ibc.ChainConfig) []string {
+func chainDiagnosticAbsoluteFilePaths(chainName string) []string {
 	return []string{
-		fmt.Sprintf("/var/cosmos-chain/%s/config/genesis.json", cfg.Name),
-		fmt.Sprintf("/var/cosmos-chain/%s/config/app.toml", cfg.Name),
-		fmt.Sprintf("/var/cosmos-chain/%s/config/config.toml", cfg.Name),
-		fmt.Sprintf("/var/cosmos-chain/%s/config/client.toml", cfg.Name),
+		fmt.Sprintf("/var/cosmos-chain/%s/config/genesis.json", chainName),
+		fmt.Sprintf("/var/cosmos-chain/%s/config/app.toml", chainName),
+		fmt.Sprintf("/var/cosmos-chain/%s/config/config.toml", chainName),
+		fmt.Sprintf("/var/cosmos-chain/%s/config/client.toml", chainName),
 	}
 }
 

--- a/e2e/testsuite/testconfig.go
+++ b/e2e/testsuite/testconfig.go
@@ -1,4 +1,4 @@
-package testconfig
+package testsuite
 
 import (
 	"encoding/json"
@@ -387,6 +387,7 @@ func newDefaultSimappConfig(cc ChainConfig, name, chainID, denom string, cometCf
 		Bech32Prefix:           "cosmos",
 		CoinType:               fmt.Sprint(sdk.GetConfig().GetCoinType()),
 		Denom:                  denom,
+		EncodingConfig:         SDKEncodingConfig(),
 		GasPrices:              fmt.Sprintf("0.00%s", denom),
 		GasAdjustment:          1.3,
 		TrustingPeriod:         "508h",

--- a/e2e/testsuite/testsuite.go
+++ b/e2e/testsuite/testsuite.go
@@ -16,7 +16,6 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/cosmos/ibc-go/e2e/relayer"
-	"github.com/cosmos/ibc-go/e2e/testconfig"
 	"github.com/cosmos/ibc-go/e2e/testsuite/diagnostics"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
@@ -36,7 +35,7 @@ type E2ETestSuite struct {
 	suite.Suite
 
 	grpcClients    map[string]GRPCClients
-	paths          map[string]path
+	paths          map[string]pathPair
 	relayers       relayer.RelayerMap
 	logger         *zap.Logger
 	DockerClient   *dockerclient.Client
@@ -47,14 +46,14 @@ type E2ETestSuite struct {
 	pathNameIndex int64
 }
 
-// path is a pairing of two chains which will be used in a test.
-type path struct {
+// pathPair is a pairing of two chains which will be used in a test.
+type pathPair struct {
 	chainA, chainB *cosmos.CosmosChain
 }
 
 // newPath returns a path built from the given chains.
-func newPath(chainA, chainB *cosmos.CosmosChain) path {
-	return path{
+func newPath(chainA, chainB *cosmos.CosmosChain) pathPair {
+	return pathPair{
 		chainA: chainA,
 		chainB: chainB,
 	}
@@ -62,7 +61,7 @@ func newPath(chainA, chainB *cosmos.CosmosChain) path {
 
 // GetRelayerUsers returns two ibc.Wallet instances which can be used for the relayer users
 // on the two chains.
-func (s *E2ETestSuite) GetRelayerUsers(ctx context.Context, chainOpts ...testconfig.ChainOptionConfiguration) (ibc.Wallet, ibc.Wallet) {
+func (s *E2ETestSuite) GetRelayerUsers(ctx context.Context, chainOpts ...ChainOptionConfiguration) (ibc.Wallet, ibc.Wallet) {
 	chainA, chainB := s.GetChains(chainOpts...)
 	chainAAccountBytes, err := chainA.GetAddress(ctx, ChainARelayerName)
 	s.Require().NoError(err)
@@ -89,7 +88,7 @@ func (s *E2ETestSuite) GetRelayerUsers(ctx context.Context, chainOpts ...testcon
 func (s *E2ETestSuite) SetupChainsRelayerAndChannel(ctx context.Context, channelOpts ...func(*ibc.CreateChannelOptions)) (ibc.Relayer, ibc.ChannelOutput) {
 	chainA, chainB := s.GetChains()
 
-	r := relayer.New(s.T(), testconfig.LoadConfig().RelayerConfig, s.logger, s.DockerClient, s.network)
+	r := relayer.New(s.T(), LoadConfig().RelayerConfig, s.logger, s.DockerClient, s.network)
 
 	pathName := s.generatePathName()
 
@@ -205,9 +204,9 @@ func (s *E2ETestSuite) UpdateClients(ctx context.Context, relayer ibc.Relayer, p
 
 // GetChains returns two chains that can be used in a test. The pair returned
 // is unique to the current test being run. Note: this function does not create containers.
-func (s *E2ETestSuite) GetChains(chainOpts ...testconfig.ChainOptionConfiguration) (*cosmos.CosmosChain, *cosmos.CosmosChain) {
+func (s *E2ETestSuite) GetChains(chainOpts ...ChainOptionConfiguration) (*cosmos.CosmosChain, *cosmos.CosmosChain) {
 	if s.paths == nil {
-		s.paths = map[string]path{}
+		s.paths = map[string]pathPair{}
 	}
 
 	path, ok := s.paths[s.T().Name()]
@@ -215,7 +214,7 @@ func (s *E2ETestSuite) GetChains(chainOpts ...testconfig.ChainOptionConfiguratio
 		return path.chainA, path.chainB
 	}
 
-	chainOptions := testconfig.DefaultChainOptions()
+	chainOptions := DefaultChainOptions()
 	for _, opt := range chainOpts {
 		opt(&chainOptions)
 	}
@@ -316,7 +315,7 @@ func (s *E2ETestSuite) AssertPacketRelayed(ctx context.Context, chain *cosmos.Co
 
 // createCosmosChains creates two separate chains in docker containers.
 // test and can be retrieved with GetChains.
-func (s *E2ETestSuite) createCosmosChains(chainOptions testconfig.ChainOptions) (*cosmos.CosmosChain, *cosmos.CosmosChain) {
+func (s *E2ETestSuite) createCosmosChains(chainOptions ChainOptions) (*cosmos.CosmosChain, *cosmos.CosmosChain) {
 	client, network := interchaintest.DockerSetup(s.T())
 	t := s.T()
 
@@ -335,7 +334,8 @@ func (s *E2ETestSuite) createCosmosChains(chainOptions testconfig.ChainOptions) 
 	// cleanup task which deletes all containers. By registering a cleanup function afterwards, it is executed first
 	// this allows us to process the logs before the containers are removed.
 	t.Cleanup(func() {
-		diagnostics.Collect(t, s.DockerClient, chainOptions)
+		debugModeEnabled := LoadConfig().DebugConfig.DumpLogs
+		diagnostics.Collect(t, s.DockerClient, chainOptions.ChainAConfig.Name, chainOptions.ChainBConfig.Name, debugModeEnabled)
 	})
 
 	return chainA, chainB
@@ -384,9 +384,9 @@ func GetIBCToken(fullTokenDenom string, portID, channelID string) transfertypes.
 // use less resources and allow the tests to run faster.
 // both the number of validators and full nodes can be overwritten in a config file.
 func getValidatorsAndFullNodes(chainIdx int) (int, int) {
-	if testconfig.IsCI() {
+	if IsCI() {
 		return 4, 1
 	}
-	tc := testconfig.LoadConfig()
+	tc := LoadConfig()
 	return tc.GetChainNumValidators(chainIdx), tc.GetChainNumFullNodes(chainIdx)
 }

--- a/e2e/testsuite/tx.go
+++ b/e2e/testsuite/tx.go
@@ -19,7 +19,6 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	test "github.com/strangelove-ventures/interchaintest/v7/testutil"
 
-	"github.com/cosmos/ibc-go/e2e/testconfig"
 	"github.com/cosmos/ibc-go/e2e/testsuite/sanitize"
 	"github.com/cosmos/ibc-go/e2e/testvalues"
 	feetypes "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
@@ -101,7 +100,7 @@ func (s *E2ETestSuite) AssertTxFailure(resp sdk.TxResponse, expectedError *error
 	errorMsg := fmt.Sprintf("%+v", resp)
 	// In older versions, the codespace and abci codes were different. So in compatibility tests
 	// we can not make assertions on them.
-	if testconfig.GetChainATag() == testconfig.GetChainBTag() {
+	if GetChainATag() == GetChainBTag() {
 		s.Require().Equal(expectedError.ABCICode(), resp.Code, errorMsg)
 		s.Require().Equal(expectedError.Codespace(), resp.Codespace, errorMsg)
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

we currently do not set a codec in our ChainConfig for `interchaintest`, which causes problems when we try to run the e2e tests in PRs containing the `08-wasm`. this pr updates our `ChainConfig` to use the codec from simapp.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
