### PR TITLE
docs(callbacks): improved godocs for ContractKeeper state reversion

### DIFF
--- a/docs/middleware/callbacks/interfaces.md
+++ b/docs/middleware/callbacks/interfaces.md
@@ -68,57 +68,76 @@ The callbacks middleware requires the secondary application to implement the [`C
 ```go
 // ContractKeeper defines the entry points exposed to the VM module which invokes a smart contract
 type ContractKeeper interface {
-  // IBCSendPacketCallback is called in the source chain when a PacketSend is executed. The
-  // packetSenderAddress is determined by the underlying module, and may be empty if the sender is
-  // unknown or undefined. The contract is expected to handle the callback within the user defined
-  // gas limit, and handle any errors, or panics gracefully.
-  // If an error is returned, the transaction will be reverted by the callbacks middleware, and the
-  // packet will not be sent.
-  IBCSendPacketCallback(
-    ctx sdk.Context,
-    sourcePort string,
-    sourceChannel string,
-    timeoutHeight clienttypes.Height,
-    timeoutTimestamp uint64,
-    packetData []byte,
-    contractAddress,
-    packetSenderAddress string,
-  ) error
-  // IBCOnAcknowledgementPacketCallback is called in the source chain when a packet acknowledgement
-  // is received. The packetSenderAddress is determined by the underlying module, and may be empty if
-  // the sender is unknown or undefined. The contract is expected to handle the callback within the
-  // user defined gas limit, and handle any errors, or panics gracefully.
-  // If an error is returned, state will be reverted by the callbacks middleware.
-  IBCOnAcknowledgementPacketCallback(
-    ctx sdk.Context,
-    packet channeltypes.Packet,
-    acknowledgement []byte,
-    relayer sdk.AccAddress,
-    contractAddress,
-    packetSenderAddress string,
-  ) error
-  // IBCOnTimeoutPacketCallback is called in the source chain when a packet is not received before
-  // the timeout height. The packetSenderAddress is determined by the underlying module, and may be
-  // empty if the sender is unknown or undefined. The contract is expected to handle the callback
-  // within the user defined gas limit, and handle any error, out of gas, or panics gracefully.
-  // If an error is returned, state will be reverted by the callbacks middleware.
-  IBCOnTimeoutPacketCallback(
-    ctx sdk.Context,
-    packet channeltypes.Packet,
-    relayer sdk.AccAddress,
-    contractAddress,
-    packetSenderAddress string,
-  ) error
-  // IBCReceivePacketCallback is called in the destination chain when a packet acknowledgement is written.
-  // The contract is expected to handle the callback within the user defined gas limit, and handle any errors,
-  // out of gas, or panics gracefully.
-  // If an error is returned, state will be reverted by the callbacks middleware.
-  IBCReceivePacketCallback(
-    ctx sdk.Context,
-    packet ibcexported.PacketI,
-    ack ibcexported.Acknowledgement,
-    contractAddress string,
-  ) error
+	// IBCSendPacketCallback is called in the source chain when a PacketSend is executed. The
+	// packetSenderAddress is determined by the underlying module, and may be empty if the sender is
+	// unknown or undefined. The contract is expected to handle the callback within the user defined
+	// gas limit, and handle any errors, or panics gracefully.
+	// This entry point is called with a cached context. If an error is returned, then the changes in
+	// this context will not be persisted, and the error will be propagated to the underlying IBC
+	// application, resulting in a packet send failure.
+	//
+	// Implementations are provided with the packetSenderAddress and MAY choose to use this to perform
+	// validation on the origin of a given packet. It is recommended to perform the same validation
+	// on all source chain callbacks (SendPacket, AcknowledgementPacket, TimeoutPacket). This
+	// defensively guards against exploits due to incorrectly wired SendPacket ordering in IBC stacks.
+	IBCSendPacketCallback(
+		cachedCtx sdk.Context,
+		sourcePort string,
+		sourceChannel string,
+		timeoutHeight clienttypes.Height,
+		timeoutTimestamp uint64,
+		packetData []byte,
+		contractAddress,
+		packetSenderAddress string,
+	) error
+	// IBCOnAcknowledgementPacketCallback is called in the source chain when a packet acknowledgement
+	// is received. The packetSenderAddress is determined by the underlying module, and may be empty if
+	// the sender is unknown or undefined. The contract is expected to handle the callback within the
+	// user defined gas limit, and handle any errors, or panics gracefully.
+	// This entry point is called with a cached context. If an error is returned, then the changes in
+	// this context will not be persisted, but the packet lifecycle will not be blocked.
+	//
+	// Implementations are provided with the packetSenderAddress and MAY choose to use this to perform
+	// validation on the origin of a given packet. It is recommended to perform the same validation
+	// on all source chain callbacks (SendPacket, AcknowledgementPacket, TimeoutPacket). This
+	// defensively guards against exploits due to incorrectly wired SendPacket ordering in IBC stacks.
+	IBCOnAcknowledgementPacketCallback(
+		cachedCtx sdk.Context,
+		packet channeltypes.Packet,
+		acknowledgement []byte,
+		relayer sdk.AccAddress,
+		contractAddress,
+		packetSenderAddress string,
+	) error
+	// IBCOnTimeoutPacketCallback is called in the source chain when a packet is not received before
+	// the timeout height. The packetSenderAddress is determined by the underlying module, and may be
+	// empty if the sender is unknown or undefined. The contract is expected to handle the callback
+	// within the user defined gas limit, and handle any error, out of gas, or panics gracefully.
+	// This entry point is called with a cached context. If an error is returned, then the changes in
+	// this context will not be persisted, but the packet lifecycle will not be blocked.
+	//
+	// Implementations are provided with the packetSenderAddress and MAY choose to use this to perform
+	// validation on the origin of a given packet. It is recommended to perform the same validation
+	// on all source chain callbacks (SendPacket, AcknowledgementPacket, TimeoutPacket). This
+	// defensively guards against exploits due to incorrectly wired SendPacket ordering in IBC stacks.
+	IBCOnTimeoutPacketCallback(
+		cachedCtx sdk.Context,
+		packet channeltypes.Packet,
+		relayer sdk.AccAddress,
+		contractAddress,
+		packetSenderAddress string,
+	) error
+	// IBCReceivePacketCallback is called in the destination chain when a packet acknowledgement is written.
+	// The contract is expected to handle the callback within the user defined gas limit, and handle any errors,
+	// out of gas, or panics gracefully.
+	// This entry point is called with a cached context. If an error is returned, then the changes in
+	// this context will not be persisted, but the packet lifecycle will not be blocked.
+	IBCReceivePacketCallback(
+		cachedCtx sdk.Context,
+		packet ibcexported.PacketI,
+		ack ibcexported.Acknowledgement,
+		contractAddress string,
+	) error
 }
 ```
 

--- a/modules/apps/callbacks/types/expected_keepers.go
+++ b/modules/apps/callbacks/types/expected_keepers.go
@@ -14,15 +14,16 @@ type ContractKeeper interface {
 	// packetSenderAddress is determined by the underlying module, and may be empty if the sender is
 	// unknown or undefined. The contract is expected to handle the callback within the user defined
 	// gas limit, and handle any errors, or panics gracefully.
-	// If an error is returned, the transaction will be reverted by the callbacks middleware, and the
-	// packet will not be sent.
+	// This entry point is called with a cached context. If an error is returned, then the changes in
+	// this context will not be persisted, and the error will be propagated to the underlying IBC
+	// application, resulting in a packet send failure.
 	//
 	// Implementations are provided with the packetSenderAddress and MAY choose to use this to perform
 	// validation on the origin of a given packet. It is recommended to perform the same validation
 	// on all source chain callbacks (SendPacket, AcknowledgementPacket, TimeoutPacket). This
 	// defensively guards against exploits due to incorrectly wired SendPacket ordering in IBC stacks.
 	IBCSendPacketCallback(
-		ctx sdk.Context,
+		cachedCtx sdk.Context,
 		sourcePort string,
 		sourceChannel string,
 		timeoutHeight clienttypes.Height,
@@ -35,14 +36,15 @@ type ContractKeeper interface {
 	// is received. The packetSenderAddress is determined by the underlying module, and may be empty if
 	// the sender is unknown or undefined. The contract is expected to handle the callback within the
 	// user defined gas limit, and handle any errors, or panics gracefully.
-	// If an error is returned, state will be reverted by the callbacks middleware.
+	// This entry point is called with a cached context. If an error is returned, then the changes in
+	// this context will not be persisted, but the packet lifecycle will not be blocked.
 	//
 	// Implementations are provided with the packetSenderAddress and MAY choose to use this to perform
 	// validation on the origin of a given packet. It is recommended to perform the same validation
 	// on all source chain callbacks (SendPacket, AcknowledgementPacket, TimeoutPacket). This
 	// defensively guards against exploits due to incorrectly wired SendPacket ordering in IBC stacks.
 	IBCOnAcknowledgementPacketCallback(
-		ctx sdk.Context,
+		cachedCtx sdk.Context,
 		packet channeltypes.Packet,
 		acknowledgement []byte,
 		relayer sdk.AccAddress,
@@ -53,14 +55,15 @@ type ContractKeeper interface {
 	// the timeout height. The packetSenderAddress is determined by the underlying module, and may be
 	// empty if the sender is unknown or undefined. The contract is expected to handle the callback
 	// within the user defined gas limit, and handle any error, out of gas, or panics gracefully.
-	// If an error is returned, state will be reverted by the callbacks middleware.
+	// This entry point is called with a cached context. If an error is returned, then the changes in
+	// this context will not be persisted, but the packet lifecycle will not be blocked.
 	//
 	// Implementations are provided with the packetSenderAddress and MAY choose to use this to perform
 	// validation on the origin of a given packet. It is recommended to perform the same validation
 	// on all source chain callbacks (SendPacket, AcknowledgementPacket, TimeoutPacket). This
 	// defensively guards against exploits due to incorrectly wired SendPacket ordering in IBC stacks.
 	IBCOnTimeoutPacketCallback(
-		ctx sdk.Context,
+		cachedCtx sdk.Context,
 		packet channeltypes.Packet,
 		relayer sdk.AccAddress,
 		contractAddress,
@@ -69,9 +72,10 @@ type ContractKeeper interface {
 	// IBCReceivePacketCallback is called in the destination chain when a packet acknowledgement is written.
 	// The contract is expected to handle the callback within the user defined gas limit, and handle any errors,
 	// out of gas, or panics gracefully.
-	// If an error is returned, state will be reverted by the callbacks middleware.
+	// This entry point is called with a cached context. If an error is returned, then the changes in
+	// this context will not be persisted, but the packet lifecycle will not be blocked.
 	IBCReceivePacketCallback(
-		ctx sdk.Context,
+		cachedCtx sdk.Context,
 		packet ibcexported.PacketI,
 		ack ibcexported.Acknowledgement,
 		contractAddress string,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

closes: #4509 


### Commit Message / Changelog Entry

```text
docs(callbacks): improved godocs for ContractKeeper state reversion
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Review `Codecov Report` in the comment section below once CI passes.
