### PR TITLE
Use HasInflightPackets to check if channel has finished flushing

### DIFF
--- a/modules/core/04-channel/keeper/keeper.go
+++ b/modules/core/04-channel/keeper/keeper.go
@@ -571,11 +571,11 @@ func (k Keeper) iterateHashes(ctx sdk.Context, iterator db.Iterator, cb func(por
 	}
 }
 
-// hasInflightPackets returns true if there are packet commitments stored at the specified
+// HasInflightPackets returns true if there are packet commitments stored at the specified
 // port and channel, and false otherwise.
 //
 //lint:ignore U1000 Ignore unused function temporarily for debugging
-func (k Keeper) hasInflightPackets(ctx sdk.Context, portID, channelID string) bool {
+func (k Keeper) HasInflightPackets(ctx sdk.Context, portID, channelID string) bool {
 	iterator := sdk.KVStorePrefixIterator(ctx.KVStore(k.storeKey), []byte(host.PacketCommitmentPrefixPath(portID, channelID)))
 	defer sdk.LogDeferred(ctx.Logger(), func() error { return iterator.Close() })
 

--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -477,7 +477,7 @@ func (k Keeper) AcknowledgePacket(
 	// Delete packet commitment, since the packet has been acknowledged, the commitement is no longer necessary
 	k.deletePacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
-	if channel.FlushStatus == types.FLUSHING && !k.hasInflightPackets(ctx, packet.GetSourcePort(), packet.GetSourceChannel()) {
+	if channel.FlushStatus == types.FLUSHING && !k.HasInflightPackets(ctx, packet.GetSourcePort(), packet.GetSourceChannel()) {
 		channel.FlushStatus = types.FLUSHCOMPLETE
 		k.SetChannel(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), channel)
 	}

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -153,7 +153,7 @@ func (k Keeper) TimeoutExecuted(
 
 	k.deletePacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
-	if channel.FlushStatus == types.FLUSHING && !k.hasInflightPackets(ctx, packet.GetSourcePort(), packet.GetSourceChannel()) {
+	if channel.FlushStatus == types.FLUSHING && !k.HasInflightPackets(ctx, packet.GetSourcePort(), packet.GetSourceChannel()) {
 		channel.FlushStatus = types.FLUSHCOMPLETE
 		k.SetChannel(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), channel)
 	}

--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -193,7 +193,7 @@ func (k Keeper) WriteUpgradeTryChannel(ctx sdk.Context, portID, channelID string
 	channel.State = types.TRYUPGRADE
 	channel.FlushStatus = types.FLUSHING
 
-	if !k.hasInflightPackets(ctx, portID, channelID) {
+	if !k.HasInflightPackets(ctx, portID, channelID) {
 		channel.FlushStatus = types.FLUSHCOMPLETE
 	}
 
@@ -291,7 +291,7 @@ func (k Keeper) WriteUpgradeAckChannel(ctx sdk.Context, portID, channelID, upgra
 	channel.State = types.ACKUPGRADE
 	channel.FlushStatus = types.FLUSHING
 
-	if !k.hasInflightPackets(ctx, portID, channelID) {
+	if !k.HasInflightPackets(ctx, portID, channelID) {
 		channel.FlushStatus = types.FLUSHCOMPLETE
 	}
 
@@ -322,7 +322,7 @@ func (k Keeper) ChanUpgradeOpen(
 	proofCounterpartyChannel []byte,
 	proofHeight clienttypes.Height,
 ) error {
-	if k.hasInflightPackets(ctx, portID, channelID) {
+	if k.HasInflightPackets(ctx, portID, channelID) {
 		return errorsmod.Wrapf(types.ErrPendingInflightPackets, "port ID (%s) channel ID (%s)", portID, channelID)
 	}
 

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -854,18 +854,12 @@ func (k Keeper) ChannelUpgradeAck(goCtx context.Context, msg *channeltypes.MsgCh
 
 	// Move channel to OPEN state if both chains have finished flushing any in-flight packets. Counterparty flush status
 	// has been verified in ChanUpgradeAck.
-	if msg.CounterpartyFlushStatus == channeltypes.FLUSHCOMPLETE {
-		channel, found := k.ChannelKeeper.GetChannel(ctx, msg.PortId, msg.ChannelId)
-		if !found {
-			return nil, errorsmod.Wrapf(channeltypes.ErrChannelNotFound, "port ID (%s) channel ID (%s)", msg.PortId, msg.ChannelId)
-		}
-		if channel.FlushStatus == channeltypes.FLUSHCOMPLETE {
-			cbs.OnChanUpgradeOpen(ctx, msg.PortId, msg.ChannelId)
+	if msg.CounterpartyFlushStatus == channeltypes.FLUSHCOMPLETE && !k.ChannelKeeper.HasInflightPackets(ctx, msg.PortId, msg.ChannelId) {
+		cbs.OnChanUpgradeOpen(ctx, msg.PortId, msg.ChannelId)
 
-			k.ChannelKeeper.WriteUpgradeOpenChannel(ctx, msg.PortId, msg.ChannelId)
+		k.ChannelKeeper.WriteUpgradeOpenChannel(ctx, msg.PortId, msg.ChannelId)
 
-			ctx.Logger().Info("channel upgrade open succeeded", "port-id", msg.PortId, "channel-id", msg.ChannelId)
-		}
+		ctx.Logger().Info("channel upgrade open succeeded", "port-id", msg.PortId, "channel-id", msg.ChannelId)
 	}
 
 	return &channeltypes.MsgChannelUpgradeAckResponse{Result: channeltypes.SUCCESS}, nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

from great suggestion left here https://github.com/cosmos/ibc-go/pull/4075#discussion_r1267936158. Does require we export `HasInflightPackets` but that function does seem like it should be public as other similar querying functions in keeper.

closes: #XXXX

### Commit Message / Changelog Entry

```bash
imp: use HasInflightPackets to check if channel has finished flushing in ChannelUpgradeAck
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
