### PR TITLE
fix(statemachine)!: add check for length of version and counterparty version in channel handshake messages

### DIFF
--- a/modules/core/04-channel/types/channel.go
+++ b/modules/core/04-channel/types/channel.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
 )
 
+const MaximumVersionLength = 8192 // maximum length of the version in bytes
+
 var (
 	_ exported.ChannelI             = (*Channel)(nil)
 	_ exported.CounterpartyChannelI = (*Counterparty)(nil)
@@ -77,6 +79,9 @@ func (ch Channel) ValidateBasic() error {
 	}
 	if err := host.ConnectionIdentifierValidator(ch.ConnectionHops[0]); err != nil {
 		return errorsmod.Wrap(err, "invalid connection hop ID")
+	}
+	if len(ch.Version) > MaximumVersionLength {
+		return errorsmod.Wrapf(ErrInvalidChannelVersion, "version must not exceed %d bytes", MaximumVersionLength)
 	}
 	return ch.Counterparty.ValidateBasic()
 }

--- a/modules/core/04-channel/types/msgs.go
+++ b/modules/core/04-channel/types/msgs.go
@@ -123,6 +123,9 @@ func (msg MsgChannelOpenTry) ValidateBasic() error {
 	if err := host.ChannelIdentifierValidator(msg.Channel.Counterparty.ChannelId); err != nil {
 		return errorsmod.Wrap(err, "invalid counterparty channel ID")
 	}
+	if len(msg.CounterpartyVersion) > MaximumVersionLength {
+		return errorsmod.Wrapf(ErrInvalidChannelVersion, "counterparty version must not exceed %d bytes", MaximumVersionLength)
+	}
 
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
@@ -169,6 +172,9 @@ func (msg MsgChannelOpenAck) ValidateBasic() error {
 	}
 	if len(msg.ProofTry) == 0 {
 		return errorsmod.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty try proof")
+	}
+	if len(msg.CounterpartyVersion) > MaximumVersionLength {
+		return errorsmod.Wrapf(ErrInvalidChannelVersion, "counterparty version must not exceed %d bytes", MaximumVersionLength)
 	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {

--- a/modules/core/04-channel/types/msgs_test.go
+++ b/modules/core/04-channel/types/msgs_test.go
@@ -18,6 +18,7 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	commitmenttypes "github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
+	ibctesting "github.com/cosmos/ibc-go/v8/testing"
 	"github.com/cosmos/ibc-go/v8/testing/simapp"
 )
 
@@ -125,6 +126,7 @@ func (suite *TypesTestSuite) TestMsgChannelOpenInitValidateBasic() {
 		{"too short connection id", types.NewMsgChannelOpenInit(portid, version, types.UNORDERED, invalidShortConnHops, cpportid, addr), false},
 		{"too long connection id", types.NewMsgChannelOpenInit(portid, version, types.UNORDERED, invalidLongConnHops, cpportid, addr), false},
 		{"connection id contains non-alpha", types.NewMsgChannelOpenInit(portid, version, types.UNORDERED, []string{invalidConnection}, cpportid, addr), false},
+		{"too long version", types.NewMsgChannelOpenInit(portid, ibctesting.GenerateString(types.MaximumVersionLength+1), types.UNORDERED, connHops, cpportid, addr), false},
 		{"", types.NewMsgChannelOpenInit(portid, "", types.UNORDERED, connHops, cpportid, addr), true},
 		{"invalid counterparty port id", types.NewMsgChannelOpenInit(portid, version, types.UNORDERED, connHops, invalidPort, addr), false},
 		{"channel not in INIT state", &types.MsgChannelOpenInit{portid, tryOpenChannel, addr}, false},
@@ -162,7 +164,10 @@ func (suite *TypesTestSuite) TestMsgChannelOpenTryValidateBasic() {
 		{"connection hops more than 1 ", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, invalidConnHops, cpportid, cpchanid, version, suite.proof, height, addr), false},
 		{"too short connection id", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, invalidShortConnHops, cpportid, cpchanid, version, suite.proof, height, addr), false},
 		{"too long connection id", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, invalidLongConnHops, cpportid, cpchanid, version, suite.proof, height, addr), false},
+		{"too long connection id", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, invalidLongConnHops, cpportid, cpchanid, version, suite.proof, height, addr), false},
 		{"connection id contains non-alpha", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, []string{invalidConnection}, cpportid, cpchanid, version, suite.proof, height, addr), false},
+		{"too long counterparty version", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, connHops, cpportid, cpchanid, ibctesting.GenerateString(types.MaximumVersionLength+1), suite.proof, height, addr), false},
+		{"too long version", types.NewMsgChannelOpenTry(portid, ibctesting.GenerateString(types.MaximumVersionLength+1), types.UNORDERED, connHops, cpportid, cpchanid, version, suite.proof, height, addr), false},
 		{"", types.NewMsgChannelOpenTry(portid, "", types.UNORDERED, connHops, cpportid, cpchanid, version, suite.proof, height, addr), true},
 		{"invalid counterparty port id", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, connHops, invalidPort, cpchanid, version, suite.proof, height, addr), false},
 		{"invalid counterparty channel id", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, connHops, cpportid, invalidChannel, version, suite.proof, height, addr), false},
@@ -199,6 +204,7 @@ func (suite *TypesTestSuite) TestMsgChannelOpenAckValidateBasic() {
 		{"too short channel id", types.NewMsgChannelOpenAck(portid, invalidShortChannel, chanid, version, suite.proof, height, addr), false},
 		{"too long channel id", types.NewMsgChannelOpenAck(portid, invalidLongChannel, chanid, version, suite.proof, height, addr), false},
 		{"channel id contains non-alpha", types.NewMsgChannelOpenAck(portid, invalidChannel, chanid, version, suite.proof, height, addr), false},
+		{"too long counterparty version", types.NewMsgChannelOpenAck(portid, chanid, chanid, ibctesting.GenerateString(types.MaximumVersionLength+1), suite.proof, height, addr), false},
 		{"", types.NewMsgChannelOpenAck(portid, chanid, chanid, "", suite.proof, height, addr), true},
 		{"empty proof", types.NewMsgChannelOpenAck(portid, chanid, chanid, version, emptyProof, height, addr), false},
 		{"invalid counterparty channel id", types.NewMsgChannelOpenAck(portid, chanid, invalidShortChannel, version, suite.proof, height, addr), false},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

ref: #4859 

I think the check for `MsgChannelOpenTry` and `MsgChannelOpenAck` might not be strictly needed, since you need a valid `MsgChannelOpenInit` to succeed to start the process and both messages require proofs (i.e. you could submit `MsgChannelOpenTry` or `MsgChannelOpenAck` with a version string above the maximum permitted length, but execution would fail because there wouldn't be a channel end on the counterparty with such version string), but I guess it doesn't hurt to add the check in those messages too.

### Commit Message / Changelog Entry

```text
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
