### PR TITLE
fix(statemachine)!: add check for length of version fields in connection handshake messages

### DIFF
--- a/modules/core/03-connection/types/msgs.go
+++ b/modules/core/03-connection/types/msgs.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
 )
 
+const MaximumVersionFieldsLength = 4096 // maximum length in bytes for the fields in version
+
 var (
 	_ sdk.Msg = (*MsgConnectionOpenInit)(nil)
 	_ sdk.Msg = (*MsgConnectionOpenConfirm)(nil)

--- a/modules/core/03-connection/types/msgs_test.go
+++ b/modules/core/03-connection/types/msgs_test.go
@@ -99,6 +99,8 @@ func (suite *MsgTestSuite) TestNewMsgConnectionOpenInit() {
 		{"invalid counterparty connection ID", &types.MsgConnectionOpenInit{connectionID, types.NewCounterparty("clienttotest", "connectiontotest", prefix), version, 500, signer}, false},
 		{"empty counterparty prefix", types.NewMsgConnectionOpenInit("clienttotest", "clienttotest", emptyPrefix, version, 500, signer), false},
 		{"supplied version fails basic validation", types.NewMsgConnectionOpenInit("clienttotest", "clienttotest", prefix, &types.Version{}, 500, signer), false},
+		{"too long version identifier", types.NewMsgConnectionOpenInit("clienttotest", "clienttotest", prefix, types.NewVersion(ibctesting.GenerateString(types.MaximumVersionFieldsLength+1), []string{"ORDER_ORDERED"}), 500, signer), false},
+		{"too long version feature", types.NewMsgConnectionOpenInit("clienttotest", "clienttotest", prefix, types.NewVersion(types.DefaultIBCVersionIdentifier, []string{ibctesting.GenerateString(types.MaximumVersionFieldsLength + 1)}), 500, signer), false},
 		{"empty singer", types.NewMsgConnectionOpenInit("clienttotest", "clienttotest", prefix, version, 500, ""), false},
 		{"success", types.NewMsgConnectionOpenInit("clienttotest", "clienttotest", prefix, version, 500, signer), true},
 	}
@@ -158,6 +160,8 @@ func (suite *MsgTestSuite) TestNewMsgConnectionOpenTry() {
 		{"empty singer", types.NewMsgConnectionOpenTry("clienttotesta", "connectiontotest", "clienttotest", clientState, prefix, []*types.Version{ibctesting.ConnectionVersion}, 500, suite.proof, suite.proof, suite.proof, clientHeight, clientHeight, ""), false},
 		{"success", types.NewMsgConnectionOpenTry("clienttotesta", "connectiontotest", "clienttotest", clientState, prefix, []*types.Version{ibctesting.ConnectionVersion}, 500, suite.proof, suite.proof, suite.proof, clientHeight, clientHeight, signer), true},
 		{"invalid version", types.NewMsgConnectionOpenTry("clienttotesta", "connectiontotest", "clienttotest", clientState, prefix, []*types.Version{{}}, 500, suite.proof, suite.proof, suite.proof, clientHeight, clientHeight, signer), false},
+		{"too long version identifier", types.NewMsgConnectionOpenTry("clienttotesta", "connectiontotest", "clienttotest", clientState, prefix, []*types.Version{types.NewVersion(ibctesting.GenerateString(types.MaximumVersionFieldsLength+1), []string{"ORDER_ORDERED"})}, 500, suite.proof, suite.proof, suite.proof, clientHeight, clientHeight, signer), false},
+		{"too long version feature", types.NewMsgConnectionOpenTry("clienttotesta", "connectiontotest", "clienttotest", clientState, prefix, []*types.Version{types.NewVersion(types.DefaultIBCVersionIdentifier, []string{ibctesting.GenerateString(types.MaximumVersionFieldsLength + 1)})}, 500, suite.proof, suite.proof, suite.proof, clientHeight, clientHeight, signer), false},
 	}
 
 	for _, tc := range testCases {
@@ -204,6 +208,8 @@ func (suite *MsgTestSuite) TestNewMsgConnectionOpenAck() {
 		{"empty proofConsensus", types.NewMsgConnectionOpenAck(connectionID, connectionID, clientState, suite.proof, suite.proof, emptyProof, clientHeight, clientHeight, ibctesting.ConnectionVersion, signer), false},
 		{"invalid consensusHeight", types.NewMsgConnectionOpenAck(connectionID, connectionID, clientState, suite.proof, suite.proof, suite.proof, clientHeight, clienttypes.ZeroHeight(), ibctesting.ConnectionVersion, signer), false},
 		{"invalid version", types.NewMsgConnectionOpenAck(connectionID, connectionID, clientState, suite.proof, suite.proof, suite.proof, clientHeight, clientHeight, &types.Version{}, signer), false},
+		{"too long version identifier", types.NewMsgConnectionOpenAck(connectionID, connectionID, clientState, suite.proof, suite.proof, suite.proof, clientHeight, clientHeight, types.NewVersion(ibctesting.GenerateString(types.MaximumVersionFieldsLength+1), []string{"ORDER_ORDERED"}), signer), false},
+		{"too long version feature", types.NewMsgConnectionOpenAck(connectionID, connectionID, clientState, suite.proof, suite.proof, suite.proof, clientHeight, clientHeight, types.NewVersion(types.DefaultIBCVersionIdentifier, []string{ibctesting.GenerateString(types.MaximumVersionFieldsLength + 1)}), signer), false},
 		{"empty signer", types.NewMsgConnectionOpenAck(connectionID, connectionID, clientState, suite.proof, suite.proof, suite.proof, clientHeight, clientHeight, ibctesting.ConnectionVersion, ""), false},
 		{"success", types.NewMsgConnectionOpenAck(connectionID, connectionID, clientState, suite.proof, suite.proof, suite.proof, clientHeight, clientHeight, ibctesting.ConnectionVersion, signer), true},
 	}

--- a/modules/core/03-connection/types/version.go
+++ b/modules/core/03-connection/types/version.go
@@ -56,9 +56,15 @@ func ValidateVersion(version *Version) error {
 	if strings.TrimSpace(version.Identifier) == "" {
 		return errorsmod.Wrap(ErrInvalidVersion, "version identifier cannot be blank")
 	}
+	if len(version.Identifier) > MaximumVersionFieldsLength {
+		return errorsmod.Wrapf(ErrInvalidVersion, "version identifier must not exceed %d bytes", MaximumVersionFieldsLength)
+	}
 	for i, feature := range version.Features {
 		if strings.TrimSpace(feature) == "" {
 			return errorsmod.Wrapf(ErrInvalidVersion, "feature cannot be blank, index %d", i)
+		}
+		if len(feature) > MaximumVersionFieldsLength {
+			return errorsmod.Wrapf(ErrInvalidVersion, "feature must not exceed %d bytes, index %d", MaximumVersionFieldsLength, i)
 		}
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

ref: #4859 

With [a similar reasoning as for the channel handshake messages](https://github.com/cosmos/ibc-go/pull/4877), the checks in `MsgConnectionOpenTry` and `MsgConnectionOpenAck` might not be needed, but added them to be extra defensive. 

### Commit Message / Changelog Entry

```text
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
