### PR TITLE
refactor: implementation for onChanUpgradeAck ics29

### DIFF
--- a/modules/apps/29-fee/ibc_middleware_test.go
+++ b/modules/apps/29-fee/ibc_middleware_test.go
@@ -1223,115 +1223,115 @@ func (suite *FeeTestSuite) TestOnChanUpgradeTry() {
 	}
 }
 
-// TODO: Revisit these testcases when core refactor is completed
-// func (suite *FeeTestSuite) TestOnChanUpgradeAck() {
-// 	var (
-// 		expFeeEnabled bool
-// 		path          *ibctesting.Path
-// 	)
+func (suite *FeeTestSuite) TestOnChanUpgradeAck() {
+	var (
+		path *ibctesting.Path
+	)
 
-// 	testCases := []struct {
-// 		name     string
-// 		malleate func()
-// 		expError error
-// 	}{
-// 		{
-// 			"success",
-// 			func() {},
-// 			nil,
-// 		},
-// 		{
-// 			"success with fee middleware disabled",
-// 			func() {
-// 				expFeeEnabled = false
-// 				suite.chainA.GetSimApp().IBCFeeKeeper.DeleteFeeEnabled(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-// 			},
-// 			nil,
-// 		},
-// 		{
-// 			"invalid upgrade version",
-// 			func() {
-// 				expFeeEnabled = true
-// 				counterpartyUpgrade := path.EndpointB.GetChannelUpgrade()
-// 				counterpartyUpgrade.Fields.Version = ibctesting.InvalidID
-// 				path.EndpointB.SetChannelUpgrade(counterpartyUpgrade)
+	testCases := []struct {
+		name     string
+		malleate func()
+		expError error
+	}{
+		{
+			"success",
+			func() {},
+			nil,
+		},
+		{
+			"success with fee middleware disabled",
+			func() {
+				suite.chainA.GetSimApp().IBCFeeKeeper.DeleteFeeEnabled(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+			},
+			nil,
+		},
+		{
+			"invalid upgrade version",
+			func() {
+				counterpartyUpgrade := path.EndpointB.GetChannelUpgrade()
+				counterpartyUpgrade.Fields.Version = ibctesting.InvalidID
+				path.EndpointB.SetChannelUpgrade(counterpartyUpgrade)
 
-// 				suite.coordinator.CommitBlock(suite.chainB)
-// 			},
-// 			channeltypes.NewUpgradeError(1, types.ErrInvalidVersion),
-// 		},
-// 		{
-// 			"invalid fee version",
-// 			func() {
-// 				expFeeEnabled = true
-// 				upgradeVersion := string(types.ModuleCdc.MustMarshalJSON(&types.Metadata{FeeVersion: ibctesting.InvalidID, AppVersion: ibcmock.Version}))
+				suite.coordinator.CommitBlock(suite.chainB)
 
-// 				counterpartyUpgrade := path.EndpointB.GetChannelUpgrade()
-// 				counterpartyUpgrade.Fields.Version = upgradeVersion
-// 				path.EndpointB.SetChannelUpgrade(counterpartyUpgrade)
+				suite.chainA.GetSimApp().FeeMockModule.IBCApp.OnChanUpgradeAck = func(_ sdk.Context, _, _, _ string) error {
+					return types.ErrInvalidVersion
+				}
+			},
+			types.ErrInvalidVersion,
+		},
+		{
+			"invalid fee version",
+			func() {
+				upgradeVersion := string(types.ModuleCdc.MustMarshalJSON(&types.Metadata{FeeVersion: ibctesting.InvalidID, AppVersion: ibcmock.Version}))
 
-// 				suite.coordinator.CommitBlock(suite.chainB)
-// 			},
-// 			channeltypes.NewUpgradeError(1, types.ErrInvalidVersion),
-// 		},
-// 		{
-// 			"underlying app callback returns error",
-// 			func() {
-// 				expFeeEnabled = true
-// 				suite.chainA.GetSimApp().FeeMockModule.IBCApp.OnChanUpgradeAck = func(_ sdk.Context, _, _, _ string) error {
-// 					return ibcmock.MockApplicationCallbackError
-// 				}
-// 			},
-// 			channeltypes.NewUpgradeError(1, ibcmock.MockApplicationCallbackError),
-// 		},
-// 	}
+				counterpartyUpgrade := path.EndpointB.GetChannelUpgrade()
+				counterpartyUpgrade.Fields.Version = upgradeVersion
+				path.EndpointB.SetChannelUpgrade(counterpartyUpgrade)
 
-// 	for _, tc := range testCases {
-// 		tc := tc
-// 		suite.Run(tc.name, func() {
-// 			suite.SetupTest()
+				suite.coordinator.CommitBlock(suite.chainB)
+			},
+			types.ErrInvalidVersion,
+		},
+		{
+			"underlying app callback returns error",
+			func() {
+				suite.chainA.GetSimApp().FeeMockModule.IBCApp.OnChanUpgradeAck = func(_ sdk.Context, _, _, _ string) error {
+					return ibcmock.MockApplicationCallbackError
+				}
+			},
+			ibcmock.MockApplicationCallbackError,
+		},
+	}
 
-// 			path = ibctesting.NewPath(suite.chainA, suite.chainB)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
 
-// 			// configure the initial path to create an unincentivized mock channel
-// 			path.EndpointA.ChannelConfig.PortID = ibctesting.MockFeePort
-// 			path.EndpointB.ChannelConfig.PortID = ibctesting.MockFeePort
-// 			path.EndpointA.ChannelConfig.Version = ibcmock.Version
-// 			path.EndpointB.ChannelConfig.Version = ibcmock.Version
+			path = ibctesting.NewPath(suite.chainA, suite.chainB)
 
-// 			suite.coordinator.Setup(path)
+			// configure the initial path to create an unincentivized mock channel
+			path.EndpointA.ChannelConfig.PortID = ibctesting.MockFeePort
+			path.EndpointB.ChannelConfig.PortID = ibctesting.MockFeePort
+			path.EndpointA.ChannelConfig.Version = ibcmock.Version
+			path.EndpointB.ChannelConfig.Version = ibcmock.Version
 
-// 			// configure the channel upgrade version to enabled ics29 fee middleware
-// 			expFeeEnabled = true
-// 			upgradeVersion := string(types.ModuleCdc.MustMarshalJSON(&types.Metadata{FeeVersion: types.Version, AppVersion: ibcmock.Version}))
-// 			path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = upgradeVersion
-// 			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = upgradeVersion
+			suite.coordinator.Setup(path)
 
-// 			err := path.EndpointA.ChanUpgradeInit()
-// 			suite.Require().NoError(err)
+			// configure the channel upgrade version to enabled ics29 fee middleware
+			upgradeVersion := string(types.ModuleCdc.MustMarshalJSON(&types.Metadata{FeeVersion: types.Version, AppVersion: ibcmock.Version}))
+			path.EndpointA.ChannelConfig.ProposedUpgrade.Fields.Version = upgradeVersion
+			path.EndpointB.ChannelConfig.ProposedUpgrade.Fields.Version = upgradeVersion
 
-// 			err = path.EndpointB.ChanUpgradeTry()
-// 			suite.Require().NoError(err)
+			err := path.EndpointA.ChanUpgradeInit()
+			suite.Require().NoError(err)
 
-// 			tc.malleate()
+			err = path.EndpointB.ChanUpgradeTry()
+			suite.Require().NoError(err)
 
-// 			err = path.EndpointA.ChanUpgradeAck()
-// 			suite.Require().NoError(err)
+			tc.malleate()
 
-// 			isFeeEnabled := suite.chainA.GetSimApp().IBCFeeKeeper.IsFeeEnabled(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-// 			suite.Require().Equal(expFeeEnabled, isFeeEnabled)
+			counterpartyUpgrade := path.EndpointB.GetChannelUpgrade()
 
-// 			if tc.expError != nil {
-// 				// NOTE: application callback failure in OnChanUpgradeAck results in an ErrorReceipt being written to state signaling for cancellation
-// 				if expUpgradeError, ok := tc.expError.(*channeltypes.UpgradeError); ok {
-// 					errorReceipt, found := suite.chainA.GetSimApp().GetIBCKeeper().ChannelKeeper.GetUpgradeErrorReceipt(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-// 					suite.Require().True(found)
-// 					suite.Require().Equal(expUpgradeError.GetErrorReceipt(), errorReceipt)
-// 				}
-// 			}
-// 		})
-// 	}
-// }
+			module, _, err := suite.chainA.App.GetIBCKeeper().PortKeeper.LookupModuleByPort(suite.chainA.GetContext(), ibctesting.MockFeePort)
+			suite.Require().NoError(err)
+
+			cbs, ok := suite.chainA.App.GetIBCKeeper().Router.GetRoute(module)
+			suite.Require().True(ok)
+
+			err = cbs.OnChanUpgradeAck(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, counterpartyUpgrade.Fields.Version)
+
+			expPass := tc.expError == nil
+			if expPass {
+				suite.Require().NoError(err)
+			} else {
+				suite.Require().Error(err)
+				suite.Require().ErrorIs(err, tc.expError)
+			}
+		})
+	}
+}
 
 func (suite *FeeTestSuite) TestGetAppVersion() {
 	var (

--- a/modules/apps/29-fee/ibc_middleware_test.go
+++ b/modules/apps/29-fee/ibc_middleware_test.go
@@ -1224,9 +1224,7 @@ func (suite *FeeTestSuite) TestOnChanUpgradeTry() {
 }
 
 func (suite *FeeTestSuite) TestOnChanUpgradeAck() {
-	var (
-		path *ibctesting.Path
-	)
+	var path *ibctesting.Path
 
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

ref: #1900 

<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
