### PR TITLE
Separate event creation from event emission.

### DIFF
--- a/modules/core/04-channel/keeper/events.go
+++ b/modules/core/04-channel/keeper/events.go
@@ -272,9 +272,9 @@ func emitChannelClosedEvent(ctx sdk.Context, packet exported.PacketI, channel ty
 	})
 }
 
-// emitChannelUpgradeInitEvent emits a channel upgrade init event
-func emitChannelUpgradeInitEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
-	ctx.EventManager().EmitEvents(sdk.Events{
+// createChannelUpgradeInitEvent creates a channel upgrade init event
+func createChannelUpgradeInitEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) sdk.Events {
+	return sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeInit,
 			sdk.NewAttribute(types.AttributeKeyPortID, portID),
@@ -291,12 +291,17 @@ func emitChannelUpgradeInitEvent(ctx sdk.Context, portID string, channelID strin
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 		),
-	})
+	}
 }
 
-// emitChannelUpgradeTryEvent emits a channel upgrade try event
-func emitChannelUpgradeTryEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
-	ctx.EventManager().EmitEvents(sdk.Events{
+// emitChannelUpgradeInitEvent emits a channel upgrade init event
+func emitChannelUpgradeInitEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
+	ctx.EventManager().EmitEvents(createChannelUpgradeInitEvent(portID, channelID, currentChannel, upgrade))
+}
+
+// createChannelUpgradeTryEvent creates a channel upgrade try event
+func createChannelUpgradeTryEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) sdk.Events {
+	return sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeTry,
 			sdk.NewAttribute(types.AttributeKeyPortID, portID),
@@ -313,12 +318,17 @@ func emitChannelUpgradeTryEvent(ctx sdk.Context, portID string, channelID string
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 		),
-	})
+	}
 }
 
-// emitChannelUpgradeAckEvent emits a channel upgrade ack event
-func emitChannelUpgradeAckEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
-	ctx.EventManager().EmitEvents(sdk.Events{
+// emitChannelUpgradeTryEvent emits a channel upgrade try event
+func emitChannelUpgradeTryEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
+	ctx.EventManager().EmitEvents(createChannelUpgradeTryEvent(portID, channelID, currentChannel, upgrade))
+}
+
+// createChannelUpgradeAckEvent creates a channel upgrade ack event
+func createChannelUpgradeAckEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) sdk.Events {
+	return sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeAck,
 			sdk.NewAttribute(types.AttributeKeyPortID, portID),
@@ -335,12 +345,17 @@ func emitChannelUpgradeAckEvent(ctx sdk.Context, portID string, channelID string
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 		),
-	})
+	}
 }
 
-// emitChannelUpgradeOpenEvent emits a channel upgrade open event
-func emitChannelUpgradeOpenEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel) {
-	ctx.EventManager().EmitEvents(sdk.Events{
+// emitChannelUpgradeAckEvent emits a channel upgrade ack event
+func emitChannelUpgradeAckEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
+	ctx.EventManager().EmitEvents(createChannelUpgradeAckEvent(portID, channelID, currentChannel, upgrade))
+}
+
+// createChannelUpgradeOpenEvent creates a channel upgrade open event
+func createChannelUpgradeOpenEvent(portID string, channelID string, currentChannel types.Channel) sdk.Events {
+	return sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeOpen,
 			sdk.NewAttribute(types.AttributeKeyPortID, portID),
@@ -358,12 +373,17 @@ func emitChannelUpgradeOpenEvent(ctx sdk.Context, portID string, channelID strin
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 		),
-	})
+	}
 }
 
-// emitChannelUpgradeTimeoutEvent emits an upgrade timeout event.
-func emitChannelUpgradeTimeoutEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
-	ctx.EventManager().EmitEvents(sdk.Events{
+// emitChannelUpgradeOpenEvent emits a channel upgrade open event
+func emitChannelUpgradeOpenEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel) {
+	ctx.EventManager().EmitEvents(createChannelUpgradeOpenEvent(portID, channelID, currentChannel))
+}
+
+// createChannelUpgradeTimeoutEvent creates an upgrade timeout event.
+func createChannelUpgradeTimeoutEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) sdk.Events {
+	return sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeTimeout,
 			sdk.NewAttribute(types.AttributeKeyPortID, portID),
@@ -380,12 +400,17 @@ func emitChannelUpgradeTimeoutEvent(ctx sdk.Context, portID string, channelID st
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 		),
-	})
+	}
 }
 
