### PR TITLE
fix(testing): update validators before UpdateClient call

### DIFF
--- a/testing/chain.go
+++ b/testing/chain.go
@@ -279,14 +279,14 @@ func (chain *TestChain) NextBlock() {
 
 	chain.App.Commit()
 
-	// set the last header to the current header
-	// use nil trusted fields
-	chain.LastHeader = chain.CurrentTMClientHeader()
-
 	// val set changes returned from previous block get applied to the next validators
 	// of this block. See tendermint spec for details.
 	chain.Vals = chain.NextVals
 	chain.NextVals = ApplyValSetChanges(chain.T, chain.Vals, res.ValidatorUpdates)
+
+	// set the last header to the current header
+	// use nil trusted fields
+	chain.LastHeader = chain.CurrentTMClientHeader()
 
 	// increment the current header
 	chain.CurrentHeader = tmproto.Header{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The current version of [ICS][0] uses a copy of `ibc-go/testing`, located in the `legacy_ibc_testing` folder, because it requires a couple of shims to work properly in its context.

There's a pending [PR][1] where this folder is removed and where ICS really uses this repo for testing.  I was able to workaround most of the shims, except one that in my opinion requires a change in `ibco-go/testing`. This change (contained in this PR) switches the order of 2 instructions in the `NextBlock()` function.

Currently, the validators are updated after the `chain.LastHeader` update, which, in the context of the ICS tests, makes the `UpdateClient()` call fail, because the trusted validators hash doesn't match the consensus state next validators hash. The condition that fails is exactly here:

https://github.com/cosmos/ibc-go/blob/71c6d71bb2f8712ef344c64f7805b56ef10c83b9/modules/light-clients/07-tendermint/update.go#L215

The patch simply ensures that the validators are updated before the `lastHeader` is updated, which fix the problem for ICS. For this repo, this change doesn't fail the tests, but I lack knowledge on IBC to undertand all the consequences, so please let me know if this is irrelevant. In that case we'll probably have to find an other workaround or to keep the `legacy_ibc_testing` folder in ICS.

This change targets the `release/v7.2.x` branch because ICS depends on 7.1.0. Ideally, we expect to have this patch in a 7.2.1 or 7.3.0, please let us know what's possible.

[0]: https://github.com/cosmos/interchain-security
[1]: https://github.com/cosmos/interchain-security/pull/1185


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
