### PR TITLE
Remove panic handling testing code for non-panicking methods.

### DIFF
--- a/modules/light-clients/08-wasm/types/client_state_test.go
+++ b/modules/light-clients/08-wasm/types/client_state_test.go
@@ -347,9 +347,6 @@ func (suite *TypesTestSuite) TestInitialize() {
 				suite.Require().Equal(expConsensusState, clientStore.Get(host.ConsensusStateKey(clientState.GetLatestHeight())))
 			} else {
 				suite.Require().ErrorIs(err, tc.expError)
-
-				suite.Require().False(clientStore.Has(host.ClientStateKey()))
-				suite.Require().False(clientStore.Has(host.ConsensusStateKey(clientState.GetLatestHeight())))
 			}
 		})
 	}

--- a/modules/light-clients/08-wasm/types/misbehaviour_handle_test.go
+++ b/modules/light-clients/08-wasm/types/misbehaviour_handle_test.go
@@ -80,6 +80,7 @@ func (suite *TypesTestSuite) TestVerifyClientMessage() {
 			err := endpoint.CreateClient()
 			suite.Require().NoError(err)
 
+			clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.ctx, endpoint.ClientID)
 			clientState := endpoint.GetClientState()
 
 			clientMsg = &types.ClientMessage{
@@ -88,7 +89,7 @@ func (suite *TypesTestSuite) TestVerifyClientMessage() {
 
 			tc.malleate()
 
-			err = clientState.VerifyClientMessage(suite.ctx, suite.chainA.App.AppCodec(), suite.store, clientMsg)
+			err = clientState.VerifyClientMessage(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), clientStore, clientMsg)
 
 			expPass := tc.expErr == nil
 			if expPass {

--- a/modules/light-clients/08-wasm/types/misbehaviour_handle_test.go
+++ b/modules/light-clients/08-wasm/types/misbehaviour_handle_test.go
@@ -102,13 +102,11 @@ func (suite *TypesTestSuite) TestVerifyClientMessage() {
 
 func (suite *TypesTestSuite) TestCheckForMisbehaviour() {
 	var clientMessage exported.ClientMessage
-	var foundMisbehaviour bool
 
 	testCases := []struct {
 		name                 string
 		malleate             func()
 		expFoundMisbehaviour bool
-		expPanic             error
 	}{
 		{
 			"success: no misbehaviour",
@@ -120,7 +118,6 @@ func (suite *TypesTestSuite) TestCheckForMisbehaviour() {
 				})
 			},
 			false,
-			nil,
 		},
 		{
 			"success: misbehaviour found", func() {
@@ -131,7 +128,6 @@ func (suite *TypesTestSuite) TestCheckForMisbehaviour() {
 				})
 			},
 			true,
-			nil,
 		},
 		{
 			"success: contract error, resp cannot be marshalled", func() {
@@ -141,7 +137,6 @@ func (suite *TypesTestSuite) TestCheckForMisbehaviour() {
 				})
 			},
 			false,
-			nil,
 		},
 		{
 			"success: vm returns error, ", func() {
@@ -150,7 +145,6 @@ func (suite *TypesTestSuite) TestCheckForMisbehaviour() {
 				})
 			},
 			false,
-			nil,
 		},
 		{
 			"success: invalid client message", func() {
@@ -158,16 +152,6 @@ func (suite *TypesTestSuite) TestCheckForMisbehaviour() {
 				// we will not register the callback here because this test case does not reach the VM
 			},
 			false,
-			nil,
-		},
-		{
-			"failure: contract panics, panic propogated", func() {
-				suite.mockVM.RegisterQueryCallback(types.CheckForMisbehaviourMsg{}, func(_ wasmvm.Checksum, _ wasmvmtypes.Env, _ []byte, _ wasmvm.KVStore, _ wasmvm.GoAPI, _ wasmvm.Querier, _ wasmvm.GasMeter, _ uint64, _ wasmvmtypes.UFraction) ([]byte, uint64, error) {
-					panic(errors.New("panic in query to contract"))
-				})
-			},
-			false,
-			errors.New("panic in query to contract"),
 		},
 	}
 
@@ -184,18 +168,12 @@ func (suite *TypesTestSuite) TestCheckForMisbehaviour() {
 				Data: []byte{1},
 			}
 
+			clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.ctx, endpoint.ClientID)
+
 			tc.malleate()
 
-			if tc.expPanic == nil {
-				foundMisbehaviour = clientState.CheckForMisbehaviour(suite.ctx, suite.chainA.App.AppCodec(), suite.store, clientMessage)
-				suite.Require().Equal(tc.expFoundMisbehaviour, foundMisbehaviour)
-			} else {
-				suite.PanicsWithError(
-					tc.expPanic.Error(),
-					func() {
-						clientState.CheckForMisbehaviour(suite.ctx, suite.chainA.App.AppCodec(), suite.store, clientMessage)
-					})
-			}
+			foundMisbehaviour := clientState.CheckForMisbehaviour(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), clientStore, clientMessage)
+			suite.Require().Equal(tc.expFoundMisbehaviour, foundMisbehaviour)
 		})
 	}
 }


### PR DESCRIPTION
## Description

see small discussion we had here https://github.com/cosmos/ibc-go/pull/4894/files#r1365157212

closes: #XXXX

### Commit Message / Changelog Entry

```text
chore: remove panic checks for non-panicking methods
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