-// emitErrorReceiptEvent emits an error receipt event
-func emitErrorReceiptEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade, err error) {
-	ctx.EventManager().EmitEvents(sdk.Events{
+// emitChannelUpgradeTimeoutEvent emits an upgrade timeout event.
+func emitChannelUpgradeTimeoutEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
+	ctx.EventManager().EmitEvents(createChannelUpgradeTimeoutEvent(portID, channelID, currentChannel, upgrade))
+}
+
+// createErrorReceiptEvent creates an error receipt event
+func createErrorReceiptEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade, err error) sdk.Events {
+	return sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeInit,
 			sdk.NewAttribute(types.AttributeKeyPortID, portID),
@@ -402,12 +427,17 @@ func emitErrorReceiptEvent(ctx sdk.Context, portID string, channelID string, cur
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 		),
-	})
+	}
 }
 
-// emitChannelUpgradeCancelEvent emits an upgraded cancelled event.
-func emitChannelUpgradeCancelEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
-	ctx.EventManager().EmitEvents(sdk.Events{
+// emitErrorReceiptEvent emits an error receipt event
+func emitErrorReceiptEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade, err error) {
+	ctx.EventManager().EmitEvents(createErrorReceiptEvent(portID, channelID, currentChannel, upgrade, err))
+}
+
+// createChannelUpgradeCancelEvent creates an upgraded cancelled event.
+func createChannelUpgradeCancelEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) sdk.Events {
+	return sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeCancel,
 			sdk.NewAttribute(types.AttributeKeyPortID, portID),
@@ -423,5 +453,10 @@ func emitChannelUpgradeCancelEvent(ctx sdk.Context, portID string, channelID str
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 		),
-	})
+	}
+}
+
+// emitChannelUpgradeCancelEvent emits an upgraded cancelled event.
+func emitChannelUpgradeCancelEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
+	ctx.EventManager().EmitEvents(createChannelUpgradeCancelEvent(portID, channelID, currentChannel, upgrade))
 }

--- a/modules/core/04-channel/keeper/export_test.go
+++ b/modules/core/04-channel/keeper/export_test.go
@@ -30,3 +30,38 @@ func (k Keeper) StartFlushUpgradeHandshake(
 func (k Keeper) ValidateSelfUpgradeFields(ctx sdk.Context, proposedUpgrade types.UpgradeFields, currentChannel types.Channel) error {
 	return k.validateSelfUpgradeFields(ctx, proposedUpgrade, currentChannel)
 }
+
+// CreateChannelUpgradeInitEvent is a wrapper around createChannelUpgradeInitEvent to allow the function to be directly called in tests.
+func CreateChannelUpgradeInitEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) sdk.Events {
+	return createChannelUpgradeInitEvent(portID, channelID, currentChannel, upgrade)
+}
+
+// CreateChannelUpgradeTryEvent is a wrapper around createChannelUpgradeTryEvent to allow the function to be directly called in tests.
+func CreateChannelUpgradeTryEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) sdk.Events {
+	return createChannelUpgradeTryEvent(portID, channelID, currentChannel, upgrade)
+}
+
+// CreateChannelUpgradeAckEvent is a wrapper around createChannelUpgradeAckEvent to allow the function to be directly called in tests.
+func CreateChannelUpgradeAckEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) sdk.Events {
+	return createChannelUpgradeAckEvent(portID, channelID, currentChannel, upgrade)
+}
+
+// CreateChannelUpgradeOpenEvent is a wrapper around createChannelUpgradeOpenEvent to allow the function to be directly called in tests.
+func CreateChannelUpgradeOpenEvent(portID string, channelID string, currentChannel types.Channel) sdk.Events {
+	return createChannelUpgradeOpenEvent(portID, channelID, currentChannel)
+}
+
+// CreateChannelUpgradeTimeoutEvent is a wrapper around createChannelUpgradeTimeoutEvent to allow the function to be directly called in tests.
+func CreateChannelUpgradeTimeoutEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) sdk.Events {
+	return createChannelUpgradeTimeoutEvent(portID, channelID, currentChannel, upgrade)
+}
+
+// CreateErrorReceiptEvent is a wrapper around createErrorReceiptEvent to allow the function to be directly called in tests.
+func CreateErrorReceiptEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade, err error) sdk.Events {
+	return createErrorReceiptEvent(portID, channelID, currentChannel, upgrade, err)
+}
+
+// CreateChannelUpgradeCancelEvent is a wrapper around createChannelUpgradeCancelEvent to allow the function to be directly called in tests.
+func CreateChannelUpgradeCancelEvent(portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) sdk.Events {
+	return createChannelUpgradeCancelEvent(portID, channelID, currentChannel, upgrade)
+}


### PR DESCRIPTION
## Description

An idea for easing testing of events, as discussed in https://github.com/cosmos/ibc-go/pull/4020#discussion_r1261275169. The exported functions can then directly be used in tests to check for event emissions.

If people find value in it, can also be done for the older events.

closes: #XXXX

### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
