### PR TITLE
feat: add unpack inerfaces message assertion to ibc software upgrade msg

### DIFF
--- a/modules/core/02-client/types/msgs.go
+++ b/modules/core/02-client/types/msgs.go
@@ -25,6 +25,7 @@ var (
 	_ codectypes.UnpackInterfacesMessage = (*MsgUpdateClient)(nil)
 	_ codectypes.UnpackInterfacesMessage = (*MsgSubmitMisbehaviour)(nil)
 	_ codectypes.UnpackInterfacesMessage = (*MsgUpgradeClient)(nil)
+	_ codectypes.UnpackInterfacesMessage = (*MsgIBCSoftwareUpgrade)(nil)
 )
 
 // NewMsgCreateClient creates a new MsgCreateClient instance
@@ -327,6 +328,11 @@ func (msg *MsgIBCSoftwareUpgrade) GetSigners() []sdk.AccAddress {
 		panic(err)
 	}
 	return []sdk.AccAddress{accAddr}
+}
+
+// UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
+func (msg *MsgIBCSoftwareUpgrade) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	return unpacker.UnpackAny(msg.UpgradedClientState, new(exported.ClientState))
 }
 
 // NewMsgRecoverClient creates a new MsgRecoverClient instance

--- a/modules/core/02-client/types/msgs_test.go
+++ b/modules/core/02-client/types/msgs_test.go
@@ -923,3 +923,31 @@ func (suite *TypesTestSuite) TestMsgIBCSoftwareUpgrade_ValidateBasic() {
 		}
 	}
 }
+
+// tests a MsgIBCSoftwareUpgrade can be marshaled and unmarshaled, and the
+// client state can be unpacked
+func (suite *TypesTestSuite) TestMarshalMsgIBCSoftwareUpgrade() {
+	cdc := suite.chainA.App.AppCodec()
+
+	// create proposal
+	plan := upgradetypes.Plan{
+		Name:   "upgrade ibc",
+		Height: 1000,
+	}
+
+	msg, err := types.NewMsgIBCSoftwareUpgrade(ibctesting.TestAccAddress, plan, &ibctm.ClientState{})
+	suite.Require().NoError(err)
+
+	// marshal message
+	bz, err := cdc.MarshalJSON(msg)
+	suite.Require().NoError(err)
+
+	// unmarshal proposal
+	newMsg := &types.MsgIBCSoftwareUpgrade{}
+	err = cdc.UnmarshalJSON(bz, newMsg)
+	suite.Require().NoError(err)
+
+	// unpack client state
+	_, err = types.UnpackClientState(newMsg.UpgradedClientState)
+	suite.Require().NoError(err)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX


### Commit Message / Changelog Entry

```bash
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
