### PR TITLE
Use collections.Contains in metadata, version.

### DIFF
--- a/modules/apps/27-interchain-accounts/types/metadata.go
+++ b/modules/apps/27-interchain-accounts/types/metadata.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/cosmos/ibc-go/v7/internal/collections"
 	connectiontypes "github.com/cosmos/ibc-go/v7/modules/core/03-connection/types"
 )
 
@@ -133,13 +134,7 @@ func ValidateHostMetadata(ctx sdk.Context, channelKeeper ChannelKeeper, connecti
 
 // isSupportedEncoding returns true if the provided encoding is supported, otherwise false
 func isSupportedEncoding(encoding string) bool {
-	for _, enc := range getSupportedEncoding() {
-		if enc == encoding {
-			return true
-		}
-	}
-
-	return false
+	return collections.Contains(encoding, getSupportedEncoding())
 }
 
 // getSupportedEncoding returns a string slice of supported encoding formats
@@ -149,13 +144,7 @@ func getSupportedEncoding() []string {
 
 // isSupportedTxType returns true if the provided transaction type is supported, otherwise false
 func isSupportedTxType(txType string) bool {
-	for _, t := range getSupportedTxTypes() {
-		if t == txType {
-			return true
-		}
-	}
-
-	return false
+	return collections.Contains(txType, getSupportedTxTypes())
 }
 
 // getSupportedTxTypes returns a string slice of supported transaction types

--- a/modules/core/03-connection/types/version.go
+++ b/modules/core/03-connection/types/version.go
@@ -6,7 +6,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 
 	"github.com/cosmos/ibc-go/v7/internal/collections"
-	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 )
 
 var (
@@ -100,7 +99,7 @@ func (version Version) VerifyProposedVersion(proposedVersion *Version) error {
 
 // VerifySupportedFeature takes in a version and feature string and returns
 // true if the feature is supported by the version and false otherwise.
-func VerifySupportedFeature(version exported.Version, feature string) bool {
+func VerifySupportedFeature(version *Version, feature string) bool {
 	return collections.Contains(feature, version.GetFeatures())
 }
 

--- a/modules/core/03-connection/types/version.go
+++ b/modules/core/03-connection/types/version.go
@@ -103,12 +103,7 @@ func (version Version) VerifyProposedVersion(proposedVersion exported.Version) e
 // VerifySupportedFeature takes in a version and feature string and returns
 // true if the feature is supported by the version and false otherwise.
 func VerifySupportedFeature(version exported.Version, feature string) bool {
-	for _, f := range version.GetFeatures() {
-		if f == feature {
-			return true
-		}
-	}
-	return false
+	return collections.Contains(feature, version.GetFeatures())
 }
 
 // GetCompatibleVersions returns a descending ordered set of compatible IBC

--- a/modules/core/03-connection/types/version.go
+++ b/modules/core/03-connection/types/version.go
@@ -5,7 +5,7 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 
-	collections "github.com/cosmos/ibc-go/v7/internal/collections"
+	"github.com/cosmos/ibc-go/v7/internal/collections"
 	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 )
 


### PR DESCRIPTION
## Description

closes: #XXXX

### Commit Message / Changelog Entry

```bash
nit: use collections.Contains when checking for supported encoding, tx and feature.
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
