### PR TITLE
Add a helper function to create a mock contract.

### DIFF
--- a/modules/light-clients/08-wasm/keeper/msg_server_test.go
+++ b/modules/light-clients/08-wasm/keeper/msg_server_test.go
@@ -68,7 +68,7 @@ func (suite *KeeperTestSuite) TestMsgStoreCode() {
 		{
 			"fails with wasm code too large",
 			func() {
-				msg = types.NewMsgStoreCode(signer, append(wasmtesting.WasmMagicNumber, []byte(ibctesting.GenerateString(uint(types.MaxWasmByteSize())))...))
+				msg = types.NewMsgStoreCode(signer, wasmtesting.CreateMockContract([]byte(ibctesting.GenerateString(uint(types.MaxWasmByteSize())))))
 			},
 			types.ErrWasmCodeTooLarge,
 		},
@@ -139,8 +139,7 @@ func (suite *KeeperTestSuite) TestMsgMigrateContract() {
 	oldChecksum, err := types.CreateChecksum(wasmtesting.Code)
 	suite.Require().NoError(err)
 
-	newByteCode := wasmtesting.WasmMagicNumber
-	newByteCode = append(newByteCode, []byte("MockByteCode-TestMsgMigrateContract")...)
+	newByteCode := wasmtesting.CreateMockContract([]byte("MockByteCode-TestMsgMigrateContract"))
 
 	govAcc := authtypes.NewModuleAddress(govtypes.ModuleName).String()
 
@@ -341,8 +340,7 @@ func (suite *KeeperTestSuite) TestMsgRemoveChecksum() {
 				expChecksums = []types.Checksum{}
 
 				for i := 0; i < 20; i++ {
-					mockCode := []byte{byte(i)}
-					mockCode = append(wasmtesting.WasmMagicNumber, mockCode...)
+					mockCode := wasmtesting.CreateMockContract([]byte{byte(i)})
 					checksum, err := types.CreateChecksum(mockCode)
 					suite.Require().NoError(err)
 

--- a/modules/light-clients/08-wasm/keeper/snapshotter_test.go
+++ b/modules/light-clients/08-wasm/keeper/snapshotter_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (suite *KeeperTestSuite) TestSnapshotter() {
-	gzippedContract, err := types.GzipIt(append(wasmtesting.WasmMagicNumber, []byte("gzipped-contract")...))
+	gzippedContract, err := types.GzipIt(wasmtesting.CreateMockContract([]byte("gzipped-contract")))
 	suite.Require().NoError(err)
 
 	testCases := []struct {

--- a/modules/light-clients/08-wasm/testing/values.go
+++ b/modules/light-clients/08-wasm/testing/values.go
@@ -31,3 +31,8 @@ func CreateMockClientStateBz(cdc codec.BinaryCodec, checksum types.Checksum) []b
 	mockClientSate := types.NewClientState([]byte{1}, checksum, clienttypes.NewHeight(2000, 2))
 	return clienttypes.MustMarshalClientState(cdc, mockClientSate)
 }
+
+// CreateMockContract returns a well formed (magic number prefixed) wasm contract the given code.
+func CreateMockContract(code []byte) []byte {
+	return append(WasmMagicNumber, code...)
+}

--- a/modules/light-clients/08-wasm/types/migrate_contract_test.go
+++ b/modules/light-clients/08-wasm/types/migrate_contract_test.go
@@ -105,7 +105,7 @@ func (suite *TypesTestSuite) TestMigrateContract() {
 			var err error
 			oldHash, err = types.CreateChecksum(wasmtesting.Code)
 			suite.Require().NoError(err)
-			newHash, err = types.CreateChecksum(append(wasmtesting.WasmMagicNumber, []byte{1, 2, 3}...))
+			newHash, err = types.CreateChecksum(wasmtesting.CreateMockContract([]byte{1, 2, 3}))
 			suite.Require().NoError(err)
 
 			err = ibcwasm.Checksums.Set(suite.chainA.GetContext(), newHash)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

this seemed like a common enough pattern to warrant cleaning up.

closes: #XXXX


### Commit Message / Changelog Entry

```text
chore: add CreateMockContract in wasmtesting to create well formed wasm code.
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
