### PR TITLE
refactor: adapt testing endpoint query for channel upgrade proofs

### DIFF
--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -283,7 +283,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeTry() {
 			// ensure clients are up to date to receive valid proofs
 			suite.Require().NoError(path.EndpointB.UpdateClient())
 
-			proofCounterpartyChannel, proofCounterpartyUpgrade, proofHeight := path.EndpointB.QueryChannelUpgradeProof()
+			proofChannel, proofUpgrade, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
 
 			upgrade, err := suite.chainB.GetSimApp().IBCKeeper.ChannelKeeper.ChanUpgradeTry(
 				suite.chainB.GetContext(),
@@ -292,8 +292,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeTry() {
 				proposedUpgrade.Fields.ConnectionHops,
 				counterpartyUpgrade.Fields,
 				path.EndpointA.GetChannel().UpgradeSequence,
-				proofCounterpartyChannel,
-				proofCounterpartyUpgrade,
+				proofChannel,
+				proofUpgrade,
 				proofHeight,
 			)
 
@@ -542,7 +542,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeAck() {
 
 			tc.malleate()
 
-			proofChannel, proofUpgrade, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
+			proofChannel, proofUpgrade, proofHeight := path.EndpointB.QueryChannelUpgradeProof()
 
 			err = suite.chainA.GetSimApp().IBCKeeper.ChannelKeeper.ChanUpgradeAck(
 				suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, counterpartyUpgrade,
@@ -839,7 +839,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeConfirm() {
 
 			tc.malleate()
 
-			proofChannel, proofUpgrade, proofHeight := path.EndpointB.QueryChannelUpgradeProof()
+			proofChannel, proofUpgrade, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
 
 			err = suite.chainB.GetSimApp().IBCKeeper.ChannelKeeper.ChanUpgradeConfirm(
 				suite.chainB.GetContext(), path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, counterpartyChannelState, counterpartyUpgrade,
@@ -1075,10 +1075,12 @@ func (suite *KeeperTestSuite) TestChanUpgradeOpen() {
 
 			tc.malleate()
 
-			proofCounterpartyChannel, _, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
+			channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+			proofChannel, proofHeight := path.EndpointB.QueryProof(channelKey)
+
 			err = suite.chainA.GetSimApp().IBCKeeper.ChannelKeeper.ChanUpgradeOpen(
 				suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID,
-				path.EndpointB.GetChannel().State, proofCounterpartyChannel, proofHeight,
+				path.EndpointB.GetChannel().State, proofChannel, proofHeight,
 			)
 
 			if tc.expError == nil {
@@ -1489,9 +1491,9 @@ func (suite *KeeperTestSuite) TestWriteUpgradeCancelChannel() {
 
 func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 	var (
-		path                     *ibctesting.Path
-		proofHeight              exported.Height
-		proofCounterpartyChannel []byte
+		path         *ibctesting.Path
+		proofChannel []byte
+		proofHeight  exported.Height
 	)
 
 	timeoutUpgrade := func() {
@@ -1510,7 +1512,9 @@ func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 			"success: proof timestamp has passed",
 			func() {
 				timeoutUpgrade()
-				proofCounterpartyChannel, _, proofHeight = path.EndpointA.QueryChannelUpgradeProof()
+
+				channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+				proofChannel, proofHeight = path.EndpointB.QueryProof(channelKey)
 			},
 			nil,
 		},
@@ -1572,7 +1576,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 
 				suite.Require().NoError(path.EndpointA.UpdateClient())
 
-				proofCounterpartyChannel, _, proofHeight = path.EndpointA.QueryChannelUpgradeProof()
+				channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+				proofChannel, proofHeight = path.EndpointB.QueryProof(channelKey)
 
 				// modify state so the proof becomes invalid.
 				channel.State = types.FLUSHING
@@ -1592,7 +1597,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 
 				suite.Require().NoError(path.EndpointA.UpdateClient())
 
-				proofCounterpartyChannel, _, proofHeight = path.EndpointA.QueryChannelUpgradeProof()
+				channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+				proofChannel, proofHeight = path.EndpointB.QueryProof(channelKey)
 			},
 			types.ErrInvalidUpgradeSequence,
 		},
@@ -1605,7 +1611,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 
 				suite.Require().NoError(path.EndpointB.UpdateClient())
 
-				proofCounterpartyChannel, _, proofHeight = path.EndpointA.QueryChannelUpgradeProof()
+				channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+				proofChannel, proofHeight = path.EndpointB.QueryProof(channelKey)
 			},
 			types.ErrInvalidUpgradeTimeout,
 		},
@@ -1620,7 +1627,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 
 				suite.Require().NoError(path.EndpointA.UpdateClient())
 
-				proofCounterpartyChannel, _, proofHeight = path.EndpointA.QueryChannelUpgradeProof()
+				channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+				proofChannel, proofHeight = path.EndpointB.QueryProof(channelKey)
 			},
 			types.ErrInvalidCounterparty,
 		},
@@ -1640,7 +1648,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 				suite.Require().NoError(path.EndpointA.UpdateClient())
 				suite.Require().NoError(path.EndpointB.UpdateClient())
 
-				proofCounterpartyChannel, _, proofHeight = path.EndpointA.QueryChannelUpgradeProof()
+				channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+				proofChannel, proofHeight = path.EndpointB.QueryProof(channelKey)
 			},
 			connectiontypes.ErrConnectionNotFound,
 		},
@@ -1654,7 +1663,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 
 				suite.Require().NoError(path.EndpointA.UpdateClient())
 
-				proofCounterpartyChannel, _, proofHeight = path.EndpointA.QueryChannelUpgradeProof()
+				channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+				proofChannel, proofHeight = path.EndpointB.QueryProof(channelKey)
 			},
 			types.ErrUpgradeTimeoutFailed,
 		},
