### PR TITLE
Use only timestamp only for upgrade timeouts.

### DIFF
--- a/modules/core/04-channel/keeper/keeper_test.go
+++ b/modules/core/04-channel/keeper/keeper_test.go
@@ -506,7 +506,7 @@ func (suite *KeeperTestSuite) TestParams() {
 	}{
 		{"success: set default params", types.DefaultParams(), true},
 		{"success: zero timeout height", types.NewParams(types.NewTimeout(clienttypes.ZeroHeight(), 10000)), true},
-		{"success: zero timestamp timestamp", types.NewParams(types.NewTimeout(types.DefaultTimeout.Height, 0)), true},
+		{"fail: zero timeout timestamp", types.NewParams(types.NewTimeout(types.DefaultTimeout.Height, 0)), false},
 		{"fail: zero timeout", types.NewParams(types.NewTimeout(clienttypes.ZeroHeight(), 0)), false},
 	}
 

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -1420,10 +1420,17 @@ func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 			func() {
 				// force timeout as the default timeout is 1000.
 				// TODO: modify timeout in test to be lower.
-				suite.coordinator.CommitNBlocks(suite.chainB, 1000)
+				//suite.coordinator.CommitNBlocks(suite.chainB, 1000)
+
+
+				upgrade := path.EndpointA.GetProposedUpgrade()
+				upgrade.Timeout = types.NewTimeout(clienttypes.ZeroHeight(), 1)
+				path.EndpointB.SetChannelUpgrade(upgrade)
+				path.EndpointA.SetChannelCounterpartyUpgrade(upgrade)
 
 				// ensure clients are up to date to receive valid proofs
 				suite.Require().NoError(path.EndpointA.UpdateClient())
+				suite.Require().NoError(path.EndpointB.UpdateClient())
 
 				proofCounterpartyChannel, _, proofHeight = path.EndpointA.QueryChannelUpgradeProof()
 			},

--- a/modules/core/04-channel/types/params.go
+++ b/modules/core/04-channel/types/params.go
@@ -2,13 +2,14 @@ package types
 
 import (
 	"fmt"
+	"time"
 
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 )
 
-// TODO: determine sane default value for upgrade timeout.
+// TODO: determine sane default value for upgrade timeout. and make this relative.
 
-var DefaultTimeout = NewTimeout(clienttypes.NewHeight(1, 1000), 0)
+var DefaultTimeout = NewTimeout(clienttypes.ZeroHeight(), uint64(time.Now().Add(time.Hour).UnixNano()))
 
 // NewParams creates a new parameter configuration for the channel submodule
 func NewParams(upgradeTimeout Timeout) Params {
@@ -24,8 +25,11 @@ func DefaultParams() Params {
 
 // Validate the params.
 func (p Params) Validate() error {
-	if !p.UpgradeTimeout.IsValid() {
-		return fmt.Errorf("upgrade timeout invalid: %v", p.UpgradeTimeout)
+	if !p.UpgradeTimeout.Height.IsZero() {
+		return fmt.Errorf("upgrade timeout height must be zero: %v", p.UpgradeTimeout)
+	}
+	if p.UpgradeTimeout.Timestamp == 0 {
+		return fmt.Errorf("upgrade timeout timestamp invalid: %v", p.UpgradeTimeout)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #4313

This PR ensures that if an upgrade height is specified, the ValidateBasic fails.

Only the timestamp is used for timing out upgrades.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
