### PR TITLE
Use a type constraint instead of any for wasmCall/wasmQuery.

### DIFF
--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -154,7 +154,7 @@ func (cs ClientState) VerifyMembership(
 			Value:            value,
 		},
 	}
-	_, err := wasmQuery[contractResult](ctx, clientStore, &cs, payload)
+	_, err := wasmQuery[emptyResult](ctx, clientStore, &cs, payload)
 	return err
 }
 
@@ -192,6 +192,6 @@ func (cs ClientState) VerifyNonMembership(
 			Path:             path,
 		},
 	}
-	_, err := wasmQuery[contractResult](ctx, clientStore, &cs, payload)
+	_, err := wasmQuery[emptyResult](ctx, clientStore, &cs, payload)
 	return err
 }

--- a/modules/light-clients/08-wasm/types/contract_api.go
+++ b/modules/light-clients/08-wasm/types/contract_api.go
@@ -95,12 +95,13 @@ type verifyUpgradeAndUpdateStateMsg struct {
 // checkSubstituteAndUpdateStateMsg is a sudoMsg sent to the contract to check a given substitute client and update to its state.
 type checkSubstituteAndUpdateStateMsg struct{}
 
-// ContractResult defines the expected interface a Result returned by a contract call is expected to implement.
-type ContractResult interface{}
+// ContractResult is a type constraint that defines the expected results that can be returned by a contract call/query.
+type ContractResult interface {
+	emptyResult | statusResult | exportMetadataResult | timestampAtHeightResult | checkForMisbehaviourResult | updateStateResult
+}
 
-// contractResult is the default implementation of the ContractResult interface and the default return type of any contract call
-// that does not require a custom return type.
-type contractResult struct{}
+// emptyResult is the default return type of any contract call that does not require a custom return type.
+type emptyResult struct{}
 
 // statusResult is the expected return type of the statusMsg query. It returns the status of the wasm client.
 type statusResult struct {

--- a/modules/light-clients/08-wasm/types/proposal_handle.go
+++ b/modules/light-clients/08-wasm/types/proposal_handle.go
@@ -39,6 +39,6 @@ func (cs ClientState) CheckSubstituteAndUpdateState(
 		CheckSubstituteAndUpdateState: &checkSubstituteAndUpdateStateMsg{},
 	}
 
-	_, err := wasmCall[contractResult](ctx, store, &cs, payload)
+	_, err := wasmCall[emptyResult](ctx, store, &cs, payload)
 	return err
 }

--- a/modules/light-clients/08-wasm/types/update.go
+++ b/modules/light-clients/08-wasm/types/update.go
@@ -27,7 +27,7 @@ func (cs ClientState) VerifyClientMessage(ctx sdk.Context, _ codec.BinaryCodec, 
 	payload := queryMsg{
 		VerifyClientMessage: &verifyClientMessageMsg{ClientMessage: clientMessage},
 	}
-	_, err := wasmQuery[contractResult](ctx, clientStore, &cs, payload)
+	_, err := wasmQuery[emptyResult](ctx, clientStore, &cs, payload)
 	return err
 }
 
@@ -67,7 +67,7 @@ func (cs ClientState) UpdateStateOnMisbehaviour(ctx sdk.Context, _ codec.BinaryC
 		UpdateStateOnMisbehaviour: &updateStateOnMisbehaviourMsg{ClientMessage: clientMessage},
 	}
 
-	_, err := wasmCall[contractResult](ctx, clientStore, &cs, payload)
+	_, err := wasmCall[emptyResult](ctx, clientStore, &cs, payload)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/light-clients/08-wasm/types/upgrade.go
+++ b/modules/light-clients/08-wasm/types/upgrade.go
@@ -51,6 +51,6 @@ func (cs ClientState) VerifyUpgradeAndUpdateState(
 		},
 	}
 
-	_, err := wasmCall[contractResult](ctx, clientStore, &cs, payload)
+	_, err := wasmCall[emptyResult](ctx, clientStore, &cs, payload)
 	return err
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Point raised in walkthrough of 08-wasm. Uses a type constraint for the generic argument to wasmCall/wasmQuery.

closes: #XXXX


### Commit Message / Changelog Entry

```text
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
