### PR TITLE
Use hasConsensusState instead of GetConsensusState

### DIFF
--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -176,7 +176,7 @@ func (cs ClientState) VerifyMembership(
 		return errorsmod.Wrapf(ibcerrors.ErrInvalidType, "expected %T, got %T", commitmenttypes.MerklePath{}, path)
 	}
 
-	found := hasConsensusState(clientStore, cdc, height)
+	found := hasConsensusState(clientStore, height)
 	if !found {
 		return errorsmod.Wrapf(clienttypes.ErrConsensusStateNotFound, "please ensure the proof was constructed against a height that exists on the client")
 	}
@@ -233,7 +233,7 @@ func (cs ClientState) VerifyNonMembership(
 		return errorsmod.Wrapf(ibcerrors.ErrInvalidType, "expected %T, got %T", commitmenttypes.MerklePath{}, path)
 	}
 
-	found := hasConsensusState(clientStore, cdc, height)
+	found := hasConsensusState(clientStore, height)
 	if !found {
 		return errorsmod.Wrapf(clienttypes.ErrConsensusStateNotFound, "please ensure the proof was constructed against a height that exists on the client")
 	}

--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -176,9 +176,9 @@ func (cs ClientState) VerifyMembership(
 		return errorsmod.Wrapf(ibcerrors.ErrInvalidType, "expected %T, got %T", commitmenttypes.MerklePath{}, path)
 	}
 
-	_, err := GetConsensusState(clientStore, cdc, height)
-	if err != nil {
-		return errorsmod.Wrap(err, "please ensure the proof was constructed against a height that exists on the client")
+	found := hasConsensusState(clientStore, cdc, height)
+	if !found {
+		return errorsmod.Wrapf(clienttypes.ErrConsensusStateNotFound, "please ensure the proof was constructed against a height that exists on the client")
 	}
 
 	payload := verifyMembershipPayload{
@@ -191,7 +191,7 @@ func (cs ClientState) VerifyMembership(
 			Value:            value,
 		},
 	}
-	_, err = call[contractResult](ctx, clientStore, &cs, payload)
+	_, err := call[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }
 
@@ -233,9 +233,9 @@ func (cs ClientState) VerifyNonMembership(
 		return errorsmod.Wrapf(ibcerrors.ErrInvalidType, "expected %T, got %T", commitmenttypes.MerklePath{}, path)
 	}
 
-	_, err := GetConsensusState(clientStore, cdc, height)
-	if err != nil {
-		return errorsmod.Wrap(err, "please ensure the proof was constructed against a height that exists on the client")
+	found := hasConsensusState(clientStore, cdc, height)
+	if !found {
+		return errorsmod.Wrapf(clienttypes.ErrConsensusStateNotFound, "please ensure the proof was constructed against a height that exists on the client")
 	}
 
 	payload := verifyNonMembershipPayload{
@@ -247,7 +247,7 @@ func (cs ClientState) VerifyNonMembership(
 			Path:             path,
 		},
 	}
-	_, err = call[contractResult](ctx, clientStore, &cs, payload)
+	_, err := call[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }
 

--- a/modules/light-clients/08-wasm/types/store.go
+++ b/modules/light-clients/08-wasm/types/store.go
@@ -6,8 +6,6 @@ import (
 
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 
-	errorsmod "cosmossdk.io/errors"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
 	"github.com/cosmos/cosmos-sdk/store/listenkv"
@@ -110,25 +108,9 @@ func setConsensusState(clientStore sdk.KVStore, cdc codec.BinaryCodec, consensus
 	clientStore.Set(key, val)
 }
 
-// getConsensusState retrieves the consensus state from the client prefixed
-// store. An error is returned if the consensus state does not exist or it cannot be unmarshalled.
-func GetConsensusState(clientStore sdk.KVStore, cdc codec.BinaryCodec, height exported.Height) (*ConsensusState, error) {
-	bz := clientStore.Get(host.ConsensusStateKey(height))
-	if len(bz) == 0 {
-		return nil, errorsmod.Wrapf(clienttypes.ErrConsensusStateNotFound, "consensus state does not exist for height %s", height)
-	}
-
-	consensusStateI, err := clienttypes.UnmarshalConsensusState(cdc, bz)
-	if err != nil {
-		return nil, errorsmod.Wrapf(clienttypes.ErrInvalidConsensus, "unmarshal error: %v", err)
-	}
-
-	consensusState, ok := consensusStateI.(*ConsensusState)
-	if !ok {
-		return nil, errorsmod.Wrapf(clienttypes.ErrInvalidConsensus, "invalid consensus type. expected %T, got %T", &ConsensusState{}, consensusState)
-	}
-
-	return consensusState, nil
+// hasConsensusState returns true if a consensus state at the given height exists in the store.
+func hasConsensusState(clientStore sdk.KVStore, cdc codec.BinaryCodec, height exported.Height) bool {
+	return clientStore.Has(host.ConsensusStateKey(height))
 }
 
 var _ wasmvmtypes.KVStore = &storeAdapter{}

--- a/modules/light-clients/08-wasm/types/store.go
+++ b/modules/light-clients/08-wasm/types/store.go
@@ -109,7 +109,7 @@ func setConsensusState(clientStore sdk.KVStore, cdc codec.BinaryCodec, consensus
 }
 
 // hasConsensusState returns true if a consensus state at the given height exists in the store.
-func hasConsensusState(clientStore sdk.KVStore, cdc codec.BinaryCodec, height exported.Height) bool {
+func hasConsensusState(clientStore sdk.KVStore, height exported.Height) bool {
 	return clientStore.Has(host.ConsensusStateKey(height))
 }
 

--- a/modules/light-clients/08-wasm/types/upgrade.go
+++ b/modules/light-clients/08-wasm/types/upgrade.go
@@ -57,7 +57,7 @@ func (cs ClientState) VerifyUpgradeAndUpdateState(
 	// Must prove against latest consensus state to ensure we are verifying against latest upgrade plan
 	// This verifies that upgrade is intended for the provided revision, since committed client must exist
 	// at this consensus state
-	found := hasConsensusState(clientStore, cdc, lastHeight)
+	found := hasConsensusState(clientStore, lastHeight)
 	if !found {
 		return errorsmod.Wrapf(clienttypes.ErrConsensusStateNotFound, "could not retrieve consensus state for height %s", lastHeight)
 	}

--- a/modules/light-clients/08-wasm/types/upgrade.go
+++ b/modules/light-clients/08-wasm/types/upgrade.go
@@ -57,9 +57,9 @@ func (cs ClientState) VerifyUpgradeAndUpdateState(
 	// Must prove against latest consensus state to ensure we are verifying against latest upgrade plan
 	// This verifies that upgrade is intended for the provided revision, since committed client must exist
 	// at this consensus state
-	_, err := GetConsensusState(clientStore, cdc, lastHeight)
-	if err != nil {
-		return errorsmod.Wrapf(err, "could not retrieve consensus state for height %s", lastHeight)
+	found := hasConsensusState(clientStore, cdc, lastHeight)
+	if !found {
+		return errorsmod.Wrapf(clienttypes.ErrConsensusStateNotFound, "could not retrieve consensus state for height %s", lastHeight)
 	}
 
 	payload := verifyUpgradeAndUpdateStatePayload{
@@ -71,6 +71,6 @@ func (cs ClientState) VerifyUpgradeAndUpdateState(
 		},
 	}
 
-	_, err = call[contractResult](ctx, clientStore, &cs, payload)
+	_, err := call[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

closes: #4010

### Commit Message / Changelog Entry

```bash
chore: replace GetConsensusState with HasConsensusState
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
