### PR TITLE
Remove manual setting of flush status in ChanUpgradeOpen

### DIFF
--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -726,15 +726,6 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpen() {
 			err = path.EndpointB.ChanUpgradeAck()
 			suite.Require().NoError(err)
 
-			// TODO: Remove setting of FLUSHCOMPLETE once #3928 is completed
-			channelB := path.EndpointB.GetChannel()
-			channelB.FlushStatus = types.FLUSHCOMPLETE
-			path.EndpointB.SetChannel(channelB)
-
-			channelA := path.EndpointA.GetChannel()
-			channelA.FlushStatus = types.FLUSHCOMPLETE
-			path.EndpointA.SetChannel(channelA)
-
 			suite.coordinator.CommitBlock(suite.chainA, suite.chainB)
 			suite.Require().NoError(path.EndpointA.UpdateClient())
 


### PR DESCRIPTION
## Description

:broom: 

closes: #XXXX


### Commit Message / Changelog Entry

```bash
chore: remove manual setting of flush status
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
