### PR TITLE
e2e: refactor grandpa test ibc transfer to use suite.transfer

### DIFF
--- a/e2e/tests/wasm/grandpa_test.go
+++ b/e2e/tests/wasm/grandpa_test.go
@@ -82,7 +82,10 @@ func (s *GrandpaTestSuite) TestMsgTransfer_Succeeds_GrandpaContract() {
 	t.Run("send successful IBC transfer from Cosmos to Polkadot parachain", func(t *testing.T) {
 		// Send 1.77 stake from cosmosUser to parachainUser
 		transferAmount := testvalues.TransferAmount(amountToSend, cosmosChain.Config().Denom)
-		transferTxResp := s.Transfer(ctx, cosmosChain, cosmosUser, channelA.PortID, channelA.ChannelID, transferAmount, cosmosUser.FormattedAddress(), polkadotUser.FormattedAddress(), s.GetTimeoutHeight(ctx, polkadotChain), 0, "")
+		// set timeout height on other side
+		timeoutHeight := s.GetTimeoutHeight(ctx, polkadotChain)
+		timeoutHeight.RevisionHeight += 100
+		transferTxResp := s.Transfer(ctx, cosmosChain, cosmosUser, channelA.PortID, channelA.ChannelID, transferAmount, cosmosUser.FormattedAddress(), polkadotUser.FormattedAddress(), timeoutHeight, 0, "")
 		s.AssertTxSuccess(transferTxResp)
 		// verify token balance for cosmos user has decreased
 		balance, err := cosmosChain.GetBalance(ctx, cosmosUser.FormattedAddress(), cosmosChain.Config().Denom)

--- a/e2e/tests/wasm/grandpa_test.go
+++ b/e2e/tests/wasm/grandpa_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cosmos/ibc-go/e2e/testvalues"
 	wasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
 	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+	"github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 )
 
 const (
@@ -83,9 +84,8 @@ func (s *GrandpaTestSuite) TestMsgTransfer_Succeeds_GrandpaContract() {
 		// Send 1.77 stake from cosmosUser to parachainUser
 		transferAmount := testvalues.TransferAmount(amountToSend, cosmosChain.Config().Denom)
 		// set timeout height on other side
-		timeoutHeight := s.GetTimeoutHeight(ctx, polkadotChain)
-		timeoutHeight.RevisionHeight += 100
-		transferTxResp := s.Transfer(ctx, cosmosChain, cosmosUser, channelA.PortID, channelA.ChannelID, transferAmount, cosmosUser.FormattedAddress(), polkadotUser.FormattedAddress(), timeoutHeight, 0, "")
+		timeoutTimestamp := time.Now().Add(time.Hour * 1)
+		transferTxResp := s.Transfer(ctx, cosmosChain, cosmosUser, channelA.PortID, channelA.ChannelID, transferAmount, cosmosUser.FormattedAddress(), polkadotUser.FormattedAddress(), types.ZeroHeight(), uint64(timeoutTimestamp.Unix()), "")
 		s.AssertTxSuccess(transferTxResp)
 		// verify token balance for cosmos user has decreased
 		balance, err := cosmosChain.GetBalance(ctx, cosmosUser.FormattedAddress(), cosmosChain.Config().Denom)

--- a/e2e/testsuite/tx.go
+++ b/e2e/testsuite/tx.go
@@ -180,7 +180,7 @@ func (s *E2ETestSuite) waitForGovV1ProposalToPass(ctx context.Context, chain ibc
 	err := test.WaitForCondition(testvalues.VotingPeriod, 10*time.Second, func() (bool, error) {
 		proposal, err := s.QueryProposalV1(ctx, chain, proposalID)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 
 		govProposal = proposal

--- a/e2e/testsuite/tx.go
+++ b/e2e/testsuite/tx.go
@@ -180,7 +180,7 @@ func (s *E2ETestSuite) waitForGovV1ProposalToPass(ctx context.Context, chain ibc
 	err := test.WaitForCondition(testvalues.VotingPeriod, 10*time.Second, func() (bool, error) {
 		proposal, err := s.QueryProposalV1(ctx, chain, proposalID)
 		if err != nil {
-			return false, nil
+			return false, err 
 		}
 
 		govProposal = proposal


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #4963 


### Commit Message / Changelog Entry

```text
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
