### PR TITLE
Clean up vm entry points

### DIFF
--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -115,8 +115,7 @@ func (cs ClientState) Initialize(ctx sdk.Context, _ codec.BinaryCodec, clientSto
 	// The global store key can be used here to implement #4085
 	// wasmStore := ctx.KVStore(WasmStoreKey)
 
-	err := wasmInit(ctx, clientStore, &cs, payload)
-	return err
+	return wasmInit(ctx, clientStore, &cs, payload)
 }
 
 // VerifyMembership is a generic proof verification method which verifies a proof of the existence of a value at a given CommitmentPath at the specified height.

--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"encoding/json"
-
 	errorsmod "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -114,19 +112,11 @@ func (cs ClientState) Initialize(ctx sdk.Context, _ codec.BinaryCodec, clientSto
 		ConsensusState: consensusState,
 	}
 
-	encodedData, err := json.Marshal(payload)
-	if err != nil {
-		return errorsmod.Wrapf(err, "failed to marshal payload for wasm contract instantiation")
-	}
-
 	// The global store key can be used here to implement #4085
 	// wasmStore := ctx.KVStore(WasmStoreKey)
 
-	_, err = initContract(ctx, clientStore, cs.CodeHash, encodedData)
-	if err != nil {
-		return errorsmod.Wrapf(err, "failed to initialize contract")
-	}
-	return nil
+	err := wasmInit(ctx, clientStore, &cs, payload)
+	return err
 }
 
 // VerifyMembership is a generic proof verification method which verifies a proof of the existence of a value at a given CommitmentPath at the specified height.

--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -209,8 +209,8 @@ func (cs ClientState) VerifyNonMembership(
 	return err
 }
 
-// call calls the contract with the given payload and returns the result.
-func call[T ContractResult](ctx sdk.Context, clientStore sdk.KVStore, cs *ClientState, payload any) (T, error) {
+// wasmCall calls the contract with the given payload and returns the result.
+func wasmCall[T ContractResult](ctx sdk.Context, clientStore sdk.KVStore, cs *ClientState, payload any) (T, error) {
 	var result T
 	encodedData, err := json.Marshal(payload)
 	if err != nil {

--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -1,9 +1,7 @@
 package types
 
 import (
-	"encoding/hex"
 	"encoding/json"
-	"errors"
 
 	errorsmod "cosmossdk.io/errors"
 
@@ -207,54 +205,4 @@ func (cs ClientState) VerifyNonMembership(
 	}
 	_, err := wasmQuery[contractResult](ctx, clientStore, &cs, payload)
 	return err
-}
-
-// wasmCall calls the contract with the given payload and returns the result.
-func wasmCall[T ContractResult](ctx sdk.Context, clientStore sdk.KVStore, cs *ClientState, payload any) (T, error) {
-	var result T
-	encodedData, err := json.Marshal(payload)
-	if err != nil {
-		return result, errorsmod.Wrapf(err, "failed to marshal payload for wasm execution")
-	}
-	resp, err := callContract(ctx, clientStore, cs.CodeHash, encodedData)
-	if err != nil {
-		return result, errorsmod.Wrapf(err, "call to wasm contract failed")
-	}
-	// Only allow Data to flow back to us. SubMessages, Events and Attributes are not allowed.
-	if len(resp.Messages) > 0 {
-		return result, errorsmod.Wrapf(ErrWasmSubMessagesNotAllowed, "code hash (%s)", hex.EncodeToString(cs.CodeHash))
-	}
-	if len(resp.Events) > 0 {
-		return result, errorsmod.Wrapf(ErrWasmEventsNotAllowed, "code hash (%s)", hex.EncodeToString(cs.CodeHash))
-	}
-	if len(resp.Attributes) > 0 {
-		return result, errorsmod.Wrapf(ErrWasmAttributesNotAllowed, "code hash (%s)", hex.EncodeToString(cs.CodeHash))
-	}
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return result, errorsmod.Wrapf(err, "failed to unmarshal result of wasm execution")
-	}
-	if !result.Validate() {
-		return result, errorsmod.Wrapf(errors.New(result.Error()), "error occurred while executing contract with code hash %s", hex.EncodeToString(cs.CodeHash))
-	}
-	return result, nil
-}
-
-// wasmQuery queries the contract with the given payload and returns the result.
-func wasmQuery[T ContractResult](ctx sdk.Context, clientStore sdk.KVStore, cs *ClientState, payload any) (T, error) {
-	var result T
-	encodedData, err := json.Marshal(payload)
-	if err != nil {
-		return result, errorsmod.Wrapf(err, "failed to marshal payload for wasm query")
-	}
-	resp, err := queryContract(ctx, clientStore, cs.CodeHash, encodedData)
-	if err != nil {
-		return result, errorsmod.Wrapf(err, "query to wasm contract failed")
-	}
-	if err := json.Unmarshal(resp, &result); err != nil {
-		return result, errorsmod.Wrapf(err, "failed to unmarshal result of wasm query")
-	}
-	if !result.Validate() {
-		return result, errorsmod.Wrapf(errors.New(result.Error()), "error occurred while querying contract with code hash %s", hex.EncodeToString(cs.CodeHash))
-	}
-	return result, nil
 }

--- a/modules/light-clients/08-wasm/types/proposal_handle.go
+++ b/modules/light-clients/08-wasm/types/proposal_handle.go
@@ -39,6 +39,6 @@ func (cs ClientState) CheckSubstituteAndUpdateState(
 		CheckSubstituteAndUpdateState: &checkSubstituteAndUpdateStateMsg{},
 	}
 
-	_, err := call[contractResult](ctx, store, &cs, payload)
+	_, err := wasmCall[contractResult](ctx, store, &cs, payload)
 	return err
 }

--- a/modules/light-clients/08-wasm/types/update.go
+++ b/modules/light-clients/08-wasm/types/update.go
@@ -42,7 +42,7 @@ func (cs ClientState) UpdateState(ctx sdk.Context, cdc codec.BinaryCodec, client
 		UpdateState: &updateStateMsg{ClientMessage: clientMessage},
 	}
 
-	result, err := call[updateStateResult](ctx, clientStore, &cs, payload)
+	result, err := wasmCall[updateStateResult](ctx, clientStore, &cs, payload)
 	if err != nil {
 		panic(err)
 	}
@@ -62,7 +62,7 @@ func (cs ClientState) UpdateStateOnMisbehaviour(ctx sdk.Context, _ codec.BinaryC
 		UpdateStateOnMisbehaviour: &updateStateOnMisbehaviourMsg{ClientMessage: clientMessage},
 	}
 
-	_, err := call[contractResult](ctx, clientStore, &cs, payload)
+	_, err := wasmCall[contractResult](ctx, clientStore, &cs, payload)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/light-clients/08-wasm/types/upgrade.go
+++ b/modules/light-clients/08-wasm/types/upgrade.go
@@ -51,6 +51,6 @@ func (cs ClientState) VerifyUpgradeAndUpdateState(
 		},
 	}
 
