### PR TITLE
Remove check on flush status for send packet.

### DIFF
--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -36,14 +36,7 @@ func (k Keeper) SendPacket(
 	}
 
 	if channel.State != types.OPEN {
-		return 0, errorsmod.Wrapf(
-			types.ErrInvalidChannelState,
-			"channel is not OPEN (got %s)", channel.State.String(),
-		)
-	}
-
-	if channel.FlushStatus != types.NOTINFLUSH {
-		return 0, errorsmod.Wrapf(types.ErrInvalidFlushStatus, "expected flush status to be %s during packet send, got %s", types.NOTINFLUSH, channel.FlushStatus)
+		return 0, errorsmod.Wrapf(types.ErrInvalidChannelState, "channel is not OPEN (got %s)", channel.State)
 	}
 
 	if !k.scopedKeeper.AuthenticateCapability(ctx, channelCap, host.ChannelCapabilityPath(sourcePort, sourceChannel)) {

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -224,7 +224,7 @@ func (suite *KeeperTestSuite) TestSendPacket() {
 				sourceChannel = path.EndpointA.ChannelID
 
 				channel := path.EndpointA.GetChannel()
-				channel.FlushStatus = types.FLUSHING
+				channel.State = types.STATE_FLUSHING
 				path.EndpointA.SetChannel(channel)
 			},
 			false,
@@ -236,19 +236,23 @@ func (suite *KeeperTestSuite) TestSendPacket() {
 				sourceChannel = path.EndpointA.ChannelID
 
 				channel := path.EndpointA.GetChannel()
-				channel.FlushStatus = types.FLUSHCOMPLETE
+				channel.State = types.STATE_FLUSHCOMPLETE
 				path.EndpointA.SetChannel(channel)
 			},
 			false,
 		},
 		{
-			"channel is in INITUPGRADE state",
+			"channel is in FLUSHING state",
 			func() {
 				suite.coordinator.Setup(path)
 
 				path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
+				path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = ibcmock.UpgradeVersion
 
-				err := path.EndpointA.ChanUpgradeInit()
+				err := path.EndpointB.ChanUpgradeInit()
+				suite.Require().NoError(err)
+
+				err = path.EndpointA.ChanUpgradeTry()
 				suite.Require().NoError(err)
 			},
 			false,

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -218,19 +218,7 @@ func (suite *KeeperTestSuite) TestSendPacket() {
 			channelCap = capabilitytypes.NewCapability(5)
 		}, false},
 		{
-			"invalid flush status: FLUSHING",
-			func() {
-				suite.coordinator.Setup(path)
-				sourceChannel = path.EndpointA.ChannelID
-
-				channel := path.EndpointA.GetChannel()
-				channel.State = types.STATE_FLUSHING
-				path.EndpointA.SetChannel(channel)
-			},
-			false,
-		},
-		{
-			"invalid flush status: FLUSHCOMPLETE",
+			"channel is in FLUSH_COMPLETE state",
 			func() {
 				suite.coordinator.Setup(path)
 				sourceChannel = path.EndpointA.ChannelID


### PR DESCRIPTION
## Description

closes: #4383 


### Commit Message / Changelog Entry

```bash
chore: amend sendpacket to remove flush status check.
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
