### PR TITLE
Use counterparty connection hops when verifying channel state

### DIFF
--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -356,18 +356,19 @@ func (k Keeper) ChanUpgradeOpen(
 			return errorsmod.Wrapf(types.ErrUpgradeNotFound, "failed to retrieve channel upgrade: port ID (%s) channel ID (%s)", portID, channelID)
 		}
 		// If counterparty has reached OPEN, we must use the upgraded connection to verify the counterparty channel
-		upgradedConnection, err := k.GetConnection(ctx, upgrade.Fields.ConnectionHops[0])
+		upgradeConnection, err := k.GetConnection(ctx, upgrade.Fields.ConnectionHops[0])
 		if err != nil {
 			return errorsmod.Wrap(err, "failed to retrieve connection using the upgrade connection hops")
 		}
-		if upgradedConnection.GetState() != int32(connectiontypes.OPEN) {
-			return errorsmod.Wrapf(connectiontypes.ErrInvalidConnectionState, "connection state is not OPEN (got %s)", connectiontypes.State(upgradedConnection.GetState()).String())
+
+		if upgradeConnection.GetState() != int32(connectiontypes.OPEN) {
+			return errorsmod.Wrapf(connectiontypes.ErrInvalidConnectionState, "connection state is not OPEN (got %s)", connectiontypes.State(upgradeConnection.GetState()).String())
 		}
 
 		counterpartyChannel = types.Channel{
 			State:           types.OPEN,
 			Ordering:        upgrade.Fields.Ordering,
-			ConnectionHops:  []string{upgradedConnection.GetCounterparty().GetConnectionID()},
+			ConnectionHops:  []string{upgradeConnection.GetCounterparty().GetConnectionID()},
 			Counterparty:    types.NewCounterparty(portID, channelID),
 			Version:         upgrade.Fields.Version,
 			UpgradeSequence: channel.UpgradeSequence,

--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -355,11 +355,19 @@ func (k Keeper) ChanUpgradeOpen(
 		if !found {
 			return errorsmod.Wrapf(types.ErrUpgradeNotFound, "failed to retrieve channel upgrade: port ID (%s) channel ID (%s)", portID, channelID)
 		}
+		// If counterparty has reached OPEN, we must use the upgraded connection to verify the counterparty channel
+		upgradedConnection, err := k.GetConnection(ctx, upgrade.Fields.ConnectionHops[0])
+		if err != nil {
+			return errorsmod.Wrap(err, "failed to retrieve connection using the upgrade connection hops")
+		}
+		if upgradedConnection.GetState() != int32(connectiontypes.OPEN) {
+			return errorsmod.Wrapf(connectiontypes.ErrInvalidConnectionState, "connection state is not OPEN (got %s)", connectiontypes.State(upgradedConnection.GetState()).String())
+		}
 
 		counterpartyChannel = types.Channel{
 			State:           types.OPEN,
 			Ordering:        upgrade.Fields.Ordering,
-			ConnectionHops:  upgrade.Fields.ConnectionHops,
+			ConnectionHops:  []string{upgradedConnection.GetCounterparty().GetConnectionID()},
 			Counterparty:    types.NewCounterparty(portID, channelID),
 			Version:         upgrade.Fields.Version,
 			UpgradeSequence: channel.UpgradeSequence,

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -801,8 +801,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpenCounterPartyStates() {
 		},
 	}
 
-	// Create an initial path used only to invoke a ChanOpenInit handshake.
-	// This bumps the channel identifier generated for chain A on the
+	// Create an initial path used only to invoke ConnOpenInit/ChanOpenInit handlers.
+	// This bumps the connection/channel identifiers generated for chain A on the
 	// next path used to run the upgrade handshake.
 	// See issue 4062.
 	path = ibctesting.NewPath(suite.chainA, suite.chainB)

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -754,6 +754,90 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpen() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestChanUpgradeOpenCounterPartyStates() {
+	var path *ibctesting.Path
+	testCases := []struct {
+		name     string
+		malleate func()
+		expError error
+	}{
+		{
+			"success, counterparty in OPEN",
+			func() {
+				path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
+				path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
+
+				err := path.EndpointB.ChanUpgradeInit()
+				suite.Require().NoError(err)
+
+				err = path.EndpointA.ChanUpgradeTry()
+				suite.Require().NoError(err)
+
+				err = path.EndpointB.ChanUpgradeAck()
+				suite.Require().NoError(err)
+
+				err = path.EndpointB.ChanUpgradeOpen()
+				suite.Require().NoError(err)
+
+				suite.coordinator.CommitBlock(suite.chainA, suite.chainB)
+				suite.Require().NoError(path.EndpointA.UpdateClient())
+			},
+			nil,
+		},
+		{
+			"success, counterparty in TRYUPGRADE",
+			func() {
+				path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
+				path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
+
+				err := path.EndpointA.ChanUpgradeInit()
+				suite.Require().NoError(err)
+
+				err = path.EndpointB.ChanUpgradeTry()
+				suite.Require().NoError(err)
+
+				err = path.EndpointA.ChanUpgradeAck()
+				suite.Require().NoError(err)
+			},
+			nil,
+		},
+	}
+
+	// Create an initial path used only to invoke a ChanOpenInit handshake.
+	// This bumps the channel identifier generated for chain A on the
+	// next path used to run the upgrade handshake.
+	// See issue 4062.
+	path = ibctesting.NewPath(suite.chainA, suite.chainB)
+	suite.coordinator.SetupClients(path)
+	suite.Require().NoError(path.EndpointA.ConnOpenInit())
+	suite.coordinator.SetupConnections(path)
+	suite.Require().NoError(path.EndpointA.ChanOpenInit())
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			path = ibctesting.NewPath(suite.chainA, suite.chainB)
+			suite.coordinator.Setup(path)
+
+			tc.malleate()
+
+			proofCounterpartyChannel, _, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
+			err := suite.chainA.GetSimApp().IBCKeeper.ChannelKeeper.ChanUpgradeOpen(
+				suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID,
+				path.EndpointB.GetChannel().State, proofCounterpartyChannel, proofHeight,
+			)
+
+			if tc.expError == nil {
+				suite.Require().NoError(err)
+			} else {
+				suite.Require().ErrorIs(err, tc.expError)
+			}
+		})
+	}
+}
+
 func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 	var (
 		path                     *ibctesting.Path

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -754,6 +754,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpen() {
 	}
 }
 
