### PR TITLE
imp: adding `IsOpen` and `IsClosed` methods to Channel type (#4152)

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/keeper/handshake.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/handshake.go
@@ -67,7 +67,7 @@ func (k Keeper) OnChanOpenInit(
 			panic(fmt.Sprintf("active channel mapping set for %s but channel does not exist in channel store", activeChannelID))
 		}
 
-		if channel.State == channeltypes.OPEN {
+		if channel.IsOpen() {
 			return "", errorsmod.Wrapf(icatypes.ErrActiveChannelAlreadySet, "existing active channel %s for portID %s is already OPEN", activeChannelID, portID)
 		}
 

--- a/modules/apps/27-interchain-accounts/controller/keeper/keeper.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/keeper.go
@@ -146,7 +146,7 @@ func (k Keeper) GetOpenActiveChannel(ctx sdk.Context, connectionID, portID strin
 
 	channel, found := k.channelKeeper.GetChannel(ctx, portID, channelID)
 
-	if found && channel.State == channeltypes.OPEN {
+	if found && channel.IsOpen() {
 		return channelID, true
 	}
 
@@ -161,7 +161,7 @@ func (k Keeper) IsActiveChannelClosed(ctx sdk.Context, connectionID, portID stri
 	}
 
 	channel, found := k.channelKeeper.GetChannel(ctx, portID, channelID)
-	return found && channel.State == channeltypes.CLOSED
+	return found && channel.IsClosed()
 }
 
 // GetAllActiveChannels returns a list of all active interchain accounts controller channels and their associated connection and port identifiers

--- a/modules/apps/27-interchain-accounts/host/keeper/handshake.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/handshake.go
@@ -51,7 +51,7 @@ func (k Keeper) OnChanOpenTry(
 			panic(fmt.Sprintf("active channel mapping set for %s but channel does not exist in channel store", activeChannelID))
 		}
 
-		if channel.State == channeltypes.OPEN {
+		if channel.IsOpen() {
 			return "", errorsmod.Wrapf(icatypes.ErrActiveChannelAlreadySet, "existing active channel %s for portID %s is already OPEN", activeChannelID, portID)
 		}
 

--- a/modules/apps/27-interchain-accounts/host/keeper/keeper.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/keeper.go
@@ -17,7 +17,6 @@ import (
 	genesistypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/genesis/types"
 	"github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
 	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
-	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
 	ibcerrors "github.com/cosmos/ibc-go/v7/modules/core/errors"
@@ -146,7 +145,7 @@ func (k Keeper) GetOpenActiveChannel(ctx sdk.Context, connectionID, portID strin
 
 	channel, found := k.channelKeeper.GetChannel(ctx, portID, channelID)
 
-	if found && channel.State == channeltypes.OPEN {
+	if found && channel.IsOpen() {
 		return channelID, true
 	}
 

--- a/modules/core/04-channel/keeper/handshake.go
+++ b/modules/core/04-channel/keeper/handshake.go
@@ -385,7 +385,7 @@ func (k Keeper) ChanCloseInit(
 		return errorsmod.Wrapf(types.ErrChannelNotFound, "port ID (%s) channel ID (%s)", portID, channelID)
 	}
 
-	if channel.State == types.CLOSED {
+	if channel.IsClosed() {
 		return errorsmod.Wrap(types.ErrInvalidChannelState, "channel is already CLOSED")
 	}
 
@@ -441,7 +441,7 @@ func (k Keeper) ChanCloseConfirm(
 		return errorsmod.Wrapf(types.ErrChannelNotFound, "port ID (%s) channel ID (%s)", portID, channelID)
 	}
 
-	if channel.State == types.CLOSED {
+	if channel.IsClosed() {
 		return errorsmod.Wrap(types.ErrInvalidChannelState, "channel is already CLOSED")
 	}
 

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -171,7 +171,7 @@ func (k Keeper) TimeoutExecuted(
 	// emit an event marking that we have processed the timeout
 	emitTimeoutPacketEvent(ctx, packet, channel)
 
-	if channel.Ordering == types.ORDERED && channel.State == types.CLOSED {
+	if channel.Ordering == types.ORDERED && channel.IsClosed() {
 		emitChannelClosedEvent(ctx, packet, channel)
 	}
 

--- a/modules/core/04-channel/types/channel.go
+++ b/modules/core/04-channel/types/channel.go
@@ -51,6 +51,16 @@ func (ch Channel) GetVersion() string {
 	return ch.Version
 }
 
+// IsOpen returns true if the channel state is OPEN
+func (ch Channel) IsOpen() bool {
+	return ch.State == OPEN
+}
+
+// IsClosed returns true if the channel state is CLOSED
+func (ch Channel) IsClosed() bool {
+	return ch.State == CLOSED
+}
+
 // ValidateBasic performs a basic validation of the channel fields
 func (ch Channel) ValidateBasic() error {
 	if ch.State == UNINITIALIZED {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Add IsOpen and IsClosed methods to Channel. 

closes: #4152


### Commit Message / Changelog Entry

```bash
imp: adding `IsOpen` and `IsClosed` methods to Channel type (#4152)
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Review `Codecov Report` in the comment section below once CI passes.
