### PR TITLE
Modify wrappedStore to allow reads from both substitute and subject, writes only to subject

### DIFF
--- a/modules/light-clients/08-wasm/types/export_test.go
+++ b/modules/light-clients/08-wasm/types/export_test.go
@@ -26,12 +26,12 @@ func GetClientID(clientStore storetypes.KVStore) (string, error) {
 // NewUpdateProposalWrappedStore is a wrapper around newUpdateProposalWrappedStore to allow the function to be directly called in tests.
 //
 //nolint:revive // Returning unexported type for testing purposes.
-func NewUpdateProposalWrappedStore(subjectStore, substituteStore storetypes.KVStore) updateProposalWrappedStore {
+func NewUpdateProposalWrappedStore(subjectStore, substituteStore storetypes.KVStore) migrateClientWrappedStore {
 	return newUpdateProposalWrappedStore(subjectStore, substituteStore)
 }
 
 // GetStore is a wrapper around getStore to allow the function to be directly called in tests.
-func (ws updateProposalWrappedStore) GetStore(key []byte) storetypes.KVStore {
+func (ws migrateClientWrappedStore) GetStore(key []byte) storetypes.KVStore {
 	return ws.getStore(key)
 }
 

--- a/modules/light-clients/08-wasm/types/export_test.go
+++ b/modules/light-clients/08-wasm/types/export_test.go
@@ -13,6 +13,11 @@ import (
 // MaxWasmSize is the maximum size of a wasm code in bytes.
 const MaxWasmSize = maxWasmSize
 
+var (
+	SubjectPrefix    = subjectPrefix
+	SubstitutePrefix = substitutePrefix
+)
+
 // GetClientID is a wrapper around getClientID to allow the function to be directly called in tests.
 func GetClientID(clientStore storetypes.KVStore) (string, error) {
 	return getClientID(clientStore)
@@ -21,8 +26,18 @@ func GetClientID(clientStore storetypes.KVStore) (string, error) {
 // NewUpdateProposalWrappedStore is a wrapper around newUpdateProposalWrappedStore to allow the function to be directly called in tests.
 //
 //nolint:revive // Returning unexported type for testing purposes.
-func NewUpdateProposalWrappedStore(subjectStore, substituteStore storetypes.KVStore, subjectPrefix, substitutePrefix []byte) updateProposalWrappedStore {
-	return newUpdateProposalWrappedStore(subjectStore, substituteStore, subjectPrefix, substitutePrefix)
+func NewUpdateProposalWrappedStore(subjectStore, substituteStore storetypes.KVStore) updateProposalWrappedStore {
+	return newUpdateProposalWrappedStore(subjectStore, substituteStore)
+}
+
+// GetStore is a wrapper around getStore to allow the function to be directly called in tests.
+func (ws updateProposalWrappedStore) GetStore(key []byte) storetypes.KVStore {
+	return ws.getStore(key)
+}
+
+// SplitPrefix is a wrapper around splitKey to allow the function to be directly called in tests.
+func SplitPrefix(key []byte) ([]byte, []byte) {
+	return splitPrefix(key)
 }
 
 // WasmQuery wraps wasmQuery and is used solely for testing.

--- a/modules/light-clients/08-wasm/types/export_test.go
+++ b/modules/light-clients/08-wasm/types/export_test.go
@@ -23,11 +23,11 @@ func GetClientID(clientStore storetypes.KVStore) (string, error) {
 	return getClientID(clientStore)
 }
 
-// NewUpdateProposalWrappedStore is a wrapper around newUpdateProposalWrappedStore to allow the function to be directly called in tests.
+// NewMigrateProposalWrappedStore is a wrapper around newMigrateProposalWrappedStore to allow the function to be directly called in tests.
 //
 //nolint:revive // Returning unexported type for testing purposes.
-func NewUpdateProposalWrappedStore(subjectStore, substituteStore storetypes.KVStore) migrateClientWrappedStore {
-	return newUpdateProposalWrappedStore(subjectStore, substituteStore)
+func NewMigrateProposalWrappedStore(subjectStore, substituteStore storetypes.KVStore) migrateClientWrappedStore {
+	return newMigrateClientWrappedStore(subjectStore, substituteStore)
 }
 
 // GetStore is a wrapper around getStore to allow the function to be directly called in tests.

--- a/modules/light-clients/08-wasm/types/proposal_handle.go
+++ b/modules/light-clients/08-wasm/types/proposal_handle.go
@@ -31,7 +31,7 @@ func (cs ClientState) CheckSubstituteAndUpdateState(ctx sdk.Context, _ codec.Bin
 		return errorsmod.Wrapf(clienttypes.ErrInvalidClient, "expected code hashes to be equal: expected %s, got %s", hex.EncodeToString(cs.CodeHash), hex.EncodeToString(substituteClientState.CodeHash))
 	}
 
-	store := newUpdateProposalWrappedStore(subjectClientStore, substituteClientStore)
+	store := newMigrateClientWrappedStore(subjectClientStore, substituteClientStore)
 
 	payload := SudoMsg{
 		MigrateClientStore: &MigrateClientStoreMsg{},

--- a/modules/light-clients/08-wasm/types/proposal_handle.go
+++ b/modules/light-clients/08-wasm/types/proposal_handle.go
@@ -17,11 +17,6 @@ import (
 // CheckSubstituteAndUpdateState will verify that a substitute client state is valid and update the subject client state.
 // Note that this method is used only for recovery and will not allow changes to the code hash.
 func (cs ClientState) CheckSubstituteAndUpdateState(ctx sdk.Context, _ codec.BinaryCodec, subjectClientStore, substituteClientStore storetypes.KVStore, substituteClient exported.ClientState) error {
-	var (
-		subjectPrefix    = []byte("subject/")
-		substitutePrefix = []byte("substitute/")
-	)
-
 	substituteClientState, ok := substituteClient.(*ClientState)
 	if !ok {
 		return errorsmod.Wrapf(
@@ -36,7 +31,7 @@ func (cs ClientState) CheckSubstituteAndUpdateState(ctx sdk.Context, _ codec.Bin
 		return errorsmod.Wrapf(clienttypes.ErrInvalidClient, "expected code hashes to be equal: expected %s, got %s", hex.EncodeToString(cs.CodeHash), hex.EncodeToString(substituteClientState.CodeHash))
 	}
 
-	store := newUpdateProposalWrappedStore(subjectClientStore, substituteClientStore, subjectPrefix, substitutePrefix)
+	store := newUpdateProposalWrappedStore(subjectClientStore, substituteClientStore)
 
 	payload := SudoMsg{
 		MigrateClientStore: &MigrateClientStoreMsg{},

--- a/modules/light-clients/08-wasm/types/proposal_handle_test.go
+++ b/modules/light-clients/08-wasm/types/proposal_handle_test.go
@@ -13,6 +13,7 @@ import (
 	wasmtesting "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/testing"
 	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
 	ibctm "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
 )
@@ -44,6 +45,10 @@ func (suite *TypesTestSuite) TestCheckSubstituteAndUpdateState() {
 
 						bz, err := json.Marshal(types.EmptyResult{})
 						suite.Require().NoError(err)
+
+						prefixedKey := types.SubjectPrefix
+						prefixedKey = append(prefixedKey, host.ClientStateKey()...)
+						store.Set(prefixedKey, wasmtesting.MockClientStateBz)
 
 						return &wasmvmtypes.Response{Data: bz}, wasmtesting.DefaultGasUsed, nil
 					},
@@ -113,6 +118,9 @@ func (suite *TypesTestSuite) TestCheckSubstituteAndUpdateState() {
 			expPass := tc.expErr == nil
 			if expPass {
 				suite.Require().NoError(tc.expErr)
+
+				clientStateBz := subjectClientStore.Get(host.ClientStateKey())
+				suite.Require().Equal(wasmtesting.MockClientStateBz, clientStateBz)
 			} else {
 				suite.Require().ErrorIs(err, tc.expErr)
 			}

--- a/modules/light-clients/08-wasm/types/store.go
+++ b/modules/light-clients/08-wasm/types/store.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -67,7 +68,7 @@ func (ws updateProposalWrappedStore) Has(key []byte) bool {
 func (ws updateProposalWrappedStore) Set(key, value []byte) {
 	prefix, key := splitPrefix(key)
 	if !bytes.Equal(prefix, subjectPrefix) {
-		panic(errors.New("key must be prefixed with subject/"))
+		panic(errors.New("writes only allowed on subject store; key must be prefixed with subject/"))
 	}
 
 	ws.subjectStore.Set(key, value)
@@ -79,7 +80,7 @@ func (ws updateProposalWrappedStore) Set(key, value []byte) {
 func (ws updateProposalWrappedStore) Delete(key []byte) {
 	prefix, key := splitPrefix(key)
 	if !bytes.Equal(prefix, subjectPrefix) {
-		panic(errors.New("key must be prefixed with subject/"))
+		panic(fmt.Errorf("writes only allowed on subject store; key must be prefixed with %s", subjectPrefix))
 	}
 
 	ws.subjectStore.Delete(key)
@@ -93,7 +94,7 @@ func (ws updateProposalWrappedStore) Iterator(start, end []byte) storetypes.Iter
 	prefixEnd, end := splitPrefix(end)
 
 	if !bytes.Equal(prefixStart, prefixEnd) {
-		panic(errors.New("start and end keys must be prefixed with the same prefix"))
+		panic(fmt.Errorf("writes only allowed on subject store; key must be prefixed with %s", subjectPrefix))
 	}
 
 	return ws.getStore(prefixStart).Iterator(start, end)

--- a/modules/light-clients/08-wasm/types/store.go
+++ b/modules/light-clients/08-wasm/types/store.go
@@ -37,7 +37,7 @@ type migrateClientWrappedStore struct {
 	substituteStore storetypes.KVStore
 }
 
-func newUpdateProposalWrappedStore(subjectStore, substituteStore storetypes.KVStore) migrateClientWrappedStore {
+func newMigrateClientWrappedStore(subjectStore, substituteStore storetypes.KVStore) migrateClientWrappedStore {
 	return migrateClientWrappedStore{
 		subjectStore:    subjectStore,
 		substituteStore: substituteStore,
@@ -193,11 +193,11 @@ func (s storeAdapter) ReverseIterator(start, end []byte) wasmvmtypes.Iterator {
 // Due to the 02-client module not passing the clientID to the 08-wasm module,
 // this function was devised to infer it from the store's prefix.
 // The expected format of the clientStore prefix is "<placeholder>/{clientID}/".
-// If the clientStore is of type updateProposalWrappedStore, the subjectStore's prefix is utilized instead.
+// If the clientStore is of type migrateProposalWrappedStore, the subjectStore's prefix is utilized instead.
 func getClientID(clientStore storetypes.KVStore) (string, error) {
-	upws, isUpdateProposalWrappedStore := clientStore.(migrateClientWrappedStore)
-	if isUpdateProposalWrappedStore {
-		// if the clientStore is a updateProposalWrappedStore, we retrieve the subjectStore
+	upws, isMigrateProposalWrappedStore := clientStore.(migrateClientWrappedStore)
+	if isMigrateProposalWrappedStore {
+		// if the clientStore is a migrateProposalWrappedStore, we retrieve the subjectStore
 		// because the contract call will be made on the client with the ID of the subjectStore
 		clientStore = upws.subjectStore
 	}

--- a/modules/light-clients/08-wasm/types/store.go
+++ b/modules/light-clients/08-wasm/types/store.go
@@ -11,7 +11,6 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/store/cachekv"
-	"cosmossdk.io/store/listenkv"
 	storeprefix "cosmossdk.io/store/prefix"
 	"cosmossdk.io/store/tracekv"
 	storetypes "cosmossdk.io/store/types"
@@ -19,85 +18,143 @@ import (
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
 )
 
-// updateProposalWrappedStore combines two KVStores into one while transparently routing the calls based on key prefix
+var (
+	_ wasmvmtypes.KVStore = &storeAdapter{}
+	_ storetypes.KVStore  = &updateProposalWrappedStore{}
+
+	subjectPrefix    = []byte("subject/")
+	substitutePrefix = []byte("substitute/")
+)
+
+// updateProposalWrappedStore combines two KVStores into one.
+//
+// Both stores are used for reads, but only the subjectStore is used for writes. For all operations, the key
+// is checked to determine which store to use and must be prefixed with either "subject/" or "substitute/" accordingly.
+// If the key is not prefixed with either "subject/" or "substitute/", a panic is thrown.
 type updateProposalWrappedStore struct {
 	subjectStore    storetypes.KVStore
 	substituteStore storetypes.KVStore
-
-	subjectPrefix    []byte
-	substitutePrefix []byte
 }
 
-func newUpdateProposalWrappedStore(subjectStore, substituteStore storetypes.KVStore, subjectPrefix, substitutePrefix []byte) updateProposalWrappedStore {
+func newUpdateProposalWrappedStore(subjectStore, substituteStore storetypes.KVStore) updateProposalWrappedStore {
 	return updateProposalWrappedStore{
-		subjectStore:     subjectStore,
-		substituteStore:  substituteStore,
-		subjectPrefix:    subjectPrefix,
-		substitutePrefix: substitutePrefix,
+		subjectStore:    subjectStore,
+		substituteStore: substituteStore,
 	}
 }
 
+// Get implements the storetypes.KVStore interface. It allows reads from both the subjectStore and substituteStore.
+//
+// Get will panic if the key is not prefixed with either "subject/" or "substitute/".
 func (ws updateProposalWrappedStore) Get(key []byte) []byte {
-	return ws.getStore(key).Get(ws.trimPrefix(key))
+	prefix, key := splitPrefix(key)
+
+	return ws.getStore(prefix).Get(key)
 }
 
+// Has implements the storetypes.KVStore interface. It allows reads from both the subjectStore and substituteStore.
+//
+// Note: contracts do not have access to the Has method, it is only implemented here to satisfy the storetypes.KVStore interface.
 func (ws updateProposalWrappedStore) Has(key []byte) bool {
-	return ws.getStore(key).Has(ws.trimPrefix(key))
+	prefix, key := splitPrefix(key)
+
+	return ws.getStore(prefix).Has(key)
 }
 
+// Set implements the storetypes.KVStore interface. It allows writes solely to the subjectStore.
+//
+// Set will panic if the key is not prefixed with "subject/".
 func (ws updateProposalWrappedStore) Set(key, value []byte) {
-	ws.getStore(key).Set(ws.trimPrefix(key), value)
+	prefix, key := splitPrefix(key)
+	if !bytes.Equal(prefix, subjectPrefix) {
+		panic(errors.New("key must be prefixed with subject/"))
+	}
+
+	ws.subjectStore.Set(key, value)
 }
 
+// Delete implements the storetypes.KVStore interface. It allows deletions solely to the subjectStore.
+//
+// Delete will panic if the key is not prefixed with "subject/".
 func (ws updateProposalWrappedStore) Delete(key []byte) {
-	ws.getStore(key).Delete(ws.trimPrefix(key))
+	prefix, key := splitPrefix(key)
+	if !bytes.Equal(prefix, subjectPrefix) {
+		panic(errors.New("key must be prefixed with subject/"))
+	}
+
+	ws.subjectStore.Delete(key)
 }
 
-func (ws updateProposalWrappedStore) GetStoreType() storetypes.StoreType {
-	return ws.subjectStore.GetStoreType()
-}
-
+// Iterator implements the storetypes.KVStore interface. It allows iteration over both the subjectStore and substituteStore.
+//
+// Iterator will panic if the start or end keys are not prefixed with either "subject/" or "substitute/".
 func (ws updateProposalWrappedStore) Iterator(start, end []byte) storetypes.Iterator {
-	return ws.getStore(start).Iterator(ws.trimPrefix(start), ws.trimPrefix(end))
+	prefixStart, start := splitPrefix(start)
+	prefixEnd, end := splitPrefix(end)
+
+	if !bytes.Equal(prefixStart, prefixEnd) {
+		panic(errors.New("start and end keys must be prefixed with the same prefix"))
+	}
+
+	return ws.getStore(prefixStart).Iterator(start, end)
 }
 
+// ReverseIterator implements the storetypes.KVStore interface. It allows iteration over both the subjectStore and substituteStore.
+//
+// ReverseIterator will panic if the start or end keys are not prefixed with either "subject/" or "substitute/".
 func (ws updateProposalWrappedStore) ReverseIterator(start, end []byte) storetypes.Iterator {
-	return ws.getStore(start).ReverseIterator(ws.trimPrefix(start), ws.trimPrefix(end))
+	prefixStart, start := splitPrefix(start)
+	prefixEnd, end := splitPrefix(end)
+
+	if !bytes.Equal(prefixStart, prefixEnd) {
+		panic(errors.New("start and end keys must be prefixed with the same prefix"))
+	}
+
+	return ws.getStore(prefixStart).ReverseIterator(start, end)
 }
 
+// GetStoreType implements the storetypes.KVStore interface, it is implemented solely to satisfy the interface.
+func (ws updateProposalWrappedStore) GetStoreType() storetypes.StoreType {
+	return ws.substituteStore.GetStoreType()
+}
+
+// CacheWrap implements the storetypes.KVStore interface, it is implemented solely to satisfy the interface.
 func (ws updateProposalWrappedStore) CacheWrap() storetypes.CacheWrap {
 	return cachekv.NewStore(ws)
 }
 
+// CacheWrapWithTrace implements the storetypes.KVStore interface, it is implemented solely to satisfy the interface.
 func (ws updateProposalWrappedStore) CacheWrapWithTrace(w io.Writer, tc storetypes.TraceContext) storetypes.CacheWrap {
 	return cachekv.NewStore(tracekv.NewStore(ws, w, tc))
 }
 
-func (ws updateProposalWrappedStore) CacheWrapWithListeners(storeKey storetypes.StoreKey, listeners *storetypes.MemoryListener) storetypes.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(ws, storeKey, listeners))
-}
-
-func (ws updateProposalWrappedStore) trimPrefix(key []byte) []byte {
-	if bytes.HasPrefix(key, ws.subjectPrefix) {
-		key = bytes.TrimPrefix(key, ws.subjectPrefix)
-	} else {
-		key = bytes.TrimPrefix(key, ws.substitutePrefix)
-	}
-
-	return key
-}
-
-func (ws updateProposalWrappedStore) getStore(key []byte) storetypes.KVStore {
-	if bytes.HasPrefix(key, ws.subjectPrefix) {
+// getStore returns the store to be used for the given key. If the key is prefixed with "subject/", the subjectStore
+// is returned. If the key is prefixed with "substitute/", the substituteStore is returned.
+//
+// If the key is not prefixed with either "subject/" or "substitute/", a panic is thrown.
+func (ws updateProposalWrappedStore) getStore(prefix []byte) storetypes.KVStore {
+	if bytes.Equal(prefix, subjectPrefix) {
 		return ws.subjectStore
+	} else if bytes.Equal(prefix, substitutePrefix) {
+		return ws.substituteStore
 	}
 
-	return ws.substituteStore
+	panic(errors.New("key must be prefixed with either subject/ or substitute/"))
 }
 
-var _ wasmvmtypes.KVStore = &storeAdapter{}
+// splitPrefix splits the key into the prefix and the key itself, if the key is prefixed with either "subject/" or "substitute/".
+// If the key is not prefixed with either "subject/" or "substitute/", the prefix is nil.
+func splitPrefix(key []byte) ([]byte, []byte) {
+	if bytes.HasPrefix(key, subjectPrefix) {
+		return subjectPrefix, bytes.TrimPrefix(key, subjectPrefix)
+	} else if bytes.HasPrefix(key, substitutePrefix) {
+		return substitutePrefix, bytes.TrimPrefix(key, substitutePrefix)
+	}
 
-// storeAdapter adapter to bridge SDK store impl to wasmvm
+	return nil, key
+}
+
+// storeAdapter bridges the SDK store implementation to wasmvm one. It implements the wasmvmtypes.KVStore interface.
 type storeAdapter struct {
 	parent storetypes.KVStore
 }

--- a/modules/light-clients/08-wasm/types/store_test.go
+++ b/modules/light-clients/08-wasm/types/store_test.go
@@ -14,8 +14,8 @@ import (
 
 var invalidPrefix = []byte("invalid/")
 
-// TestUpdateProposalWrappedStoreGetStore tests the getStore method of the updateProposalWrappedStore.
-func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreGetStore() {
+// TestMigrateClientWrappedStoreGetStore tests the getStore method of the migrateClientWrappedStore.
+func (suite *TypesTestSuite) TestMigrateClientWrappedStoreGetStore() {
 	// calls suite.SetupWasmWithMockVM() and creates two clients with their respective stores
 	subjectStore, substituteStore := suite.GetSubjectAndSubstituteStore()
 
@@ -54,7 +54,7 @@ func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreGetStore() {
 	for _, tc := range testCases {
 		tc := tc
 		suite.Run(tc.name, func() {
-			wrappedStore := types.NewUpdateProposalWrappedStore(subjectStore, substituteStore)
+			wrappedStore := types.NewMigrateProposalWrappedStore(subjectStore, substituteStore)
 
 			if tc.expPanic == nil {
 				suite.Require().Equal(tc.expStore, wrappedStore.GetStore(tc.prefix))
@@ -107,8 +107,8 @@ func (suite *TypesTestSuite) TestSplitPrefix() {
 	}
 }
 
-// TestUpdateProposalWrappedStoreGet tests the Get method of the updateProposalWrappedStore.
-func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreGet() {
+// TestMigrateClientWrappedStoreGet tests the Get method of the migrateClientWrappedStore.
+func (suite *TypesTestSuite) TestMigrateClientWrappedStoreGet() {
 	// calls suite.SetupWasmWithMockVM() and creates two clients with their respective stores
 	subjectStore, substituteStore := suite.GetSubjectAndSubstituteStore()
 
@@ -145,7 +145,7 @@ func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreGet() {
 	for _, tc := range testCases {
 		tc := tc
 		suite.Run(tc.name, func() {
-			wrappedStore := types.NewUpdateProposalWrappedStore(subjectStore, substituteStore)
+			wrappedStore := types.NewMigrateProposalWrappedStore(subjectStore, substituteStore)
 
 			prefixedKey := tc.prefix
 			prefixedKey = append(prefixedKey, tc.key...)
@@ -161,8 +161,8 @@ func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreGet() {
 	}
 }
 
-// TestUpdateProposalWrappedStoreSet tests the Set method of the updateProposalWrappedStore.
-func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreSet() {
+// TestMigrateClientWrappedStoreSet tests the Set method of the migrateClientWrappedStore.
+func (suite *TypesTestSuite) TestMigrateClientWrappedStoreSet() {
 	// calls suite.SetupWasmWithMockVM() and creates two clients with their respective stores
 	subjectStore, substituteStore := suite.GetSubjectAndSubstituteStore()
 
@@ -192,7 +192,7 @@ func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreSet() {
 	for _, tc := range testCases {
 		tc := tc
 		suite.Run(tc.name, func() {
-			wrappedStore := types.NewUpdateProposalWrappedStore(subjectStore, substituteStore)
+			wrappedStore := types.NewMigrateProposalWrappedStore(subjectStore, substituteStore)
 
 			prefixedKey := tc.prefix
 			prefixedKey = append(prefixedKey, tc.key...)
@@ -210,8 +210,8 @@ func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreSet() {
 	}
 }
 
-// TestUpdateProposalWrappedStoreDelete tests the Delete method of the updateProposalWrappedStore.
-func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreDelete() {
+// TestMigrateClientWrappedStoreDelete tests the Delete method of the migrateClientWrappedStore.
+func (suite *TypesTestSuite) TestMigrateClientWrappedStoreDelete() {
 	// calls suite.SetupWasmWithMockVM() and creates two clients with their respective stores
 	subjectStore, substituteStore := suite.GetSubjectAndSubstituteStore()
 
@@ -241,7 +241,7 @@ func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreDelete() {
 	for _, tc := range testCases {
 		tc := tc
 		suite.Run(tc.name, func() {
-			wrappedStore := types.NewUpdateProposalWrappedStore(subjectStore, substituteStore)
+			wrappedStore := types.NewMigrateProposalWrappedStore(subjectStore, substituteStore)
 
 			prefixedKey := tc.prefix
 			prefixedKey = append(prefixedKey, tc.key...)
@@ -257,8 +257,8 @@ func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreDelete() {
 	}
 }
 
-// TestUpdateProposalWrappedStoreIterators tests the Iterator/ReverseIterator methods of the updateProposalWrappedStore.
-func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreIterators() {
+// TestMigrateClientWrappedStoreIterators tests the Iterator/ReverseIterator methods of the migrateClientWrappedStore.
+func (suite *TypesTestSuite) TestMigrateClientWrappedStoreIterators() {
 	// calls suite.SetupWasmWithMockVM() and creates two clients with their respective stores
 	subjectStore, substituteStore := suite.GetSubjectAndSubstituteStore()
 
@@ -307,7 +307,7 @@ func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreIterators() {
 	for _, tc := range testCases {
 		tc := tc
 		suite.Run(tc.name, func() {
-			wrappedStore := types.NewUpdateProposalWrappedStore(subjectStore, substituteStore)
+			wrappedStore := types.NewMigrateProposalWrappedStore(subjectStore, substituteStore)
 
 			prefixedKeyStart := tc.prefixStart
 			prefixedKeyStart = append(prefixedKeyStart, tc.start...)
@@ -339,9 +339,9 @@ func (suite *TypesTestSuite) TestGetClientID() {
 			nil,
 		},
 		{
-			"success: clientID retrieved from updateProposalWrappedStore",
+			"success: clientID retrieved from migrateClientWrappedStore",
 			func() {
-				clientStore = types.NewUpdateProposalWrappedStore(clientStore, nil)
+				clientStore = types.NewMigrateProposalWrappedStore(clientStore, nil)
 			},
 			nil,
 		},

--- a/modules/light-clients/08-wasm/types/store_test.go
+++ b/modules/light-clients/08-wasm/types/store_test.go
@@ -1,10 +1,315 @@
 package types_test
 
 import (
-	prefixstore "cosmossdk.io/store/prefix"
+	"errors"
 
+	prefixstore "cosmossdk.io/store/prefix"
+	storetypes "cosmossdk.io/store/types"
+
+	wasmtesting "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/testing"
 	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
+	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
 )
+
+var invalidPrefix = []byte("invalid/")
+
+// TestGetStore tests the getStore method of the updateProposalWrappedStore.
+func (suite *TypesTestSuite) TestGetStore() {
+	// calls suite.SetupWasmWithMockVM() and creates two clients with their respective stores
+	subjectStore, substituteStore := suite.GetSubjectAndSubstituteStore()
+
+	testCases := []struct {
+		name     string
+		prefix   []byte
+		expStore storetypes.KVStore
+		expPanic error
+	}{
+		{
+			"success: subject store",
+			types.SubjectPrefix,
+			subjectStore,
+			nil,
+		},
+		{
+			"success: substitute store",
+			types.SubstitutePrefix,
+			substituteStore,
+			nil,
+		},
+		{
+			"failure: invalid prefix",
+			invalidPrefix,
+			nil,
+			errors.New("key must be prefixed with either subject/ or substitute/"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			wrappedStore := types.NewUpdateProposalWrappedStore(subjectStore, substituteStore)
+
+			if tc.expPanic == nil {
+				suite.Require().Equal(tc.expStore, wrappedStore.GetStore(tc.prefix))
+			} else {
+				suite.Require().PanicsWithError(tc.expPanic.Error(), func() { wrappedStore.GetStore(tc.prefix) })
+			}
+		})
+	}
+}
+
+// TestSplitPrefix tests the splitPrefix function.
+func (suite *TypesTestSuite) TestSplitPrefix() {
+	testCases := []struct {
+		name      string
+		prefix    []byte
+		expValues [][]byte
+	}{
+		{
+			"success: subject prefix",
+			types.SubjectPrefix,
+			[][]byte{types.SubjectPrefix, []byte("")},
+		},
+		{
+			"success: substitute prefix",
+			types.SubstitutePrefix,
+			[][]byte{types.SubstitutePrefix, []byte("")},
+		},
+		{
+			"success: prefix returned unchanged",
+			invalidPrefix,
+			[][]byte{nil, invalidPrefix},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			prefix, key := types.SplitPrefix(tc.prefix)
+
+			suite.Require().Equal(tc.expValues[0], prefix)
+			suite.Require().Equal(tc.expValues[1], key)
+		})
+	}
+}
+
+// TestUpdateProposalWrappedStoreGet tests the Get method of the updateProposalWrappedStore.
+func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreGet() {
+	// calls suite.SetupWasmWithMockVM() and creates two clients with their respective stores
+	subjectStore, substituteStore := suite.GetSubjectAndSubstituteStore()
+
+	testCases := []struct {
+		name     string
+		key      []byte
+		prefix   []byte
+		expStore storetypes.KVStore
+		expPanic error
+	}{
+		{
+			"success: subject store Get",
+			host.ClientStateKey(),
+			types.SubjectPrefix,
+			subjectStore,
+			nil,
+		},
+		{
+			"success: substitute store Get",
+			host.ClientStateKey(),
+			types.SubstitutePrefix,
+			substituteStore,
+			nil,
+		},
+		{
+			"failure: key not prefixed with subject/ or substitute/",
+			host.ClientStateKey(),
+			invalidPrefix,
+			nil,
+			errors.New("key must be prefixed with either subject/ or substitute/"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			wrappedStore := types.NewUpdateProposalWrappedStore(subjectStore, substituteStore)
+
+			prefixedKey := tc.prefix
+			prefixedKey = append(prefixedKey, tc.key...)
+
+			if tc.expPanic == nil {
+				expValue := tc.expStore.Get(tc.key)
+
+				suite.Require().Equal(expValue, wrappedStore.Get(prefixedKey))
+			} else {
+				suite.Require().PanicsWithError(tc.expPanic.Error(), func() { wrappedStore.Get(prefixedKey) })
+			}
+		})
+	}
+}
+
+// TestUpdateProposalWrappedStoreSet tests the Set method of the updateProposalWrappedStore.
+func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreSet() {
+	// calls suite.SetupWasmWithMockVM() and creates two clients with their respective stores
+	subjectStore, substituteStore := suite.GetSubjectAndSubstituteStore()
+
+	testCases := []struct {
+		name     string
+		key      []byte
+		prefix   []byte
+		expStore storetypes.KVStore
+		expPanic error
+	}{
+		{
+			"success: subject store Set",
+			host.ClientStateKey(),
+			types.SubjectPrefix,
+			subjectStore,
+			nil,
+		},
+		{
+			"failure: cannot Set on substitute store",
+			host.ClientStateKey(),
+			types.SubstitutePrefix,
+			nil,
+			errors.New("key must be prefixed with subject/"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			wrappedStore := types.NewUpdateProposalWrappedStore(subjectStore, substituteStore)
+
+			prefixedKey := tc.prefix
+			prefixedKey = append(prefixedKey, tc.key...)
+
+			if tc.expPanic == nil {
+				wrappedStore.Set(prefixedKey, wasmtesting.MockClientStateBz)
+
+				expValue := tc.expStore.Get(tc.key)
+
+				suite.Require().Equal(wasmtesting.MockClientStateBz, expValue)
+			} else {
+				suite.Require().PanicsWithError(tc.expPanic.Error(), func() { wrappedStore.Set(prefixedKey, wasmtesting.MockClientStateBz) })
+			}
+		})
+	}
+}
+
+// TestUpdateProposalWrappedStoreDelete tests the Delete method of the updateProposalWrappedStore.
+func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreDelete() {
+	// calls suite.SetupWasmWithMockVM() and creates two clients with their respective stores
+	subjectStore, substituteStore := suite.GetSubjectAndSubstituteStore()
+
+	testCases := []struct {
+		name     string
+		key      []byte
+		prefix   []byte
+		expStore storetypes.KVStore
+		expPanic error
+	}{
+		{
+			"success: subject store Delete",
+			host.ClientStateKey(),
+			types.SubjectPrefix,
+			subjectStore,
+			nil,
+		},
+		{
+			"failure: cannot Delete on substitute store",
+			host.ClientStateKey(),
+			types.SubstitutePrefix,
+			nil,
+			errors.New("key must be prefixed with subject/"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			wrappedStore := types.NewUpdateProposalWrappedStore(subjectStore, substituteStore)
+
+			prefixedKey := tc.prefix
+			prefixedKey = append(prefixedKey, tc.key...)
+
+			if tc.expPanic == nil {
+				wrappedStore.Delete(prefixedKey)
+
+				suite.Require().False(tc.expStore.Has(tc.key))
+			} else {
+				suite.Require().PanicsWithError(tc.expPanic.Error(), func() { wrappedStore.Delete(prefixedKey) })
+			}
+		})
+	}
+}
+
+// TestUpdateProposalWrappedStoreIterators tests the Iterator/ReverseIterator methods of the updateProposalWrappedStore.
+func (suite *TypesTestSuite) TestUpdateProposalWrappedStoreIterators() {
+	// calls suite.SetupWasmWithMockVM() and creates two clients with their respective stores
+	subjectStore, substituteStore := suite.GetSubjectAndSubstituteStore()
+
+	testCases := []struct {
+		name        string
+		start       []byte
+		end         []byte
+		prefixStart []byte
+		prefixEnd   []byte
+		expPanic    error
+	}{
+		{
+			"success: subject store Iterate",
+			[]byte("start"),
+			[]byte("end"),
+			types.SubjectPrefix,
+			types.SubjectPrefix,
+			nil,
+		},
+		{
+			"success: substitute store Iterate",
+			[]byte("start"),
+			[]byte("end"),
+			types.SubstitutePrefix,
+			types.SubstitutePrefix,
+			nil,
+		},
+		{
+			"failure: key not prefixed",
+			[]byte("start"),
+			[]byte("end"),
+			invalidPrefix,
+			invalidPrefix,
+			errors.New("key must be prefixed with either subject/ or substitute/"),
+		},
+		{
+			"failure: start and end keys not prefixed with same prefix",
+			[]byte("start"),
+			[]byte("end"),
+			types.SubjectPrefix,
+			types.SubstitutePrefix,
+			errors.New("start and end keys must be prefixed with the same prefix"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			wrappedStore := types.NewUpdateProposalWrappedStore(subjectStore, substituteStore)
+
+			prefixedKeyStart := tc.prefixStart
+			prefixedKeyStart = append(prefixedKeyStart, tc.start...)
+			prefixedKeyEnd := tc.prefixEnd
+			prefixedKeyEnd = append(prefixedKeyEnd, tc.end...)
+
+			if tc.expPanic == nil {
+				suite.Require().NotNil(wrappedStore.Iterator(prefixedKeyStart, prefixedKeyEnd))
+				suite.Require().NotNil(wrappedStore.ReverseIterator(prefixedKeyStart, prefixedKeyEnd))
+			} else {
+				suite.Require().PanicsWithError(tc.expPanic.Error(), func() { wrappedStore.Iterator(prefixedKeyStart, prefixedKeyEnd) })
+				suite.Require().PanicsWithError(tc.expPanic.Error(), func() { wrappedStore.ReverseIterator(prefixedKeyStart, prefixedKeyEnd) })
+			}
+		})
+	}
+}
 
 func (suite *TypesTestSuite) TestGetClientID() {
 	clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), defaultWasmClientID)
@@ -22,7 +327,7 @@ func (suite *TypesTestSuite) TestGetClientID() {
 		{
 			"success: clientID retrieved from updateProposalWrappedStore",
 			func() {
-				clientStore = types.NewUpdateProposalWrappedStore(clientStore, nil, nil, nil)
+				clientStore = types.NewUpdateProposalWrappedStore(clientStore, nil)
 			},
 			nil,
 		},
@@ -76,4 +381,23 @@ func (suite *TypesTestSuite) TestGetClientID() {
 			}
 		})
 	}
+}
+
+// GetSubjectAndSubstituteStore returns a subject and substitute store for testing.
+func (suite *TypesTestSuite) GetSubjectAndSubstituteStore() (storetypes.KVStore, storetypes.KVStore) {
+	suite.SetupWasmWithMockVM()
+
+	endpointA := wasmtesting.NewWasmEndpoint(suite.chainA)
+	err := endpointA.CreateClient()
+	suite.Require().NoError(err)
+
+	subjectClientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), endpointA.ClientID)
+
+	substituteEndpoint := wasmtesting.NewWasmEndpoint(suite.chainA)
+	err = substituteEndpoint.CreateClient()
+	suite.Require().NoError(err)
+
+	substituteClientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), substituteEndpoint.ClientID)
+
+	return subjectClientStore, substituteClientStore
 }

--- a/modules/light-clients/08-wasm/types/store_test.go
+++ b/modules/light-clients/08-wasm/types/store_test.go
@@ -42,6 +42,12 @@ func (suite *TypesTestSuite) TestGetStore() {
 			nil,
 			errors.New("key must be prefixed with either subject/ or substitute/"),
 		},
+		{
+			"failure: invalid prefix contains both subject/ and substitute/",
+			append(types.SubjectPrefix, types.SubstitutePrefix...),
+			nil,
+			errors.New("key must be prefixed with either subject/ or substitute/"),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -60,6 +66,8 @@ func (suite *TypesTestSuite) TestGetStore() {
 
 // TestSplitPrefix tests the splitPrefix function.
 func (suite *TypesTestSuite) TestSplitPrefix() {
+	clientStateKey := host.ClientStateKey()
+
 	testCases := []struct {
 		name      string
 		prefix    []byte
@@ -67,18 +75,23 @@ func (suite *TypesTestSuite) TestSplitPrefix() {
 	}{
 		{
 			"success: subject prefix",
-			types.SubjectPrefix,
-			[][]byte{types.SubjectPrefix, []byte("")},
+			append(types.SubjectPrefix, clientStateKey...),
+			[][]byte{types.SubjectPrefix, clientStateKey},
 		},
 		{
 			"success: substitute prefix",
-			types.SubstitutePrefix,
-			[][]byte{types.SubstitutePrefix, []byte("")},
+			append(types.SubstitutePrefix, clientStateKey...),
+			[][]byte{types.SubstitutePrefix, clientStateKey},
 		},
 		{
 			"success: prefix returned unchanged",
 			invalidPrefix,
 			[][]byte{nil, invalidPrefix},
+		},
+		{
+			"success: invalid prefix contains both subject/ and substitute/",
+			append(types.SubjectPrefix, types.SubstitutePrefix...),
+			[][]byte{types.SubjectPrefix, types.SubstitutePrefix},
 		},
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

ref for changes here https://github.com/cosmos/ibc-go/issues/4547#issuecomment-1785701346

closes: #4547

### Commit Message / Changelog Entry

```text
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
