### PR TITLE
Add store functions for counterparty upgrade.

### DIFF
--- a/modules/core/04-channel/keeper/keeper.go
+++ b/modules/core/04-channel/keeper/keeper.go
@@ -551,6 +551,33 @@ func (k Keeper) deleteUpgrade(ctx sdk.Context, portID, channelID string) {
 	store.Delete(host.ChannelUpgradeKey(portID, channelID))
 }
 
+// GetCounterpartyUpgrade gets the counterparty upgrade from the store.
+func (k Keeper) GetCounterpartyUpgrade(ctx sdk.Context, portID, channelID string) (types.Upgrade, bool) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(host.ChannelCounterpartyUpgradeKey(portID, channelID))
+	if bz == nil {
+		return types.Upgrade{}, false
+	}
+
+	var upgrade types.Upgrade
+	k.cdc.MustUnmarshal(bz, &upgrade)
+
+	return upgrade, true
+}
+
+// SetUpgrade sets the counterparty upgrade in the store.
+func (k Keeper) SetCounterpartyUpgrade(ctx sdk.Context, portID, channelID string, upgrade types.Upgrade) {
+	store := ctx.KVStore(k.storeKey)
+	bz := k.cdc.MustMarshal(&upgrade)
+	store.Set(host.ChannelCounterpartyUpgradeKey(portID, channelID), bz)
+}
+
+// deleteUpgrade deletes the counterparty upgrade in the store.
+func (k Keeper) deleteCounterpartyUpgrade(ctx sdk.Context, portID, channelID string) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(host.ChannelCounterpartyUpgradeKey(portID, channelID))
+}
+
 // common functionality for IteratePacketCommitment and IteratePacketAcknowledgement
 func (k Keeper) iterateHashes(ctx sdk.Context, iterator db.Iterator, cb func(portID, channelID string, sequence uint64, hash []byte) bool) {
 	defer sdk.LogDeferred(ctx.Logger(), func() error { return iterator.Close() })

--- a/modules/core/24-host/channel_keys.go
+++ b/modules/core/24-host/channel_keys.go
@@ -9,6 +9,7 @@ const (
 	KeyUpgradePrefix                  = "upgrades"
 	KeyUpgradeErrorPrefix             = "upgradeError"
 	KeyCounterpartyLastPacketSequence = "counterpartyLastPacketSequence"
+	KeyCounterpartyUpgrade            = "counterpartyUpgrade"
 	KeyChannelCapabilityPrefix        = "capabilities"
 )
 
@@ -59,6 +60,16 @@ func ChannelCounterpartyLastPacketSequenceKey(portID, channelID string) []byte {
 // ChannelCounterpartyLastPacketSequencePath defines the path under which the last packet sequence sent on the counterparty channel is stored.
 func ChannelCounterpartyLastPacketSequencePath(portID, channelID string) string {
 	return fmt.Sprintf("%s/%s/%s", KeyChannelUpgradePrefix, KeyCounterpartyLastPacketSequence, channelPath(portID, channelID))
+}
+
+// ChannelCounterpartyUpgradeKey returns the store key for the upgrade used on the counterparty channel.
+func ChannelCounterpartyUpgradeKey(portID, channelID string) []byte {
+	return []byte(ChannelCounterpartyUpgradePath(portID, channelID))
+}
+
+// ChannelCounterpartyUpgradePath defines the path under which the upgrade used on the counterparty channel is stored.
+func ChannelCounterpartyUpgradePath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s/%s", KeyChannelUpgradePrefix, KeyCounterpartyUpgrade, channelPath(portID, channelID))
 }
 
 func channelPath(portID, channelID string) string {


### PR DESCRIPTION
## Description

closes: #4233 


### Commit Message / Changelog Entry

```bash
chore: add store functions for the counterparty upgrade
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