-	_, err := call[contractResult](ctx, clientStore, &cs, payload)
+	_, err := wasmCall[contractResult](ctx, clientStore, &cs, payload)
 	return err
 }

--- a/modules/light-clients/08-wasm/types/vm.go
+++ b/modules/light-clients/08-wasm/types/vm.go
@@ -1,6 +1,11 @@
 package types
 
 import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+
+	errorsmod "cosmossdk.io/errors"
 	wasmvm "github.com/CosmWasm/wasmvm"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 
@@ -62,6 +67,56 @@ func queryContract(ctx sdk.Context, clientStore sdk.KVStore, codeHash []byte, ms
 	resp, gasUsed, err := WasmVM.Query(codeHash, env, msg, newStoreAdapter(clientStore), wasmvm.GoAPI{}, nil, multipliedGasMeter, gasLimit, costJSONDeserialization)
 	VMGasRegister.consumeRuntimeGas(ctx, gasUsed)
 	return resp, err
+}
+
+// wasmCall calls the contract with the given payload and returns the result.
+func wasmCall[T ContractResult](ctx sdk.Context, clientStore sdk.KVStore, cs *ClientState, payload sudoMsg) (T, error) {
+	var result T
+	encodedData, err := json.Marshal(payload)
+	if err != nil {
+		return result, errorsmod.Wrapf(err, "failed to marshal payload for wasm execution")
+	}
+	resp, err := callContract(ctx, clientStore, cs.CodeHash, encodedData)
+	if err != nil {
+		return result, errorsmod.Wrapf(err, "call to wasm contract failed")
+	}
+	// Only allow Data to flow back to us. SubMessages, Events and Attributes are not allowed.
+	if len(resp.Messages) > 0 {
+		return result, errorsmod.Wrapf(ErrWasmSubMessagesNotAllowed, "code hash (%s)", hex.EncodeToString(cs.CodeHash))
+	}
+	if len(resp.Events) > 0 {
+		return result, errorsmod.Wrapf(ErrWasmEventsNotAllowed, "code hash (%s)", hex.EncodeToString(cs.CodeHash))
+	}
+	if len(resp.Attributes) > 0 {
+		return result, errorsmod.Wrapf(ErrWasmAttributesNotAllowed, "code hash (%s)", hex.EncodeToString(cs.CodeHash))
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return result, errorsmod.Wrapf(err, "failed to unmarshal result of wasm execution")
+	}
+	if !result.Validate() {
+		return result, errorsmod.Wrapf(errors.New(result.Error()), "error occurred while executing contract with code hash %s", hex.EncodeToString(cs.CodeHash))
+	}
+	return result, nil
+}
+
+// wasmQuery queries the contract with the given payload and returns the result.
+func wasmQuery[T ContractResult](ctx sdk.Context, clientStore sdk.KVStore, cs *ClientState, payload queryMsg) (T, error) {
+	var result T
+	encodedData, err := json.Marshal(payload)
+	if err != nil {
+		return result, errorsmod.Wrapf(err, "failed to marshal payload for wasm query")
+	}
+	resp, err := queryContract(ctx, clientStore, cs.CodeHash, encodedData)
+	if err != nil {
+		return result, errorsmod.Wrapf(err, "query to wasm contract failed")
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return result, errorsmod.Wrapf(err, "failed to unmarshal result of wasm query")
+	}
+	if !result.Validate() {
+		return result, errorsmod.Wrapf(errors.New(result.Error()), "error occurred while querying contract with code hash %s", hex.EncodeToString(cs.CodeHash))
+	}
+	return result, nil
 }
 
 // getEnv returns the state of the blockchain environment the contract is running on


### PR DESCRIPTION
## Description

Does a couple of things that seemed sensible to me:

 - Move `wasmQuery` and `wasmCall` into `vm`, these are shared across files and them being in `client_state` mostly served to making me struggle to remember where they were.
 - `any` -> Concrete type.
 - Add `wasmInit` in a similar vein. Now all `wasm*` functions take the concrete msg, marshal it, call into their own respective functions and then handle the error.

closes: #XXXX


### Commit Message / Changelog Entry

```bash
chore: normalize internal api for calling/querying contracts.
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
