### PR TITLE
Improve mock wasmvm query implementation

### DIFF
--- a/modules/light-clients/08-wasm/testing/wasm_endpoint.go
+++ b/modules/light-clients/08-wasm/testing/wasm_endpoint.go
@@ -1,9 +1,9 @@
-package wasmtesting
+package testing
 
 import (
 	"github.com/stretchr/testify/require"
 
-	types "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
+	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	ibctesting "github.com/cosmos/ibc-go/v8/testing"
 )

--- a/modules/light-clients/08-wasm/types/client_state_test.go
+++ b/modules/light-clients/08-wasm/types/client_state_test.go
@@ -106,20 +106,20 @@ func (suite *TypesTestSuite) TestStatus() {
 		{
 			"client is frozen",
 			func() {
-				suite.mockVM.QueryFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
+				suite.mockVM.RegisterQueryCallback(types.StatusMessage{}, func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
 					resp := fmt.Sprintf(`{"status":"%s"}`, exported.Frozen)
-					return []byte(resp), wasmtesting.DefaultGasUsed, nil
-				}
+					return []byte(resp), types.DefaultGasUsed, nil
+				})
 			},
 			exported.Frozen,
 		},
 		{
 			"client status is expired",
 			func() {
-				suite.mockVM.QueryFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
+				suite.mockVM.RegisterQueryCallback(types.StatusMessage{}, func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
 					resp := fmt.Sprintf(`{"status":"%s"}`, exported.Expired)
-					return []byte(resp), wasmtesting.DefaultGasUsed, nil
-				}
+					return []byte(resp), types.DefaultGasUsed, nil
+				})
 			},
 			exported.Expired,
 		},