@@ -1676,7 +1686,8 @@ func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 			suite.Require().NoError(path.EndpointB.ChanUpgradeTry())
 			suite.Require().NoError(path.EndpointA.ChanUpgradeAck())
 
-			proofCounterpartyChannel, _, proofHeight = path.EndpointA.QueryChannelUpgradeProof()
+			channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+			proofChannel, proofHeight = path.EndpointB.QueryProof(channelKey)
 
 			tc.malleate()
 
@@ -1685,7 +1696,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeTimeout() {
 				path.EndpointA.ChannelConfig.PortID,
 				path.EndpointA.ChannelID,
 				path.EndpointB.GetChannel(),
-				proofCounterpartyChannel,
+				proofChannel,
 				proofHeight,
 			)
 

--- a/modules/core/keeper/msg_server_test.go
+++ b/modules/core/keeper/msg_server_test.go
@@ -1005,7 +1005,7 @@ func (suite *KeeperTestSuite) TestChannelUpgradeTry() {
 			counterpartyUpgrade, found := suite.chainA.GetSimApp().GetIBCKeeper().ChannelKeeper.GetUpgrade(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 			suite.Require().True(found)
 
-			proofChannel, proofUpgrade, proofHeight := path.EndpointB.QueryChannelUpgradeProof()
+			proofChannel, proofUpgrade, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
 
 			msg = &channeltypes.MsgChannelUpgradeTry{
 				PortId:                        path.EndpointB.ChannelConfig.PortID,
@@ -1174,7 +1174,7 @@ func (suite *KeeperTestSuite) TestChannelUpgradeAck() {
 
 			counterpartyUpgrade := path.EndpointB.GetChannelUpgrade()
 
-			proofChannel, proofUpgrade, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
+			proofChannel, proofUpgrade, proofHeight := path.EndpointB.QueryChannelUpgradeProof()
 
 			msg = &channeltypes.MsgChannelUpgradeAck{
 				PortId:              path.EndpointA.ChannelConfig.PortID,
@@ -1247,7 +1247,7 @@ func (suite *KeeperTestSuite) TestChannelUpgradeConfirm() {
 				counterpartyChannelState := path.EndpointA.GetChannel().State
 				counterpartyUpgrade := path.EndpointA.GetChannelUpgrade()
 
-				proofChannel, proofUpgrade, proofHeight := path.EndpointB.QueryChannelUpgradeProof()
+				proofChannel, proofUpgrade, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
 
 				msg = &channeltypes.MsgChannelUpgradeConfirm{
 					PortId:                   path.EndpointB.ChannelConfig.PortID,
@@ -1336,7 +1336,7 @@ func (suite *KeeperTestSuite) TestChannelUpgradeConfirm() {
 				err := path.EndpointB.UpdateClient()
 				suite.Require().NoError(err)
 
-				proofChannel, proofUpgrade, proofHeight := path.EndpointB.QueryChannelUpgradeProof()
+				proofChannel, proofUpgrade, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
 
 				msg.CounterpartyUpgrade = upgrade
 				msg.ProofChannel = proofChannel
@@ -1383,7 +1383,7 @@ func (suite *KeeperTestSuite) TestChannelUpgradeConfirm() {
 			counterpartyChannelState := path.EndpointA.GetChannel().State
 			counterpartyUpgrade := path.EndpointA.GetChannelUpgrade()
 
-			proofChannel, proofUpgrade, proofHeight := path.EndpointB.QueryChannelUpgradeProof()
+			proofChannel, proofUpgrade, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
 
 			msg = &channeltypes.MsgChannelUpgradeConfirm{
 				PortId:                   path.EndpointB.ChannelConfig.PortID,
@@ -1484,7 +1484,8 @@ func (suite *KeeperTestSuite) TestChannelUpgradeOpen() {
 			suite.Require().NoError(err)
 
 			counterpartyChannel := path.EndpointB.GetChannel()
-			proofChannel, _, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
+			channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+			proofChannel, proofHeight := path.EndpointB.QueryProof(channelKey)
 
 			msg = &channeltypes.MsgChannelUpgradeOpen{
 				PortId:                   path.EndpointA.ChannelConfig.PortID,
@@ -1646,7 +1647,9 @@ func (suite *KeeperTestSuite) TestChannelUpgradeTimeout() {
 
 				suite.Require().NoError(path.EndpointA.UpdateClient())
 
-				channelProof, _, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
+				channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+				channelProof, proofHeight := path.EndpointB.QueryProof(channelKey)
+
 				msg.ProofChannel = channelProof
 				msg.ProofHeight = proofHeight
 			},
@@ -1687,7 +1690,8 @@ func (suite *KeeperTestSuite) TestChannelUpgradeTimeout() {
 
 				suite.Require().NoError(path.EndpointA.UpdateClient())
 
-				_, _, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
+				_, _, proofHeight := path.EndpointB.QueryChannelUpgradeProof()
+
 				msg.ProofHeight = proofHeight
 				msg.ProofChannel = []byte("invalid proof")
 			},
@@ -1720,7 +1724,8 @@ func (suite *KeeperTestSuite) TestChannelUpgradeTimeout() {
 			suite.Require().NoError(path.EndpointB.ChanUpgradeTry())
 			suite.Require().NoError(path.EndpointA.ChanUpgradeAck())
 
-			channelProof, _, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
+			channelKey := host.ChannelKey(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+			channelProof, proofHeight := path.EndpointB.QueryProof(channelKey)
 
 			msg = &channeltypes.MsgChannelUpgradeTimeout{
 				PortId:              path.EndpointA.ChannelConfig.PortID,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Updates testing `Endpoint` to query `chainA` when using: `path.EndpointA.QueryChannelUpgradeProof()`.
Previously, this would query the counterparty endpoint.

closes: #5147 

<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
