### PR TITLE
Allow same VM to be assigned to the global vm.

### DIFF
--- a/modules/light-clients/08-wasm/keeper/keeper.go
+++ b/modules/light-clients/08-wasm/keeper/keeper.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"reflect"
 
 	wasmvm "github.com/CosmWasm/wasmvm"
 
@@ -37,8 +38,8 @@ func NewKeeperWithVM(
 	authority string,
 	vm *wasmvm.VM,
 ) Keeper {
-	if types.WasmVM != nil {
-		panic("global Wasm VM instance should not be already set before calling this function")
+	if types.WasmVM != nil && !reflect.DeepEqual(types.WasmVM, vm) {
+		panic("global Wasm VM instance should not be set to a different instance")
 	}
 
 	types.WasmVM = vm


### PR DESCRIPTION
## Description

Disallowing the re-assignment breaks testing since we create many testing chains ([ref](https://github.com/cosmos/ibc-go/actions/runs/5737304988/job/15548678710?pr=4222#step:4:154)). Changed to allow a different but deeply equal VM to be assigned. 

Opened #4235 to eventually discuss this.

### Commit Message / Changelog Entry

```bash
chore: allow re-assignment of vm if new vm is equal.
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
