### PR TITLE
Remove verification calls in startFlushUpgradeHandshake

### DIFF
--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -734,30 +734,6 @@ func (k Keeper) startFlushUpgradeHandshake(
 		return errorsmod.Wrapf(connectiontypes.ErrInvalidConnectionState, "connection state is not OPEN (got %s)", connectiontypes.State(connection.GetState()).String())
 	}
 
-	// verify the counterparty channel state containing the upgrade sequence
-	if err := k.connectionKeeper.VerifyChannelState(
-		ctx,
-		connection,
-		proofHeight, proofCounterpartyChannel,
-		channel.Counterparty.PortId,
-		channel.Counterparty.ChannelId,
-		counterpartyChannel,
-	); err != nil {
-		return errorsmod.Wrap(err, "failed to verify counterparty channel state")
-	}
-
-	// verifies the proof that a particular proposed upgrade has been stored in the upgrade path of the counterparty
-	if err := k.connectionKeeper.VerifyChannelUpgrade(
-		ctx,
-		channel.Counterparty.PortId,
-		channel.Counterparty.ChannelId,
-		connection,
-		counterpartyUpgrade,
-		proofCounterpartyUpgrade, proofHeight,
-	); err != nil {
-		return errorsmod.Wrap(err, "failed to verify counterparty upgrade")
-	}
-
 	// the current upgrade handshake must only continue if both channels are using the same upgrade sequence,
 	// otherwise an error receipt must be written so that the upgrade handshake may be attempted again with synchronized sequences
 	if counterpartyChannel.UpgradeSequence != channel.UpgradeSequence {

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -1370,20 +1370,6 @@ func (suite *KeeperTestSuite) TestStartFlushUpgradeHandshake() {
 			connectiontypes.ErrInvalidConnectionState,
 		},
 		{
-			"failed verification for counterparty channel state due to incorrectly constructed counterparty channel",
-			func() {
-				counterpartyChannel.Close()
-			},
-			commitmenttypes.ErrInvalidProof,
-		},
-		{
-			"failed verification for counterparty upgrade due to incorrectly constructed counterparty upgrade",
-			func() {
-				counterpartyUpgrade.LatestSequenceSend = 100
-			},
-			commitmenttypes.ErrInvalidProof,
-		},
-		{
 			"upgrade sequence mismatch, endpointB channel upgrade sequence is ahead",
 			func() {
 				channel := path.EndpointB.GetChannel()


### PR DESCRIPTION
closes: #4255 


### Commit Message / Changelog Entry

Pending the merging of PRs that add them in Try/Ack

```bash
chore: remove verification calls in startFlushUpgradeHandshake
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
