### PR TITLE
add `IsUpgradError` func for readability

### DIFF
--- a/modules/core/04-channel/types/upgrade.go
+++ b/modules/core/04-channel/types/upgrade.go
@@ -118,7 +118,7 @@ func (u *UpgradeError) GetErrorReceipt() ErrorReceipt {
 	}
 }
 
-// IsUpgradeError returns true if err is of type UpgradeErroe, otherwise false.
+// IsUpgradeError returns true if err is of type UpgradeError, otherwise false.
 func IsUpgradeError(err error) bool {
 	_, ok := err.(*UpgradeError)
 	return ok

--- a/modules/core/04-channel/types/upgrade.go
+++ b/modules/core/04-channel/types/upgrade.go
@@ -117,3 +117,12 @@ func (u *UpgradeError) GetErrorReceipt() ErrorReceipt {
 		Message:  fmt.Sprintf("ABCI code: %d: %s", code, restoreErrorString),
 	}
 }
+
+// IsUpgradeError returns true if err is of type UpgradeErroe, otherwise false.
+func IsUpgradeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*UpgradeError)
+	return ok
+}

--- a/modules/core/04-channel/types/upgrade.go
+++ b/modules/core/04-channel/types/upgrade.go
@@ -120,9 +120,6 @@ func (u *UpgradeError) GetErrorReceipt() ErrorReceipt {
 
 // IsUpgradeError returns true if err is of type UpgradeErroe, otherwise false.
 func IsUpgradeError(err error) bool {
-	if err == nil {
-		return false
-	}
 	_, ok := err.(*UpgradeError)
 	return ok
 }

--- a/modules/core/04-channel/types/upgrade_test.go
+++ b/modules/core/04-channel/types/upgrade_test.go
@@ -171,3 +171,47 @@ func (suite *TypesTestSuite) TestUpgradeErrorUnwrap() {
 	suite.Require().Equal(types.ErrInvalidChannel, unWrapped, "unwrapped error was not equal to base underlying error")
 	suite.Require().Equal(originalUpgradeError, postUnwrapUpgradeError, "original error was modified when unwrapped")
 }
+
+func (suite *TypesTestSuite) TestIsUpgradeError() {
+	var (
+		err error
+	)
+
+	testCases := []struct {
+		msg      string
+		malleate func()
+		expPass  bool
+	}{
+		{
+			"true",
+			func() {},
+			true,
+		},
+		{
+			"false with non upgrade error",
+			func() {
+				err = errors.New("error")
+			},
+			false,
+		},
+		{
+			"false with nil error",
+			func() {
+				err = nil
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.msg, func() {
+			err = types.NewUpgradeError(1, types.ErrInvalidChannel)
+
+			tc.malleate()
+
+			res := types.IsUpgradeError(err)
+			suite.Require().Equal(tc.expPass, res)
+		})
+	}
+}

--- a/modules/core/04-channel/types/upgrade_test.go
+++ b/modules/core/04-channel/types/upgrade_test.go
@@ -173,9 +173,7 @@ func (suite *TypesTestSuite) TestUpgradeErrorUnwrap() {
 }
 
 func (suite *TypesTestSuite) TestIsUpgradeError() {
-	var (
-		err error
-	)
+	var err error
 
 	testCases := []struct {
 		msg      string

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -768,8 +768,8 @@ func (k Keeper) ChannelUpgradeTry(goCtx context.Context, msg *channeltypes.MsgCh
 	upgrade, err := k.ChannelKeeper.ChanUpgradeTry(ctx, msg.PortId, msg.ChannelId, msg.ProposedUpgradeConnectionHops, msg.UpgradeTimeout, msg.CounterpartyProposedUpgrade, msg.CounterpartyUpgradeSequence, msg.ProofChannel, msg.ProofUpgrade, msg.ProofHeight)
 	if err != nil {
 		ctx.Logger().Error("channel upgrade try failed", "error", errorsmod.Wrap(err, "channel upgrade try failed"))
-		if upgradeErr, ok := err.(*channeltypes.UpgradeError); ok {
-			k.ChannelKeeper.MustAbortUpgrade(ctx, msg.PortId, msg.ChannelId, upgradeErr)
+		if channeltypes.IsUpgradeError(err) {
+			k.ChannelKeeper.MustAbortUpgrade(ctx, msg.PortId, msg.ChannelId, err)
 			cbs.OnChanUpgradeRestore(ctx, msg.PortId, msg.ChannelId)
 
 			// NOTE: a FAILURE result is returned to the client and an error receipt is written to state.
@@ -823,8 +823,8 @@ func (k Keeper) ChannelUpgradeAck(goCtx context.Context, msg *channeltypes.MsgCh
 	err = k.ChannelKeeper.ChanUpgradeAck(ctx, msg.PortId, msg.ChannelId, msg.CounterpartyFlushStatus, msg.CounterpartyUpgrade, msg.ProofChannel, msg.ProofUpgrade, msg.ProofHeight)
 	if err != nil {
 		ctx.Logger().Error("channel upgrade ack failed", "error", errorsmod.Wrap(err, "channel upgrade ack failed"))
-		if upgradeErr, ok := err.(*channeltypes.UpgradeError); ok {
-			k.ChannelKeeper.MustAbortUpgrade(ctx, msg.PortId, msg.ChannelId, upgradeErr)
+		if channeltypes.IsUpgradeError(err) {
+			k.ChannelKeeper.MustAbortUpgrade(ctx, msg.PortId, msg.ChannelId, err)
 			cbs.OnChanUpgradeRestore(ctx, msg.PortId, msg.ChannelId)
 
 			// NOTE: a FAILURE result is returned to the client and an error receipt is written to state.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #3821


### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Review `Codecov Report` in the comment section below once CI passes.
