### PR TITLE
fix(msg): register proto interface

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/types/codec.go
+++ b/modules/apps/27-interchain-accounts/controller/types/codec.go
@@ -3,6 +3,7 @@ package types
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterInterfaces registers the interchain accounts controller message types using the provided InterfaceRegistry
@@ -13,4 +14,5 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		&MsgSendTx{},
 		&MsgUpdateParams{},
 	)
+	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }


### PR DESCRIPTION
## Description

Register the ICA msgs to the interface registry allowing any BaseAccount (externally owned account) to interact with the ICA module from offchain without the necessity to be through the CLI. 

Not registering module Msgs can be an issue when using the LCD to submit signed messages due the following error:
```
data: {
  code: 2,
  message: 'unable to resolve type URL /ibc.applications.interchain_accounts.controller.v1.MsgRegisterInterchainAccountResponse',
  details: []
}
```
> reproduced here https://github.com/terra-money/core/pull/196

### Commit Message / Changelog Entry

```text
fix(msg): register proto interface
```

Credits to @javiersuweijie !