### PR TITLE
Disallow events, attributes being returned from a contract.

### DIFF
--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -220,8 +220,15 @@ func call[T ContractResult](ctx sdk.Context, clientStore sdk.KVStore, cs *Client
 	if err != nil {
 		return result, errorsmod.Wrapf(err, "call to wasm contract failed")
 	}
+	// Only allow Data to flow back to us. SubMessages, Events and Attributes are not allowed.
 	if len(resp.Messages) > 0 {
 		return result, errorsmod.Wrapf(ErrWasmSubMessagesNotAllowed, "code hash (%s)", hex.EncodeToString(cs.CodeHash))
+	}
+	if len(resp.Events) > 0 {
+		return result, errorsmod.Wrapf(ErrWasmEventsNotAllowed, "code hash (%s)", hex.EncodeToString(cs.CodeHash))
+	}
+	if len(resp.Attributes) > 0 {
+		return result, errorsmod.Wrapf(ErrWasmAttributesNotAllowed, "code hash (%s)", hex.EncodeToString(cs.CodeHash))
 	}
 	if err := json.Unmarshal(resp.Data, &result); err != nil {
 		return result, errorsmod.Wrapf(err, "failed to unmarshal result of wasm execution")

--- a/modules/light-clients/08-wasm/types/errors.go
+++ b/modules/light-clients/08-wasm/types/errors.go
@@ -13,4 +13,6 @@ var (
 	ErrWasmCodeExists            = errorsmod.Register(ModuleName, 8, "wasm code already exists")
 	ErrWasmCodeHashNotFound      = errorsmod.Register(ModuleName, 9, "wasm code hash not found")
 	ErrWasmSubMessagesNotAllowed = errorsmod.Register(ModuleName, 10, "execution of sub messages is not allowed")
+	ErrWasmEventsNotAllowed      = errorsmod.Register(ModuleName, 11, "returning events from a contract is not allowed")
+	ErrWasmAttributesNotAllowed  = errorsmod.Register(ModuleName, 12, "returning attributes from a contract is not allowed")
 )


### PR DESCRIPTION
## Description

As it done with SubMessages. This is an inital restriction that can easily be relaxed in a non-api-breaking way in the future.

closes: #4214 

### Commit Message / Changelog Entry

```bash
chore: Disallow events, attributes to be returned from a contract
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