--- a/modules/light-clients/08-wasm/types/client_state_test.go
+++ b/modules/light-clients/08-wasm/types/client_state_test.go
@@ -106,7 +106,7 @@ func (suite *TypesTestSuite) TestStatus() {
 		{
 			"client is frozen",
 			func() {
-				suite.mockVM.RegisterQueryCallback(types.StatusMessage{}, func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
+				suite.mockVM.RegisterQueryCallback(types.StatusMsg{}, func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
 					resp := fmt.Sprintf(`{"status":"%s"}`, exported.Frozen)
 					return []byte(resp), types.DefaultGasUsed, nil
 				})
@@ -116,7 +116,7 @@ func (suite *TypesTestSuite) TestStatus() {
 		{
 			"client status is expired",
 			func() {
-				suite.mockVM.RegisterQueryCallback(types.StatusMessage{}, func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
+				suite.mockVM.RegisterQueryCallback(types.StatusMsg{}, func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
 					resp := fmt.Sprintf(`{"status":"%s"}`, exported.Expired)
 					return []byte(resp), types.DefaultGasUsed, nil
 				})
@@ -126,9 +126,9 @@ func (suite *TypesTestSuite) TestStatus() {
 		{
 			"client status is unknown: vm returns an error",
 			func() {
-				suite.mockVM.QueryFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
+				suite.mockVM.RegisterQueryCallback(types.StatusMsg{}, func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
 					return nil, 0, errors.New("client status not implemented")
-				}
+				})
 			},
 			exported.Unknown,
 		},

--- a/modules/light-clients/08-wasm/types/export_test.go
+++ b/modules/light-clients/08-wasm/types/export_test.go
@@ -8,3 +8,9 @@ package types
 type InstantiateMessage struct {
 	instantiateMessage
 }
+
+type StatusMessage statusMsg
+type ExportMetadata exportMetadataMsg
+type TimestampAtHeight timestampAtHeightMsg
+type VerifyClientMessage verifyClientMessageMsg
+type CheckForMisbehaviour checkForMisbehaviourMsg

--- a/modules/light-clients/08-wasm/types/export_test.go
+++ b/modules/light-clients/08-wasm/types/export_test.go
@@ -9,8 +9,11 @@ type InstantiateMessage struct {
 	instantiateMessage
 }
 
-type StatusMessage statusMsg
-type ExportMetadata exportMetadataMsg
-type TimestampAtHeight timestampAtHeightMsg
-type VerifyClientMessage verifyClientMessageMsg
-type CheckForMisbehaviour checkForMisbehaviourMsg
+// these fields are exported aliases for the payload fields passed to the wasm vm.
+// these are used to specify callback functions to handle specific queries in the mock vm.
+
+type StatusMsg statusMsg
+type ExportMetadataMsg exportMetadataMsg
+type TimestampAtHeightMsg timestampAtHeightMsg
+type VerifyClientMessageMsg verifyClientMessageMsg
+type CheckForMisbehaviourMsg checkForMisbehaviourMsg

--- a/modules/light-clients/08-wasm/types/export_test.go
+++ b/modules/light-clients/08-wasm/types/export_test.go
@@ -12,8 +12,10 @@ type InstantiateMessage struct {
 // these fields are exported aliases for the payload fields passed to the wasm vm.
 // these are used to specify callback functions to handle specific queries in the mock vm.
 
-type StatusMsg statusMsg
-type ExportMetadataMsg exportMetadataMsg
-type TimestampAtHeightMsg timestampAtHeightMsg
-type VerifyClientMessageMsg verifyClientMessageMsg
-type CheckForMisbehaviourMsg checkForMisbehaviourMsg
+type (
+	StatusMsg               = statusMsg
+	ExportMetadataMsg       = exportMetadataMsg
+	TimestampAtHeightMsg    = timestampAtHeightMsg
+	VerifyClientMessageMsg  = verifyClientMessageMsg
+	CheckForMisbehaviourMsg = checkForMisbehaviourMsg
+)

--- a/modules/light-clients/08-wasm/types/mock_engine_test.go
+++ b/modules/light-clients/08-wasm/types/mock_engine_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 
 	wasmvm "github.com/CosmWasm/wasmvm"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
@@ -115,10 +114,6 @@ func (m *MockWasmEngine) Pin(checksum wasmvm.Checksum) error {
 	return m.PinFn(checksum)
 }
 
-func upperCaseFirstChar(s string) string {
-	return strings.ToUpper(s[:1]) + s[1:]
-}
-
 // getQueryMsgPayloadTypeName extracts the name of the struct that is populated.
 // this value is used as a key to map to a callback function to handle that message type.
 func getQueryMsgPayloadTypeName(queryMsgBz []byte) string {
@@ -152,5 +147,5 @@ func getQueryMsgPayloadTypeName(queryMsgBz []byte) string {
 		panic(fmt.Errorf("failed to extract valid query message from bytes: %s", string(queryMsgBz)))
 	}
 
-	return upperCaseFirstChar(reflect.TypeOf(payloadField).Name())
+	return reflect.TypeOf(payloadField).Name()
 }

--- a/modules/light-clients/08-wasm/types/types_test.go
+++ b/modules/light-clients/08-wasm/types/types_test.go
@@ -91,10 +91,10 @@ func (suite *TypesTestSuite) setupWasmWithMockVM() (ibctesting.TestingApp, map[s
 		return nil, 0, nil
 	}
 
-	suite.mockVM.QueryFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
+	suite.mockVM.RegisterQueryCallback(types.StatusMsg{}, func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
 		resp := fmt.Sprintf(`{"status":"%s"}`, exported.Active)
 		return []byte(resp), types.DefaultGasUsed, nil
-	}
+	})
 
 	db := dbm.NewMemDB()
 	app := simapp.NewSimApp(log.NewNopLogger(), db, nil, true, simtestutil.EmptyAppOptions{}, suite.mockVM)

--- a/modules/light-clients/08-wasm/types/types_test.go
+++ b/modules/light-clients/08-wasm/types/types_test.go
@@ -23,7 +23,6 @@ import (
 	tmjson "github.com/cometbft/cometbft/libs/json"
 	tmtypes "github.com/cometbft/cometbft/types"
 
-	wasmtesting "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/testing"
 	simapp "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/testing/simapp"
 	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
@@ -42,7 +41,7 @@ type TypesTestSuite struct {
 	testifysuite.Suite
 	coordinator *ibctesting.Coordinator
 	chainA      *ibctesting.TestChain
-	mockVM      *wasmtesting.MockWasmEngine
+	mockVM      *types.MockWasmEngine
 
 	ctx      sdk.Context
 	store    storetypes.KVStore
@@ -80,7 +79,7 @@ func (suite *TypesTestSuite) SetupWasmWithMockVM() {
 }
 
 func (suite *TypesTestSuite) setupWasmWithMockVM() (ibctesting.TestingApp, map[string]json.RawMessage) {
-	suite.mockVM = &wasmtesting.MockWasmEngine{}
+	suite.mockVM = types.NewMockWasmEngine()
 	// TODO: move default functionality required for wasm client testing to the mock VM
 	suite.mockVM.InstantiateFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, info wasmvmtypes.MessageInfo, initMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error) {
 		var payload types.InstantiateMessage
@@ -94,7 +93,7 @@ func (suite *TypesTestSuite) setupWasmWithMockVM() (ibctesting.TestingApp, map[s
 
 	suite.mockVM.QueryFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
 		resp := fmt.Sprintf(`{"status":"%s"}`, exported.Active)
-		return []byte(resp), wasmtesting.DefaultGasUsed, nil
+		return []byte(resp), types.DefaultGasUsed, nil
 	}
 
 	db := dbm.NewMemDB()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #4873

The implementation wasn't as straightforward as I was expecting.

It seems it is not possible to use type constraints as keys to a map, because of this I opted to use the type name and pre-populate the map with all allowed types so it is only possible to register types for the expected values.

I needed to move the mock vm to the same package as the types to be able to actually do this.

I'm not too happy about that, and I think we can actually revert that if we just opt to use a set of string constants instead of types. Open to suggestions!


I also looked into the possibility of using an `internal` directory, but types aren't importable from types_test from a separate package.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
