### PR TITLE
nit(callbacks): removed unused parameters in testing functions

### DIFF
--- a/modules/apps/callbacks/fee_transfer_test.go
+++ b/modules/apps/callbacks/fee_transfer_test.go
@@ -184,7 +184,7 @@ func (s *CallbacksTestSuite) TestIncentivizedTransferTimeoutCallbacks() {
 
 			s.ExecutePayPacketFeeMsg(fee)
 			preRelaySenderBalance := sdk.NewCoins(GetSimApp(s.chainA).BankKeeper.GetBalance(s.chainA.GetContext(), s.chainA.SenderAccount.GetAddress(), ibctesting.TestCoin.Denom))
-			s.ExecuteTransferTimeout(tc.transferMemo, 1)
+			s.ExecuteTransferTimeout(tc.transferMemo)
 
 			// after incentivizing the packets
 			s.AssertHasExecutedExpectedCallbackWithFee(tc.expCallback, tc.expSuccess, true, preRelaySenderBalance, fee)

--- a/modules/apps/callbacks/ica_test.go
+++ b/modules/apps/callbacks/ica_test.go
@@ -81,7 +81,7 @@ func (s *CallbacksTestSuite) TestICACallbacks() {
 		s.Run(tc.name, func() {
 			icaAddr := s.SetupICATest()
 
-			s.ExecuteICATx(icaAddr, tc.icaMemo, 1)
+			s.ExecuteICATx(icaAddr, tc.icaMemo)
 			s.AssertHasExecutedExpectedCallback(tc.expCallback, tc.expSuccess)
 		})
 	}
@@ -131,14 +131,14 @@ func (s *CallbacksTestSuite) TestICATimeoutCallbacks() {
 		s.Run(tc.name, func() {
 			icaAddr := s.SetupICATest()
 
-			s.ExecuteICATimeout(icaAddr, tc.icaMemo, 1)
+			s.ExecuteICATimeout(icaAddr, tc.icaMemo)
 			s.AssertHasExecutedExpectedCallback(tc.expCallback, tc.expSuccess)
 		})
 	}
 }
 
 // ExecuteICATx executes a stakingtypes.MsgDelegate on chainB by sending a packet containing the msg to chainB
-func (s *CallbacksTestSuite) ExecuteICATx(icaAddress, memo string, seq uint64) {
+func (s *CallbacksTestSuite) ExecuteICATx(icaAddress, memo string) {
 	timeoutTimestamp := uint64(s.chainA.GetContext().BlockTime().Add(time.Minute).UnixNano())
 	icaOwner := s.chainA.SenderAccount.GetAddress().String()
 	connectionID := s.path.EndpointA.ConnectionID
@@ -159,7 +159,7 @@ func (s *CallbacksTestSuite) ExecuteICATx(icaAddress, memo string, seq uint64) {
 }
 
 // ExecuteICATx sends and times out an ICA tx
-func (s *CallbacksTestSuite) ExecuteICATimeout(icaAddress, memo string, seq uint64) {
+func (s *CallbacksTestSuite) ExecuteICATimeout(icaAddress, memo string) {
 	relativeTimeout := uint64(1)
 	icaOwner := s.chainA.SenderAccount.GetAddress().String()
 	connectionID := s.path.EndpointA.ConnectionID

--- a/modules/apps/callbacks/transfer_test.go
+++ b/modules/apps/callbacks/transfer_test.go
@@ -161,7 +161,7 @@ func (s *CallbacksTestSuite) TestTransferTimeoutCallbacks() {
 	for _, tc := range testCases {
 		s.SetupTransferTest()
 
-		s.ExecuteTransferTimeout(tc.transferMemo, 1)
+		s.ExecuteTransferTimeout(tc.transferMemo)
 		s.AssertHasExecutedExpectedCallback(tc.expCallback, tc.expSuccess)
 	}
 }
@@ -206,7 +206,7 @@ func (s *CallbacksTestSuite) ExecuteTransfer(memo string) {
 
 // ExecuteTransferTimeout executes a transfer message on chainA for 100 denom.
 // This message is not relayed to chainB, and it times out on chainA.
-func (s *CallbacksTestSuite) ExecuteTransferTimeout(memo string, nextSeqRecv uint64) {
+func (s *CallbacksTestSuite) ExecuteTransferTimeout(memo string) {
 	timeoutHeight := clienttypes.GetSelfHeight(s.chainB.GetContext())
 	timeoutTimestamp := uint64(s.chainB.GetContext().BlockTime().UnixNano())
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

There were unused params in test functions.

closes: #XXXX

### Commit Message / Changelog Entry

```bash
nit(callbacks): removed unused parameters in testing functions
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Review `Codecov Report` in the comment section below once CI passes.