+// TestChanUpgradeOpenCounterPartyStates tests the handshake in the cases where
+// the counterparty is in a state other than OPEN.
 func (suite *KeeperTestSuite) TestChanUpgradeOpenCounterPartyStates() {
 	var path *ibctesting.Path
 	testCases := []struct {
@@ -764,9 +766,6 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpenCounterPartyStates() {
 		{
 			"success, counterparty in OPEN",
 			func() {
-				path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
-				path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
-
 				err := path.EndpointB.ChanUpgradeInit()
 				suite.Require().NoError(err)
 
@@ -776,6 +775,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpenCounterPartyStates() {
 				err = path.EndpointB.ChanUpgradeAck()
 				suite.Require().NoError(err)
 
+				// TODO: Remove when #4030 is closed. Channel will automatically
+				// move to OPEN in that case.
 				err = path.EndpointB.ChanUpgradeOpen()
 				suite.Require().NoError(err)
 
@@ -787,9 +788,6 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpenCounterPartyStates() {
 		{
 			"success, counterparty in TRYUPGRADE",
 			func() {
-				path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
-				path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
-
 				err := path.EndpointA.ChanUpgradeInit()
 				suite.Require().NoError(err)
 
@@ -820,6 +818,9 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpenCounterPartyStates() {
 
 			path = ibctesting.NewPath(suite.chainA, suite.chainB)
 			suite.coordinator.Setup(path)
+
+			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
+			path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
 
 			tc.malleate()
 

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -756,7 +756,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpen() {
 
 // TestChanUpgradeOpenCounterPartyStates tests the handshake in the cases where
 // the counterparty is in a state other than OPEN.
-func (suite *KeeperTestSuite) TestChanUpgradeOpenCounterPartyStates() {
+func (suite *KeeperTestSuite) TestChanUpgradeOpenCounterpartyStates() {
 	var path *ibctesting.Path
 	testCases := []struct {
 		name     string
@@ -830,7 +830,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpenCounterPartyStates() {
 				path.EndpointB.GetChannel().State, proofCounterpartyChannel, proofHeight,
 			)
 
-			if tc.expError == nil {
+			expPass := tc.expError == nil
+			if expPass {
 				suite.Require().NoError(err)
 			} else {
 				suite.Require().ErrorIs(err, tc.expError)


### PR DESCRIPTION
## Description

closes: #XXXX

### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
