### PR TITLE
Pin code to the wasm VM cache

### DIFF
--- a/modules/light-clients/08-wasm/keeper/keeper.go
+++ b/modules/light-clients/08-wasm/keeper/keeper.go
@@ -98,9 +98,9 @@ func (k Keeper) storeWasmCode(ctx sdk.Context, code []byte) ([]byte, error) {
 		return nil, errorsmod.Wrap(err, "failed to store contract")
 	}
 
-	// pin the code in the vm
+	// pin the code to the vm in-memory cache
 	if err := k.wasmVM.Pin(codeHash); err != nil {
-		return nil, errorsmod.Wrap(err, "pinning contract failed")
+		return nil, errorsmod.Wrapf(err, "failed to pin contract to vm cache %s", codeHash)
 	}
 
 	// safety check to assert that code ID returned by WasmVM equals to code hash

--- a/modules/light-clients/08-wasm/keeper/keeper.go
+++ b/modules/light-clients/08-wasm/keeper/keeper.go
@@ -98,6 +98,11 @@ func (k Keeper) storeWasmCode(ctx sdk.Context, code []byte) ([]byte, error) {
 		return nil, errorsmod.Wrap(err, "failed to store contract")
 	}
 
+	// pin the code in the vm
+	if err := k.wasmVM.Pin(codeHash); err != nil {
+		return nil, errorsmod.Wrap(types.ErrPinContractFailed, err.Error())
+	}
+
 	// safety check to assert that code ID returned by WasmVM equals to code hash
 	if !bytes.Equal(codeHash, expectedHash) {
 		return nil, errorsmod.Wrapf(types.ErrInvalidCodeID, "expected %s, got %s", hex.EncodeToString(expectedHash), hex.EncodeToString(codeHash))

--- a/modules/light-clients/08-wasm/keeper/keeper.go
+++ b/modules/light-clients/08-wasm/keeper/keeper.go
@@ -100,7 +100,7 @@ func (k Keeper) storeWasmCode(ctx sdk.Context, code []byte) ([]byte, error) {
 
 	// pin the code in the vm
 	if err := k.wasmVM.Pin(codeHash); err != nil {
-		return nil, errorsmod.Wrap(types.ErrPinContractFailed, err.Error())
+		return nil, errorsmod.Wrap(err, "pinning contract failed")
 	}
 
 	// safety check to assert that code ID returned by WasmVM equals to code hash

--- a/modules/light-clients/08-wasm/types/errors.go
+++ b/modules/light-clients/08-wasm/types/errors.go
@@ -11,4 +11,5 @@ var (
 	ErrWasmCodeTooLarge   = errorsmod.Register(ModuleName, 5, "wasm code too large")
 	ErrWasmCodeExists     = errorsmod.Register(ModuleName, 6, "wasm code already exists")
 	ErrWasmCodeIDNotFound = errorsmod.Register(ModuleName, 7, "wasm code id not found")
+	ErrPinContractFailed  = errorsmod.Register(ModuleName, 8, "pinning contract failed")
 )

--- a/modules/light-clients/08-wasm/types/errors.go
+++ b/modules/light-clients/08-wasm/types/errors.go
@@ -11,5 +11,4 @@ var (
 	ErrWasmCodeTooLarge   = errorsmod.Register(ModuleName, 5, "wasm code too large")
 	ErrWasmCodeExists     = errorsmod.Register(ModuleName, 6, "wasm code already exists")
 	ErrWasmCodeIDNotFound = errorsmod.Register(ModuleName, 7, "wasm code id not found")
-	ErrPinContractFailed  = errorsmod.Register(ModuleName, 8, "pinning contract failed")
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Pins the code after upload for the 08-wasm client. If it fails to pin, returns a new type `ErrPinContractFailed` error with the message "pinning contract failed"

closes: #4087


### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
