### PR TITLE
Add functions checkForUpgradeCompatibility and syncUpgradeSequence

### DIFF
--- a/modules/core/04-channel/keeper/export_test.go
+++ b/modules/core/04-channel/keeper/export_test.go
@@ -30,3 +30,13 @@ func (k Keeper) StartFlushUpgradeHandshake(
 func (k Keeper) ValidateSelfUpgradeFields(ctx sdk.Context, proposedUpgrade types.UpgradeFields, currentChannel types.Channel) error {
 	return k.validateSelfUpgradeFields(ctx, proposedUpgrade, currentChannel)
 }
+
+// CheckForUpgradeCompatibility is a wrapper around checkForUpgradeCompatibility to allow the function to be directly called in tests.
+func (k Keeper) CheckForUpgradeCompatibility(ctx sdk.Context, upgradeFields, counterpartyUpgradeFields types.UpgradeFields) error {
+	return k.checkForUpgradeCompatibility(ctx, upgradeFields, counterpartyUpgradeFields)
+}
+
+// SyncUpgradeSequence is a wrapper around syncUpgradeSequence to allow the function to be directly called in tests.
+func (k Keeper) SyncUpgradeSequence(ctx sdk.Context, portID, channelID string, channel types.Channel, counterpartyUpgradeSequence uint64) error {
+	return k.syncUpgradeSequence(ctx, portID, channelID, channel, counterpartyUpgradeSequence)
+}

--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -167,7 +167,7 @@ func (k Keeper) ChanUpgradeTry(
 		return types.Upgrade{}, errorsmod.Wrap(err, "failed to verify counterparty channel state")
 	}
 
-	if err := k.checkForUpgradeSequences(ctx, portID, channelID, channel, counterpartyUpgradeSequence); err != nil {
+	if err := k.syncUpgradeSequence(ctx, portID, channelID, channel, counterpartyUpgradeSequence); err != nil {
 		return types.Upgrade{}, err
 	}
 
@@ -308,7 +308,7 @@ func (k Keeper) ChanUpgradeAck(
 		return errorsmod.Wrapf(types.ErrUpgradeNotFound, "failed to retrieve channel upgrade: port ID (%s) channel ID (%s)", portID, channelID)
 	}
 
-	if err := k.checkForUpgradeSequences(ctx, portID, channelID, channel, counterpartyChannel.UpgradeSequence); err != nil {
+	if err := k.syncUpgradeSequence(ctx, portID, channelID, channel, counterpartyChannel.UpgradeSequence); err != nil {
 		return err
 	}
 
@@ -746,9 +746,9 @@ func (k Keeper) startFlushUpgradeHandshake(
 	return nil
 }
 
-// checkForUpgradeSequences ensures current upgrade handshake only continues if both channels are using the same upgrade sequence,
+// syncUpgradeSequence ensures current upgrade handshake only continues if both channels are using the same upgrade sequence,
 // otherwise an upgrade error is returned so that an error receipt will be written so that the upgrade handshake may be attempted again with synchronized sequences.
-func (k Keeper) checkForUpgradeSequences(ctx sdk.Context, portID, channelID string, channel types.Channel, counterpartyUpgradeSequence uint64) error {
+func (k Keeper) syncUpgradeSequence(ctx sdk.Context, portID, channelID string, channel types.Channel, counterpartyUpgradeSequence uint64) error {
 	// save the previous upgrade sequence for the error message
 	prevUpgradeSequence := channel.UpgradeSequence
 

--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -308,8 +308,6 @@ func (k Keeper) ChanUpgradeAck(
 		return errorsmod.Wrap(err, "failed to verify counterparty upgrade")
 	}
 
-	// the current upgrade handshake must only continue if both channels are using the same upgrade sequence,
-	// otherwise an error receipt must be written so that the upgrade handshake may be attempted again with synchronized sequences
 	if err := k.checkForUpgradeSequences(ctx, portID, channelID, channel, counterpartyChannel.UpgradeSequence); err != nil {
 		return err
 	}

--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -172,7 +172,7 @@ func (k Keeper) ChanUpgradeTry(
 	}
 
 	if err := k.checkForUpgradeCompatibility(ctx, upgrade.Fields, counterpartyUpgradeFields); err != nil {
-		return types.Upgrade{}, types.NewUpgradeError(counterpartyUpgradeSequence, err)
+		return types.Upgrade{}, errorsmod.Wrap(err, "failed upgrade compatibility check")
 	}
 
 	// verifies the proof that a particular proposed upgrade has been stored in the upgrade path of the counterparty

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -255,7 +255,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeTry() {
 			types.ErrIncompatibleCounterpartyUpgrade,
 		},
 		{
-			"startFlushUpgradeHandshake fails due to incompatible upgrades, chainB proposes a new connection hop that does not match counterparty",
+			"fails due to incompatible upgrades, chainB proposes a new connection hop that does not match counterparty",
 			func() {
 				// reuse existing connection to create a new connection in a non OPEN state
 				connection := path.EndpointB.GetConnection()
@@ -267,10 +267,10 @@ func (suite *KeeperTestSuite) TestChanUpgradeTry() {
 				suite.chainB.GetSimApp().GetIBCKeeper().ConnectionKeeper.SetConnection(suite.chainB.GetContext(), proposedConnectionID, connection)
 				proposedUpgrade.Fields.ConnectionHops[0] = proposedConnectionID
 			},
-			types.NewUpgradeError(1, types.ErrIncompatibleCounterpartyUpgrade),
+			types.ErrIncompatibleCounterpartyUpgrade,
 		},
 		{
-			"startFlushUpgradeHandshake fails due to mismatch in upgrade sequences",
+			"fails due to mismatch in upgrade sequences",
 			func() {
 				channel := path.EndpointB.GetChannel()
 				channel.UpgradeSequence = 5

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -252,7 +252,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeTry() {
 			func() {
 				counterpartyUpgrade.Fields.ConnectionHops = []string{ibctesting.InvalidID}
 			},
-			commitmenttypes.ErrInvalidProof,
+			types.ErrIncompatibleCounterpartyUpgrade,
 		},
 		{
 			"startFlushUpgradeHandshake fails due to incompatible upgrades, chainB proposes a new connection hop that does not match counterparty",
@@ -276,7 +276,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeTry() {
 				channel.UpgradeSequence = 5
 				path.EndpointB.SetChannel(channel)
 			},
-			types.NewUpgradeError(6, types.ErrIncompatibleCounterpartyUpgrade), // max sequence + 1 will be returned
+			types.NewUpgradeError(6, types.ErrInvalidUpgradeSequence), // max sequence + 1 will be returned
 		},
 	}
 
@@ -1606,7 +1606,7 @@ func (suite *KeeperTestSuite) assertUpgradeError(actualError, expError error) {
 		suite.Require().Equal(expUpgradeError.GetErrorReceipt(), upgradeError.GetErrorReceipt())
 	}
 
-	suite.Require().True(errorsmod.IsOf(actualError, expError), actualError)
+	suite.Require().True(errorsmod.IsOf(actualError, expError), fmt.Sprintf("expected error: %s, actual error: %s", expError, actualError))
 }
 
 // TestAbortHandshake tests that when the channel handshake is aborted, the channel state
@@ -1723,6 +1723,156 @@ func (suite *KeeperTestSuite) TestAbortHandshake() {
 				}
 
 				// TODO: assertion that GetCounterpartyLastPacketSequence is present and correct
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestCheckForUpgradeCompatibility() {
+	var (
+		path                      *ibctesting.Path
+		upgradeFields             types.UpgradeFields
+		counterpartyUpgradeFields types.UpgradeFields
+	)
+
+	testCases := []struct {
+		name     string
+		malleate func()
+		expError error
+	}{
+		{
+			"success",
+			func() {},
+			nil,
+		},
+		{
+			"upgrade ordering is not the same on both sides",
+			func() {
+				upgradeFields.Ordering = types.ORDERED
+			},
+			types.ErrIncompatibleCounterpartyUpgrade,
+		},
+		{
+			"proposed connection is not found",
+			func() {
+				upgradeFields.ConnectionHops[0] = ibctesting.InvalidID
+			},
+			connectiontypes.ErrConnectionNotFound,
+		},
+		{
+			"proposed connection is not in OPEN state",
+			func() {
+				// reuse existing connection to create a new connection in a non OPEN state
+				connectionEnd := path.EndpointB.GetConnection()
+				connectionEnd.State = connectiontypes.UNINITIALIZED
+				connectionEnd.Counterparty.ConnectionId = counterpartyUpgradeFields.ConnectionHops[0] // both sides must be each other's counterparty
+
+				// set proposed connection in state
+				proposedConnectionID := "connection-100"
+				suite.chainB.GetSimApp().GetIBCKeeper().ConnectionKeeper.SetConnection(suite.chainB.GetContext(), proposedConnectionID, connectionEnd)
+				upgradeFields.ConnectionHops[0] = proposedConnectionID
+			},
+			connectiontypes.ErrInvalidConnectionState,
+		},
+		{
+			"proposed connection ends are not each other's counterparty",
+			func() {
+				// reuse existing connection to create a new connection in a non OPEN state
+				connectionEnd := path.EndpointB.GetConnection()
+				// ensure counterparty connectionID does not match connectionID set in counterparty proposed upgrade
+				connectionEnd.Counterparty.ConnectionId = "connection-50"
+
+				// set proposed connection in state
+				proposedConnectionID := "connection-100"
+				suite.chainB.GetSimApp().GetIBCKeeper().ConnectionKeeper.SetConnection(suite.chainB.GetContext(), proposedConnectionID, connectionEnd)
+				upgradeFields.ConnectionHops[0] = proposedConnectionID
+			},
+			types.ErrIncompatibleCounterpartyUpgrade,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			path = ibctesting.NewPath(suite.chainA, suite.chainB)
+			suite.coordinator.Setup(path)
+
+			path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
+			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
+
+			err := path.EndpointA.ChanUpgradeInit()
+			suite.Require().NoError(err)
+
+			upgradeFields = path.EndpointA.GetProposedUpgrade().Fields
+			counterpartyUpgradeFields = path.EndpointB.GetProposedUpgrade().Fields
+
+			tc.malleate()
+
+			err = suite.chainB.GetSimApp().IBCKeeper.ChannelKeeper.CheckForUpgradeCompatibility(suite.chainB.GetContext(), upgradeFields, counterpartyUpgradeFields)
+			if tc.expError != nil {
+				suite.Require().ErrorIs(err, tc.expError)
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestSyncUpgradeSequence() {
+	var (
+		path                        *ibctesting.Path
+		counterpartyUpgradeSequence uint64
+	)
+
+	testCases := []struct {
+		name     string
+		malleate func()
+		expError error
+	}{
+		{
+			"success",
+			func() {},
+			nil,
+		},
+		{
+			"upgrade sequence mismatch, endpointB channel upgrade sequence is ahead",
+			func() {
+				channel := path.EndpointB.GetChannel()
+				channel.UpgradeSequence = 10
+				path.EndpointB.SetChannel(channel)
+			},
+			types.NewUpgradeError(10, types.ErrInvalidUpgradeSequence), // max sequence will be returned
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			path = ibctesting.NewPath(suite.chainA, suite.chainB)
+			suite.coordinator.Setup(path)
+
+			path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
+			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = mock.UpgradeVersion
+
+			err := path.EndpointA.ChanUpgradeInit()
+			suite.Require().NoError(err)
+
+			err = path.EndpointB.ChanUpgradeInit()
+			suite.Require().NoError(err)
+
+			counterpartyUpgradeSequence = 1
+
+			tc.malleate()
+
+			err = suite.chainB.GetSimApp().IBCKeeper.ChannelKeeper.SyncUpgradeSequence(suite.chainB.GetContext(), path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, path.EndpointB.GetChannel(), counterpartyUpgradeSequence)
+			if tc.expError != nil {
+				suite.Require().ErrorIs(err, tc.expError)
+			} else {
+				suite.Require().NoError(err)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #4250
closes: #4252

This PR removes `checkUpgradeForCompatibility` from `startFlushUpgradeHandshake` as well as moving the upgrade sequence fast forwarding logic to its own function. This logic is also executed in the ACK keeper function as it was missed in #4285

The tests which are being removed tested the now removed logic from `startFlushUpgradeHandshake`



<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
