### PR TITLE
Use wasmQuery for the rest of the query functions.

### DIFF
--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -191,7 +191,6 @@ func (cs ClientState) VerifyMembership(
 			Value:            value,
 		},
 	}
-
 	_, err = wasmQuery[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }
@@ -248,7 +247,6 @@ func (cs ClientState) VerifyNonMembership(
 			Path:             path,
 		},
 	}
-
 	_, err = wasmQuery[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }

--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -191,7 +191,7 @@ func (cs ClientState) VerifyMembership(
 			Value:            value,
 		},
 	}
-	_, err = wasmQuery[contractResult](ctx, clientStore, &cs, payload)
+	_, err := wasmQuery[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }
 
@@ -247,7 +247,7 @@ func (cs ClientState) VerifyNonMembership(
 			Path:             path,
 		},
 	}
-	_, err = wasmQuery[contractResult](ctx, clientStore, &cs, payload)
+	_, err := wasmQuery[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }
 

--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -191,7 +191,7 @@ func (cs ClientState) VerifyMembership(
 			Value:            value,
 		},
 	}
-	_, err = call[contractResult](ctx, clientStore, &cs, payload)
+	_, err = wasmQuery[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }
 
@@ -247,7 +247,7 @@ func (cs ClientState) VerifyNonMembership(
 			Path:             path,
 		},
 	}
-	_, err = call[contractResult](ctx, clientStore, &cs, payload)
+	_, err = wasmQuery[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }
 

--- a/modules/light-clients/08-wasm/types/misbehaviour_handle.go
+++ b/modules/light-clients/08-wasm/types/misbehaviour_handle.go
@@ -41,7 +41,7 @@ func (cs ClientState) CheckForMisbehaviour(ctx sdk.Context, _ codec.BinaryCodec,
 		CheckForMisbehaviour: inner,
 	}
 
-	result, err := call[CheckForMisbehaviourExecuteResult](ctx, clientStore, &cs, payload)
+	result, err := wasmQuery[CheckForMisbehaviourExecuteResult](ctx, clientStore, &cs, payload)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/light-clients/08-wasm/types/update.go
+++ b/modules/light-clients/08-wasm/types/update.go
@@ -45,7 +45,7 @@ func (cs ClientState) VerifyClientMessage(ctx sdk.Context, _ codec.BinaryCodec, 
 	payload := verifyClientMessagePayload{
 		VerifyClientMessage: inner,
 	}
-	_, err := call[contractResult](ctx, clientStore, &cs, payload)
+	_, err := wasmQuery[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Switches the relevant ClientState functions that query to use wasmQuery.

closes: #4105 


### Commit Message / Changelog Entry

```bash
chore: use wasmQuery with querying functions of ClientState.
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
