### PR TITLE
chore: update protodoc strings

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/types/tx.pb.go
+++ b/modules/apps/27-interchain-accounts/controller/types/tx.pb.go
@@ -192,7 +192,7 @@ var xxx_messageInfo_MsgSendTxResponse proto.InternalMessageInfo
 
 // MsgUpdateParams defines the payload for Msg/UpdateParams
 type MsgUpdateParams struct {
-	// signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+	// signer address
 	Signer string `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
 	// params defines the 27-interchain-accounts/controller parameters to update.
 	//

--- a/modules/apps/27-interchain-accounts/host/types/tx.pb.go
+++ b/modules/apps/27-interchain-accounts/host/types/tx.pb.go
@@ -31,7 +31,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // MsgUpdateParams defines the payload for Msg/UpdateParams
 type MsgUpdateParams struct {
-	// signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+	// signer address
 	Signer string `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
 	// params defines the 27-interchain-accounts/host parameters to update.
 	//

--- a/modules/apps/transfer/types/tx.pb.go
+++ b/modules/apps/transfer/types/tx.pb.go
@@ -130,7 +130,7 @@ var xxx_messageInfo_MsgTransferResponse proto.InternalMessageInfo
 
 // MsgUpdateParams is the Msg/UpdateParams request type.
 type MsgUpdateParams struct {
-	// signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+	// signer address
 	Signer string `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
 	// params defines the transfer parameters to update.
 	//

--- a/modules/core/02-client/types/tx.pb.go
+++ b/modules/core/02-client/types/tx.pb.go
@@ -373,7 +373,7 @@ type MsgRecoverClient struct {
 	// the substitute client identifier for the client which will replace the subject
 	// client
 	SubstituteClientId string `protobuf:"bytes,2,opt,name=substitute_client_id,json=substituteClientId,proto3" json:"substitute_client_id,omitempty"`
-	// signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+	// signer address
 	Signer string `protobuf:"bytes,3,opt,name=signer,proto3" json:"signer,omitempty"`
 }
 
@@ -556,7 +556,7 @@ var xxx_messageInfo_MsgIBCSoftwareUpgradeResponse proto.InternalMessageInfo
 
 // MsgUpdateParams defines the sdk.Msg type to update the client parameters.
 type MsgUpdateParams struct {
-	// signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+	// signer address
 	Signer string `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
 	// params defines the client parameters to update.
 	//

--- a/modules/core/03-connection/types/tx.pb.go
+++ b/modules/core/03-connection/types/tx.pb.go
@@ -380,7 +380,7 @@ var xxx_messageInfo_MsgConnectionOpenConfirmResponse proto.InternalMessageInfo
 
 // MsgUpdateParams defines the sdk.Msg type to update the connection parameters.
 type MsgUpdateParams struct {
-	// signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+	// signer address
 	Signer string `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
 	// params defines the connection parameters to update.
 	//

--- a/proto/ibc/applications/interchain_accounts/controller/v1/tx.proto
+++ b/proto/ibc/applications/interchain_accounts/controller/v1/tx.proto
@@ -67,7 +67,7 @@ message MsgUpdateParams {
 
   option (gogoproto.goproto_getters) = false;
 
-  // signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+  // signer address 
   string signer = 1;
 
   // params defines the 27-interchain-accounts/controller parameters to update.

--- a/proto/ibc/applications/interchain_accounts/host/v1/tx.proto
+++ b/proto/ibc/applications/interchain_accounts/host/v1/tx.proto
@@ -22,7 +22,7 @@ message MsgUpdateParams {
 
   option (gogoproto.goproto_getters) = false;
 
-  // signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+  // signer address 
   string signer = 1;
 
   // params defines the 27-interchain-accounts/host parameters to update.

--- a/proto/ibc/applications/transfer/v1/tx.proto
+++ b/proto/ibc/applications/transfer/v1/tx.proto
@@ -65,7 +65,7 @@ message MsgUpdateParams {
 
   option (gogoproto.goproto_getters) = false;
 
-  // signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+  // signer address 
   string signer = 1;
 
   // params defines the transfer parameters to update.

--- a/proto/ibc/core/client/v1/tx.proto
+++ b/proto/ibc/core/client/v1/tx.proto
@@ -129,7 +129,7 @@ message MsgRecoverClient {
   // client
   string substitute_client_id = 2;
 
-  // signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+  // signer address 
   string signer = 3;
 }
 
@@ -162,7 +162,7 @@ message MsgUpdateParams {
 
   option (gogoproto.goproto_getters) = false;
 
-  // signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+  // signer address 
   string signer = 1;
 
   // params defines the client parameters to update.

--- a/proto/ibc/core/connection/v1/tx.proto
+++ b/proto/ibc/core/connection/v1/tx.proto
@@ -133,7 +133,7 @@ message MsgUpdateParams {
 
   option (gogoproto.goproto_getters) = false;
 
-  // signer address (it may be the the address that controls the module, which defaults to x/gov unless overwritten).
+  // signer address 
   string signer = 1;
 
   // params defines the connection parameters to update.


### PR DESCRIPTION
## Description

This PR updates protodoc strings to omit the claim that governance is the default signer / authority. 

closes: #4668


### Commit Message / Changelog Entry

```bash
chore: omit governance as the default signer in protodoc strings

```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
