### PR TITLE
fix: add build flag directives to ignore e2e test

### DIFF
--- a/e2e/tests/wasm/grandpa_test.go
+++ b/e2e/tests/wasm/grandpa_test.go
@@ -1,3 +1,5 @@
+//go:build !test_e2e
+
 package wasm
 
 import (
@@ -62,8 +64,6 @@ func (s *GrandpaTestSuite) TestGrandpaContract() {
 
 	ctx := context.Background()
 
-
-
 	nv := 2 // Number of validators
 	nf := 1 // Number of full nodes
 
@@ -127,13 +127,13 @@ func (s *GrandpaTestSuite) TestGrandpaContract() {
 						UidGid:     "1025:1025",
 					},
 				},
-				Bin:            "simd",
-				Bech32Prefix:   "cosmos",
-				Denom:          "stake",
-				GasPrices:      "0.00stake",
-				GasAdjustment:  1.3,
-				TrustingPeriod: "504h",
-				CoinType:       "118",
+				Bin:                 "simd",
+				Bech32Prefix:        "cosmos",
+				Denom:               "stake",
+				GasPrices:           "0.00stake",
+				GasAdjustment:       1.3,
+				TrustingPeriod:      "504h",
+				CoinType:            "118",
 				NoHostMount:         true,
 				ConfigFileOverrides: configFileOverrides,
 				ModifyGenesis:       modifyGenesisShortProposals(votingPeriod, maxDepositPeriod),
@@ -171,11 +171,11 @@ func (s *GrandpaTestSuite) TestGrandpaContract() {
 		})
 
 	s.Require().NoError(ic.Build(ctx, eRep, interchaintest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
 		//BlockDatabaseFile: interchaintest.DefaultBlockDatabaseFilepath(),
-		SkipPathCreation:  true, // Skip path creation, so we can have granular control over the process
+		SkipPathCreation: true, // Skip path creation, so we can have granular control over the process
 	}))
 	fmt.Println("Interchain built")
 
@@ -353,9 +353,9 @@ func (s *GrandpaTestSuite) pushWasmContractViaGov(t *testing.T, ctx context.Cont
 	err = cosmosChain.QueryClientContractCode(ctx, codeHash, &getCodeQueryMsgRsp)
 	codeHashByte32 := sha256.Sum256(getCodeQueryMsgRsp.Data)
 	codeHash2 := hex.EncodeToString(codeHashByte32[:])
-	s.Require().NoError( err)
-	s.Require().NotEmpty( getCodeQueryMsgRsp.Data)
-	s.Require().Equal( codeHash, codeHash2)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(getCodeQueryMsgRsp.Data)
+	s.Require().Equal(codeHash, codeHash2)
 
 	return codeHash
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fixes an issue when running `make test` would attempt to run the grandpa e2e test spinning up docker containers.



<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
