### PR TITLE
Use global wasm VM instead of keeping an additional reference in keeper.

### DIFF
--- a/modules/light-clients/08-wasm/keeper/genesis.go
+++ b/modules/light-clients/08-wasm/keeper/genesis.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/internal/ibcwasm"
 	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
 )
 
@@ -20,7 +21,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, gs types.GenesisState) error {
 
 // ExportGenesis returns the 08-wasm module's exported genesis. This includes the code
 // for all contracts previously stored.
-func (k Keeper) ExportGenesis(ctx sdk.Context) types.GenesisState {
+func (Keeper) ExportGenesis(ctx sdk.Context) types.GenesisState {
 	checksums, err := types.GetAllChecksums(ctx)
 	if err != nil {
 		panic(err)
@@ -29,7 +30,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) types.GenesisState {
 	// Grab code from wasmVM and add to genesis state.
 	var genesisState types.GenesisState
 	for _, checksum := range checksums {
-		code, err := k.wasmVM.GetCode(checksum)
+		code, err := ibcwasm.GetVM().GetCode(checksum)
 		if err != nil {
 			panic(err)
 		}

--- a/modules/light-clients/08-wasm/keeper/grpc_query.go
+++ b/modules/light-clients/08-wasm/keeper/grpc_query.go
@@ -20,7 +20,7 @@ import (
 var _ types.QueryServer = (*Keeper)(nil)
 
 // Code implements the Query/Code gRPC method
-func (k Keeper) Code(goCtx context.Context, req *types.QueryCodeRequest) (*types.QueryCodeResponse, error) {
+func (Keeper) Code(goCtx context.Context, req *types.QueryCodeRequest) (*types.QueryCodeResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -35,7 +35,7 @@ func (k Keeper) Code(goCtx context.Context, req *types.QueryCodeRequest) (*types
 		return nil, status.Error(codes.NotFound, errorsmod.Wrap(types.ErrWasmChecksumNotFound, req.Checksum).Error())
 	}
 
-	code, err := k.wasmVM.GetCode(checksum)
+	code, err := ibcwasm.GetVM().GetCode(checksum)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, errorsmod.Wrap(types.ErrWasmChecksumNotFound, req.Checksum).Error())
 	}

--- a/modules/light-clients/08-wasm/keeper/keeper.go
+++ b/modules/light-clients/08-wasm/keeper/keeper.go
@@ -25,8 +25,7 @@ type Keeper struct {
 	// implements gRPC QueryServer interface
 	types.QueryServer
 
-	cdc    codec.BinaryCodec
-	wasmVM ibcwasm.WasmEngine
+	cdc codec.BinaryCodec
 
 	clientKeeper types.ClientKeeper
 
@@ -64,7 +63,6 @@ func NewKeeperWithVM(
 
 	return Keeper{
 		cdc:          cdc,
-		wasmVM:       vm,
 		clientKeeper: clientKeeper,
 		authority:    authority,
 	}
@@ -93,7 +91,7 @@ func (k Keeper) GetAuthority() string {
 	return k.authority
 }
 
-func (k Keeper) storeWasmCode(ctx sdk.Context, code []byte) ([]byte, error) {
+func (Keeper) storeWasmCode(ctx sdk.Context, code []byte) ([]byte, error) {
 	var err error
 	if types.IsGzip(code) {
 		ctx.GasMeter().ConsumeGas(types.VMGasRegister.UncompressCosts(len(code)), "Uncompress gzip bytecode")
@@ -120,7 +118,7 @@ func (k Keeper) storeWasmCode(ctx sdk.Context, code []byte) ([]byte, error) {
 
 	// create the code in the vm
 	ctx.GasMeter().ConsumeGas(types.VMGasRegister.CompileCosts(len(code)), "Compiling wasm bytecode")
-	vmChecksum, err := k.wasmVM.StoreCode(code)
+	vmChecksum, err := ibcwasm.GetVM().StoreCode(code)
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "failed to store contract")
 	}
@@ -131,7 +129,7 @@ func (k Keeper) storeWasmCode(ctx sdk.Context, code []byte) ([]byte, error) {
 	}
 
 	// pin the code to the vm in-memory cache
-	if err := k.wasmVM.Pin(vmChecksum); err != nil {
+	if err := ibcwasm.GetVM().Pin(vmChecksum); err != nil {
 		return nil, errorsmod.Wrapf(err, "failed to pin contract with checksum (%s) to vm cache", hex.EncodeToString(vmChecksum))
 	}
 

--- a/modules/light-clients/08-wasm/keeper/msg_server.go
+++ b/modules/light-clients/08-wasm/keeper/msg_server.go
@@ -50,7 +50,7 @@ func (k Keeper) RemoveChecksum(goCtx context.Context, msg *types.MsgRemoveChecks
 	}
 
 	// unpin the code from the vm in-memory cache
-	if err := k.wasmVM.Unpin(msg.Checksum); err != nil {
+	if err := ibcwasm.GetVM().Unpin(msg.Checksum); err != nil {
 		return nil, errorsmod.Wrapf(err, "failed to unpin contract with checksum (%s) from vm cache", hex.EncodeToString(msg.Checksum))
 	}
 

--- a/modules/light-clients/08-wasm/keeper/snapshotter.go
+++ b/modules/light-clients/08-wasm/keeper/snapshotter.go
@@ -12,6 +12,7 @@ import (
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
+	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/internal/ibcwasm"
 	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
 )
 
@@ -72,7 +73,7 @@ func (ws *WasmSnapshotter) SnapshotExtension(height uint64, payloadWriter snapsh
 	}
 
 	for _, checksum := range checksums {
-		wasmCode, err := ws.keeper.wasmVM.GetCode(checksum)
+		wasmCode, err := ibcwasm.GetVM().GetCode(checksum)
 		if err != nil {
 			return err
 		}
@@ -111,12 +112,12 @@ func restoreV1(ctx sdk.Context, k *Keeper, compressedCode []byte) error {
 		return errorsmod.Wrap(err, "failed to uncompress wasm code")
 	}
 
-	checksum, err := k.wasmVM.StoreCode(wasmCode)
+	checksum, err := ibcwasm.GetVM().StoreCode(wasmCode)
 	if err != nil {
 		return errorsmod.Wrap(err, "failed to store wasm code")
 	}
 
-	if err := k.wasmVM.Pin(checksum); err != nil {
+	if err := ibcwasm.GetVM().Pin(checksum); err != nil {
 		return errorsmod.Wrapf(err, "failed to pin checksum: %s to in-memory cache", hex.EncodeToString(checksum))
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

this isn't strictly necessary, it just keeps all accesses to the VM from a single place.

closes: #XXXX


### Commit Message / Changelog Entry

```text
chore: use global vm in keeper methods.
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
