### PR TITLE
refactor: remove counterparty last sequence send state entry

### DIFF
--- a/modules/core/04-channel/keeper/keeper.go
+++ b/modules/core/04-channel/keeper/keeper.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"encoding/binary"
 	"strconv"
 	"strings"
 
@@ -516,30 +515,6 @@ func (k Keeper) GetUpgrade(ctx sdk.Context, portID, channelID string) (types.Upg
 	return upgrade, true
 }
 
-// GetCounterpartyLastPacketSequence gets the counterparty last packet sequence send from the store.
-func (k Keeper) GetCounterpartyLastPacketSequence(ctx sdk.Context, portID, channelID string) (uint64, bool) {
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(host.ChannelCounterpartyLastPacketSequenceKey(portID, channelID))
-	if bz == nil {
-		return 0, false
-	}
-
-	return binary.BigEndian.Uint64(bz), true
-}
-
-// SetCounterpartyLastPacketSequence sets the counterparty last packet sequence in the store.
-func (k Keeper) SetCounterpartyLastPacketSequence(ctx sdk.Context, portID, channelID string, sequence uint64) {
-	store := ctx.KVStore(k.storeKey)
-	bz := sdk.Uint64ToBigEndian(sequence)
-	store.Set(host.ChannelCounterpartyLastPacketSequenceKey(portID, channelID), bz)
-}
-
-// deleteCounterpartyLastPacketSequence deletes the counterparty last packet sequence from the store.
-func (k Keeper) deleteCounterpartyLastPacketSequence(ctx sdk.Context, portID, channelID string) {
-	store := ctx.KVStore(k.storeKey)
-	store.Delete(host.ChannelCounterpartyLastPacketSequenceKey(portID, channelID))
-}
-
 // SetUpgrade sets the proposed upgrade using the provided port and channel identifiers.
 func (k Keeper) SetUpgrade(ctx sdk.Context, portID, channelID string, upgrade types.Upgrade) {
 	store := ctx.KVStore(k.storeKey)
@@ -583,7 +558,6 @@ func (k Keeper) deleteCounterpartyUpgrade(ctx sdk.Context, portID, channelID str
 // deleteUpgradeInfo deletes all auxiliary upgrade information.
 func (k Keeper) deleteUpgradeInfo(ctx sdk.Context, portID, channelID string) {
 	k.deleteUpgrade(ctx, portID, channelID)
-	k.deleteCounterpartyLastPacketSequence(ctx, portID, channelID)
 	k.deleteCounterpartyUpgrade(ctx, portID, channelID)
 }
 

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -1942,10 +1942,6 @@ func (suite *KeeperTestSuite) TestAbortUpgrade() {
 				if ue, ok := upgradeError.(*types.UpgradeError); ok {
 					suite.Require().Equal(ue.GetErrorReceipt(), errorReceipt, "error receipt does not match expected error receipt")
 				}
-
-				_, found = channelKeeper.GetCounterpartyLastPacketSequence(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-				suite.Require().False(found, "counterparty last packet sequence should not be found")
-
 			} else {
 
 				suite.Require().Panics(func() {
@@ -1964,8 +1960,6 @@ func (suite *KeeperTestSuite) TestAbortUpgrade() {
 				if found { // this should be all test cases except for when the upgrade is explicitly deleted.
 					suite.Require().Equal(actualUpgrade, upgrade, "upgrade info should not be deleted")
 				}
-
-				// TODO: assertion that GetCounterpartyLastPacketSequence is present and correct
 			}
 		})
 	}

--- a/modules/core/24-host/channel_keys.go
+++ b/modules/core/24-host/channel_keys.go
@@ -3,14 +3,13 @@ package host
 import "fmt"
 
 const (
-	KeyChannelEndPrefix               = "channelEnds"
-	KeyChannelPrefix                  = "channels"
-	KeyChannelUpgradePrefix           = "channelUpgrades"
-	KeyUpgradePrefix                  = "upgrades"
-	KeyUpgradeErrorPrefix             = "upgradeError"
-	KeyCounterpartyLastPacketSequence = "counterpartyLastPacketSequence"
-	KeyCounterpartyUpgrade            = "counterpartyUpgrade"
-	KeyChannelCapabilityPrefix        = "capabilities"
+	KeyChannelEndPrefix        = "channelEnds"
+	KeyChannelPrefix           = "channels"
+	KeyChannelUpgradePrefix    = "channelUpgrades"
+	KeyUpgradePrefix           = "upgrades"
+	KeyUpgradeErrorPrefix      = "upgradeError"
+	KeyCounterpartyUpgrade     = "counterpartyUpgrade"
+	KeyChannelCapabilityPrefix = "capabilities"
 )
 
 // ICS04
@@ -50,16 +49,6 @@ func ChannelUpgradePath(portID, channelID string) string {
 // ChannelUpgradeKey returns the store key for a particular channel upgrade attempt
 func ChannelUpgradeKey(portID, channelID string) []byte {
 	return []byte(ChannelUpgradePath(portID, channelID))
-}
-
-// ChannelCounterpartyLastPacketSequenceKey returns the store key for the last packet sequence sent on the counterparty channel.
-func ChannelCounterpartyLastPacketSequenceKey(portID, channelID string) []byte {
-	return []byte(ChannelCounterpartyLastPacketSequencePath(portID, channelID))
-}
-
-// ChannelCounterpartyLastPacketSequencePath defines the path under which the last packet sequence sent on the counterparty channel is stored.
-func ChannelCounterpartyLastPacketSequencePath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s/%s", KeyChannelUpgradePrefix, KeyCounterpartyLastPacketSequence, channelPath(portID, channelID))
 }
 
 // ChannelCounterpartyUpgradeKey returns the store key for the upgrade used on the counterparty channel.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #4307 

<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
