### PR TITLE
make connection lookup calls consistent in 04-channel

### DIFF
--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -93,9 +93,9 @@ func (k Keeper) ChanUpgradeTry(
 		return types.Upgrade{}, errorsmod.Wrapf(types.ErrInvalidChannelState, "expected one of [%s, %s], got %s", types.OPEN, types.INITUPGRADE, channel.State)
 	}
 
-	connection, err := k.GetConnection(ctx, channel.ConnectionHops[0])
-	if err != nil {
-		return types.Upgrade{}, errorsmod.Wrap(err, "failed to retrieve connection using the channel connection hops")
+	connection, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
+	if !found {
+		return types.Upgrade{}, errorsmod.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
 	}
 
 	if connection.GetState() != int32(connectiontypes.OPEN) {
@@ -117,7 +117,10 @@ func (k Keeper) ChanUpgradeTry(
 		Version:        counterpartyUpgrade.Fields.Version,
 	}
 
-	var upgrade types.Upgrade
+	var (
+		err     error
+		upgrade types.Upgrade
+	)
 
 	switch channel.State {
 	case types.OPEN:
@@ -164,7 +167,7 @@ func (k Keeper) ChanUpgradeTry(
 		FlushStatus:     types.NOTINFLUSH,
 	}
 
-	if err := k.startFlushUpgradeHandshake(
+	if err = k.startFlushUpgradeHandshake(
 		ctx,
 		portID, channelID,
 		proposedUpgradeFields,
@@ -236,9 +239,9 @@ func (k Keeper) ChanUpgradeAck(
 		return errorsmod.Wrapf(types.ErrInvalidFlushStatus, "expected one of [%s, %s], got %s", types.FLUSHING, types.FLUSHCOMPLETE, counterpartyFlushStatus)
 	}
 
-	connection, err := k.GetConnection(ctx, channel.ConnectionHops[0])
-	if err != nil {
-		return errorsmod.Wrap(err, "failed to retrieve connection using the channel connection hops")
+	connection, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
+	if !found {
+		return errorsmod.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
 	}
 
 	if connection.GetState() != int32(connectiontypes.OPEN) {
@@ -339,9 +342,9 @@ func (k Keeper) ChanUpgradeOpen(
 		return errorsmod.Wrapf(types.ErrInvalidFlushStatus, "expected %s, got %s", types.FLUSHCOMPLETE, channel.FlushStatus)
 	}
 
-	connection, err := k.GetConnection(ctx, channel.ConnectionHops[0])
-	if err != nil {
-		return errorsmod.Wrap(err, "failed to retrieve connection using the channel connection hops")
+	connection, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
+	if !found {
+		return errorsmod.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
 	}
 
 	if connection.GetState() != int32(connectiontypes.OPEN) {
@@ -356,9 +359,9 @@ func (k Keeper) ChanUpgradeOpen(
 			return errorsmod.Wrapf(types.ErrUpgradeNotFound, "failed to retrieve channel upgrade: port ID (%s) channel ID (%s)", portID, channelID)
 		}
 		// If counterparty has reached OPEN, we must use the upgraded connection to verify the counterparty channel
-		upgradeConnection, err := k.GetConnection(ctx, upgrade.Fields.ConnectionHops[0])
-		if err != nil {
-			return errorsmod.Wrap(err, "failed to retrieve connection using the upgrade connection hops")
+		upgradeConnection, found := k.connectionKeeper.GetConnection(ctx, upgrade.Fields.ConnectionHops[0])
+		if !found {
+			return errorsmod.Wrap(connectiontypes.ErrConnectionNotFound, upgrade.Fields.ConnectionHops[0])
 		}
 
 		if upgradeConnection.GetState() != int32(connectiontypes.OPEN) {
@@ -406,7 +409,7 @@ func (k Keeper) ChanUpgradeOpen(
 		panic(fmt.Sprintf("counterparty channel state should be in one of [%s, %s, %s]; got %s", types.TRYUPGRADE, types.ACKUPGRADE, types.OPEN, counterpartyChannelState))
 	}
 
-	if err = k.connectionKeeper.VerifyChannelState(
+	if err := k.connectionKeeper.VerifyChannelState(
 		ctx,
 		connection,
 		proofHeight, proofCounterpartyChannel,
@@ -465,9 +468,9 @@ func (k Keeper) ChanUpgradeCancel(ctx sdk.Context, portID, channelID string, err
 	}
 
 	// get underlying connection for proof verification
-	connection, err := k.GetConnection(ctx, channel.ConnectionHops[0])
-	if err != nil {
-		return errorsmod.Wrap(err, "failed to retrieve connection using the channel connection hops")
+	connection, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
+	if !found {
+		return errorsmod.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
 	}
 
 	if connection.GetState() != int32(connectiontypes.OPEN) {
@@ -674,9 +677,9 @@ func (k Keeper) startFlushUpgradeHandshake(
 		return errorsmod.Wrapf(types.ErrChannelNotFound, "port ID (%s) channel ID (%s)", portID, channelID)
 	}
 
-	connection, err := k.GetConnection(ctx, channel.ConnectionHops[0])
-	if err != nil {
-		return errorsmod.Wrap(err, "failed to retrieve connection using the channel connection hops")
+	connection, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
+	if !found {
+		return errorsmod.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
 	}
 
 	if connection.GetState() != int32(connectiontypes.OPEN) {
@@ -736,11 +739,11 @@ func (k Keeper) checkForUpgradeCompatibility(ctx sdk.Context, proposedUpgradeFie
 		return errorsmod.Wrapf(types.ErrIncompatibleCounterpartyUpgrade, "expected upgrade ordering (%s) to match counterparty upgrade ordering (%s)", proposedUpgradeFields.Ordering, counterpartyUpgrade.Fields.Ordering)
 	}
 
-	proposedConnection, err := k.GetConnection(ctx, proposedUpgradeFields.ConnectionHops[0])
-	if err != nil {
+	proposedConnection, found := k.connectionKeeper.GetConnection(ctx, proposedUpgradeFields.ConnectionHops[0])
+	if !found {
 		// NOTE: this error is expected to be unreachable as the proposed upgrade connectionID should have been
 		// validated in the upgrade INIT and TRY handlers
-		return errorsmod.Wrap(err, "expected proposed connection to be found")
+		return errorsmod.Wrap(connectiontypes.ErrConnectionNotFound, proposedUpgradeFields.ConnectionHops[0])
 	}
 
 	if proposedConnection.GetState() != int32(connectiontypes.OPEN) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #3840


### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
