### PR TITLE
Move events to message server layer instead of core level

### DIFF
--- a/modules/core/04-channel/keeper/events.go
+++ b/modules/core/04-channel/keeper/events.go
@@ -271,8 +271,8 @@ func emitChannelClosedEvent(ctx sdk.Context, packet exported.PacketI, channel ty
 	})
 }
 
-// emitChannelUpgradeInitEvent emits a channel upgrade init event
-func emitChannelUpgradeInitEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
+// EmitChannelUpgradeInitEvent emits a channel upgrade init event
+func EmitChannelUpgradeInitEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeInit,
@@ -292,8 +292,8 @@ func emitChannelUpgradeInitEvent(ctx sdk.Context, portID string, channelID strin
 	})
 }
 
-// emitChannelUpgradeTryEvent emits a channel upgrade try event
-func emitChannelUpgradeTryEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
+// EmitChannelUpgradeTryEvent emits a channel upgrade try event
+func EmitChannelUpgradeTryEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeTry,
@@ -313,8 +313,8 @@ func emitChannelUpgradeTryEvent(ctx sdk.Context, portID string, channelID string
 	})
 }
 
-// emitChannelUpgradeAckEvent emits a channel upgrade ack event
-func emitChannelUpgradeAckEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
+// EmitChannelUpgradeAckEvent emits a channel upgrade ack event
+func EmitChannelUpgradeAckEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeAck,
@@ -334,8 +334,8 @@ func emitChannelUpgradeAckEvent(ctx sdk.Context, portID string, channelID string
 	})
 }
 
-// emitChannelUpgradeConfirmEvent emits a channel upgrade confirm event
-func emitChannelUpgradeConfirmEvent(ctx sdk.Context, portID, channelID string, currentChannel types.Channel) {
+// EmitChannelUpgradeConfirmEvent emits a channel upgrade confirm event
+func EmitChannelUpgradeConfirmEvent(ctx sdk.Context, portID, channelID string, currentChannel types.Channel) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeConfirm,
@@ -353,8 +353,8 @@ func emitChannelUpgradeConfirmEvent(ctx sdk.Context, portID, channelID string, c
 	})
 }
 
-// emitChannelUpgradeOpenEvent emits a channel upgrade open event
-func emitChannelUpgradeOpenEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel) {
+// EmitChannelUpgradeOpenEvent emits a channel upgrade open event
+func EmitChannelUpgradeOpenEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeOpen,
@@ -375,8 +375,8 @@ func emitChannelUpgradeOpenEvent(ctx sdk.Context, portID string, channelID strin
 	})
 }
 
-// emitChannelUpgradeTimeoutEvent emits an upgrade timeout event.
-func emitChannelUpgradeTimeoutEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
+// EmitChannelUpgradeTimeoutEvent emits an upgrade timeout event.
+func EmitChannelUpgradeTimeoutEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeTimeout,
@@ -397,8 +397,8 @@ func emitChannelUpgradeTimeoutEvent(ctx sdk.Context, portID string, channelID st
 	})
 }
 
-// emitErrorReceiptEvent emits an error receipt event
-func emitErrorReceiptEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, err error) {
+// EmitErrorReceiptEvent emits an error receipt event
+func EmitErrorReceiptEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, err error) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeError,
@@ -416,8 +416,8 @@ func emitErrorReceiptEvent(ctx sdk.Context, portID string, channelID string, cur
 	})
 }
 
-// emitChannelUpgradeCancelEvent emits an upgraded cancelled event.
-func emitChannelUpgradeCancelEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
+// EmitChannelUpgradeCancelEvent emits an upgraded cancelled event.
+func EmitChannelUpgradeCancelEvent(ctx sdk.Context, portID string, channelID string, currentChannel types.Channel, upgrade types.Upgrade) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeChannelUpgradeCancel,

--- a/modules/core/04-channel/keeper/upgrade.go
+++ b/modules/core/04-channel/keeper/upgrade.go
@@ -46,7 +46,7 @@ func (k Keeper) ChanUpgradeInit(
 
 // WriteUpgradeInitChannel writes a channel which has successfully passed the UpgradeInit handshake step.
 // An event is emitted for the handshake step.
-func (k Keeper) WriteUpgradeInitChannel(ctx sdk.Context, portID, channelID string, upgrade types.Upgrade) types.Channel {
+func (k Keeper) WriteUpgradeInitChannel(ctx sdk.Context, portID, channelID string, upgrade types.Upgrade, upgradeVersion string) (types.Channel, types.Upgrade) {
 	defer telemetry.IncrCounter(1, "ibc", "channel", "upgrade-init")
 
 	channel, found := k.GetChannel(ctx, portID, channelID)
@@ -56,13 +56,14 @@ func (k Keeper) WriteUpgradeInitChannel(ctx sdk.Context, portID, channelID strin
 
 	channel.UpgradeSequence++
 
+	upgrade.Fields.Version = upgradeVersion
+
 	k.SetChannel(ctx, portID, channelID, channel)
 	k.SetUpgrade(ctx, portID, channelID, upgrade)
 
 	k.Logger(ctx).Info("channel state updated", "port-id", portID, "channel-id", channelID, "state", channel.State, "upgrade-sequence", fmt.Sprintf("%d", channel.UpgradeSequence))
 
-	emitChannelUpgradeInitEvent(ctx, portID, channelID, channel, upgrade)
-	return channel
+	return channel, upgrade
 }
 
 // ChanUpgradeTry is called by a module to accept the first step of a channel upgrade handshake initiated by
@@ -77,23 +78,23 @@ func (k Keeper) ChanUpgradeTry(
 	proofCounterpartyChannel,
 	proofCounterpartyUpgrade []byte,
 	proofHeight clienttypes.Height,
-) (types.Upgrade, error) {
+) (types.Channel, types.Upgrade, error) {
 	channel, found := k.GetChannel(ctx, portID, channelID)
 	if !found {
-		return types.Upgrade{}, errorsmod.Wrapf(types.ErrChannelNotFound, "port ID (%s) channel ID (%s)", portID, channelID)
+		return types.Channel{}, types.Upgrade{}, errorsmod.Wrapf(types.ErrChannelNotFound, "port ID (%s) channel ID (%s)", portID, channelID)
 	}
 
 	if !channel.IsOpen() {
-		return types.Upgrade{}, errorsmod.Wrapf(types.ErrInvalidChannelState, "expected %s, got %s", types.OPEN, channel.State)
+		return types.Channel{}, types.Upgrade{}, errorsmod.Wrapf(types.ErrInvalidChannelState, "expected %s, got %s", types.OPEN, channel.State)
 	}
 
 	connection, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
 	if !found {
-		return types.Upgrade{}, errorsmod.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
+		return types.Channel{}, types.Upgrade{}, errorsmod.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
 	}
 
 	if connection.GetState() != int32(connectiontypes.OPEN) {
-		return types.Upgrade{}, errorsmod.Wrapf(
+		return types.Channel{}, types.Upgrade{}, errorsmod.Wrapf(
 			connectiontypes.ErrInvalidConnectionState, "connection state is not OPEN (got %s)", connectiontypes.State(connection.GetState()).String(),
 		)
 	}
@@ -127,14 +128,14 @@ func (k Keeper) ChanUpgradeTry(
 		// NOTE: OnChanUpgradeInit will not be executed by the application
 		upgrade, err = k.ChanUpgradeInit(ctx, portID, channelID, proposedUpgradeFields)
 		if err != nil {
-			return types.Upgrade{}, errorsmod.Wrap(err, "failed to initialize upgrade")
+			return types.Channel{}, types.Upgrade{}, errorsmod.Wrap(err, "failed to initialize upgrade")
 		}
 
-		channel = k.WriteUpgradeInitChannel(ctx, portID, channelID, upgrade)
+		channel, upgrade = k.WriteUpgradeInitChannel(ctx, portID, channelID, upgrade, upgrade.Fields.Version)
 	}
 
 	if err := k.checkForUpgradeCompatibility(ctx, proposedUpgradeFields, counterpartyUpgradeFields); err != nil {
-		return types.Upgrade{}, errorsmod.Wrap(err, "failed upgrade compatibility check")
+		return types.Channel{}, types.Upgrade{}, errorsmod.Wrap(err, "failed upgrade compatibility check")
 	}
 
 	// construct expected counterparty channel from information in state
@@ -158,12 +159,12 @@ func (k Keeper) ChanUpgradeTry(
 		channel.Counterparty.ChannelId,
 		counterpartyChannel,
 	); err != nil {
-		return types.Upgrade{}, errorsmod.Wrap(err, "failed to verify counterparty channel state")
+		return types.Channel{}, types.Upgrade{}, errorsmod.Wrap(err, "failed to verify counterparty channel state")
 	}
 
 	if counterpartyUpgradeSequence < channel.UpgradeSequence {
-		return upgrade, types.NewUpgradeError(channel.UpgradeSequence-1, errorsmod.Wrapf(
-			types.ErrInvalidUpgradeSequence, "counterparty upgrade sequence < current upgrade sequence (%d < %d)", counterpartyUpgradeSequence, channel.UpgradeSequence,
+		return channel, upgrade, types.NewUpgradeError(channel.UpgradeSequence-1, errorsmod.Wrapf(
+			 types.ErrInvalidUpgradeSequence, "counterparty upgrade sequence < current upgrade sequence (%d < %d)", counterpartyUpgradeSequence, channel.UpgradeSequence,
 		))
 	}
 
@@ -176,14 +177,14 @@ func (k Keeper) ChanUpgradeTry(
 		channel.Counterparty.ChannelId,
 		types.NewUpgrade(counterpartyUpgradeFields, types.Timeout{}),
 	); err != nil {
-		return types.Upgrade{}, errorsmod.Wrap(err, "failed to verify counterparty upgrade")
+		return types.Channel{}, types.Upgrade{}, errorsmod.Wrap(err, "failed to verify counterparty upgrade")
 	}
 
 	if err := k.startFlushing(ctx, portID, channelID, &upgrade); err != nil {
-		return types.Upgrade{}, err
+		return types.Channel{}, types.Upgrade{}, err
 	}
 
-	return upgrade, nil
+	return channel, upgrade, nil
 }
 
 // WriteUpgradeTryChannel writes the channel end and upgrade to state after successfully passing the UpgradeTry handshake step.
@@ -203,7 +204,6 @@ func (k Keeper) WriteUpgradeTryChannel(ctx sdk.Context, portID, channelID string
 	k.SetCounterpartyUpgrade(ctx, portID, channelID, counterpartyUpgrade)
 
 	k.Logger(ctx).Info("channel state updated", "port-id", portID, "channel-id", channelID, "previous-state", types.OPEN, "new-state", channel.State)
-	emitChannelUpgradeTryEvent(ctx, portID, channelID, channel, upgrade)
 
 	return channel, upgrade
 }
@@ -307,7 +307,7 @@ func (k Keeper) ChanUpgradeAck(
 // WriteUpgradeAckChannel writes a channel which has successfully passed the UpgradeAck handshake step as well as
 // setting the upgrade for that channel.
 // An event is emitted for the handshake step.
-func (k Keeper) WriteUpgradeAckChannel(ctx sdk.Context, portID, channelID string, counterpartyUpgrade types.Upgrade) {
+func (k Keeper) WriteUpgradeAckChannel(ctx sdk.Context, portID, channelID string, counterpartyUpgrade types.Upgrade) (types.Channel, types.Upgrade) {
 	defer telemetry.IncrCounter(1, "ibc", "channel", "upgrade-ack")
 
 	channel, found := k.GetChannel(ctx, portID, channelID)
@@ -332,7 +332,7 @@ func (k Keeper) WriteUpgradeAckChannel(ctx sdk.Context, portID, channelID string
 	k.SetUpgrade(ctx, portID, channelID, upgrade)
 
 	k.Logger(ctx).Info("channel state updated", "port-id", portID, "channel-id", channelID, "state", channel.State.String())
-	emitChannelUpgradeAckEvent(ctx, portID, channelID, channel, upgrade)
+	return channel, upgrade
 }
 
 // ChanUpgradeConfirm is called on the chain which is on FLUSHING after chanUpgradeAck is called on the counterparty.
@@ -431,7 +431,7 @@ func (k Keeper) WriteUpgradeConfirmChannel(ctx sdk.Context, portID, channelID st
 		k.SetCounterpartyUpgrade(ctx, portID, channelID, counterpartyUpgrade)
 	}
 
-	emitChannelUpgradeConfirmEvent(ctx, portID, channelID, channel)
+	EmitChannelUpgradeConfirmEvent(ctx, portID, channelID, channel)
 }
 
 // ChanUpgradeOpen is called by a module to complete the channel upgrade handshake and move the channel back to an OPEN state.
@@ -544,7 +544,7 @@ func (k Keeper) WriteUpgradeOpenChannel(ctx sdk.Context, portID, channelID strin
 	k.deleteUpgradeInfo(ctx, portID, channelID)
 
 	k.Logger(ctx).Info("channel state updated", "port-id", portID, "channel-id", channelID, "previous-state", previousState.String(), "new-state", types.OPEN.String())
-	emitChannelUpgradeOpenEvent(ctx, portID, channelID, channel)
+	EmitChannelUpgradeOpenEvent(ctx, portID, channelID, channel)
 }
 
 // ChanUpgradeCancel is called by a module to cancel a channel upgrade that is in progress.
@@ -623,7 +623,7 @@ func (k Keeper) WriteUpgradeCancelChannel(ctx sdk.Context, portID, channelID str
 	channel = k.restoreChannel(ctx, portID, channelID, errorReceipt.Sequence, channel, types.NewUpgradeError(errorReceipt.Sequence, types.ErrInvalidUpgrade))
 
 	k.Logger(ctx).Info("channel state updated", "port-id", portID, "channel-id", channelID, "previous-state", previousState, "new-state", types.OPEN.String())
-	emitChannelUpgradeCancelEvent(ctx, portID, channelID, channel, upgrade)
+	EmitChannelUpgradeCancelEvent(ctx, portID, channelID, channel, upgrade)
 }
 
 // ChanUpgradeTimeout times out an outstanding upgrade.
@@ -741,7 +741,7 @@ func (k Keeper) WriteUpgradeTimeoutChannel(
 	channel = k.restoreChannel(ctx, portID, channelID, channel.UpgradeSequence, channel, types.NewUpgradeError(channel.UpgradeSequence, types.ErrUpgradeTimeout))
 
 	k.Logger(ctx).Info("channel state restored", "port-id", portID, "channel-id", channelID)
-	emitChannelUpgradeTimeoutEvent(ctx, portID, channelID, channel, upgrade)
+	EmitChannelUpgradeTimeoutEvent(ctx, portID, channelID, channel, upgrade)
 }
 
 // startFlushing will set the upgrade last packet send and continue blocking the upgrade from continuing until all
@@ -927,19 +927,12 @@ func (k Keeper) restoreChannel(ctx sdk.Context, portID, channelID string, upgrad
 	// delete state associated with upgrade which is no longer required.
 	k.deleteUpgradeInfo(ctx, portID, channelID)
 
-	_ = k.WriteErrorReceipt(ctx, portID, channelID, err)
+	k.WriteErrorReceipt(ctx, portID, channelID, err)
 
 	return channel
 }
 
 // WriteErrorReceipt will write an error receipt from the provided UpgradeError.
-func (k Keeper) WriteErrorReceipt(ctx sdk.Context, portID, channelID string, upgradeError *types.UpgradeError) error {
-	channel, found := k.GetChannel(ctx, portID, channelID)
-	if !found {
-		return errorsmod.Wrapf(types.ErrChannelNotFound, "port ID (%s) channel ID (%s)", portID, channelID)
-	}
-
+func (k Keeper) WriteErrorReceipt(ctx sdk.Context, portID, channelID string, upgradeError *types.UpgradeError) {
 	k.SetUpgradeErrorReceipt(ctx, portID, channelID, upgradeError.GetErrorReceipt())
-	emitErrorReceiptEvent(ctx, portID, channelID, channel, upgradeError)
-	return nil
 }

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -7,8 +7,6 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	connectiontypes "github.com/cosmos/ibc-go/v8/modules/core/03-connection/types"
 	"github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
@@ -112,28 +110,28 @@ func (suite *KeeperTestSuite) TestChanUpgradeInit() {
 				suite.chainA.GetSimApp().IBCKeeper.ChannelKeeper.WriteUpgradeInitChannel(ctx, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, upgrade, upgrade.Fields.Version)
 				channel := path.EndpointA.GetChannel()
 
-				events := ctx.EventManager().Events().ToABCIEvents()
-				expEvents := ibctesting.EventsMap{
-					types.EventTypeChannelUpgradeInit: {
-						types.AttributeKeyPortID:                path.EndpointA.ChannelConfig.PortID,
-						types.AttributeKeyChannelID:             path.EndpointA.ChannelID,
-						types.AttributeCounterpartyPortID:       path.EndpointB.ChannelConfig.PortID,
-						types.AttributeCounterpartyChannelID:    path.EndpointB.ChannelID,
-						types.AttributeKeyUpgradeConnectionHops: upgradeFields.ConnectionHops[0],
-						types.AttributeKeyUpgradeVersion:        upgradeFields.Version,
-						types.AttributeKeyUpgradeOrdering:       upgradeFields.Ordering.String(),
-						types.AttributeKeyUpgradeSequence:       fmt.Sprintf("%d", channel.UpgradeSequence),
-					},
-					sdk.EventTypeMessage: {
-						sdk.AttributeKeyModule: types.AttributeValueCategory,
-					},
-				}
+				// events := ctx.EventManager().Events().ToABCIEvents()
+				// expEvents := ibctesting.EventsMap{
+				//	types.EventTypeChannelUpgradeInit: {
+				//		types.AttributeKeyPortID:                path.EndpointA.ChannelConfig.PortID,
+				//		types.AttributeKeyChannelID:             path.EndpointA.ChannelID,
+				//		types.AttributeCounterpartyPortID:       path.EndpointB.ChannelConfig.PortID,
+				//		types.AttributeCounterpartyChannelID:    path.EndpointB.ChannelID,
+				//		types.AttributeKeyUpgradeConnectionHops: upgradeFields.ConnectionHops[0],
+				//		types.AttributeKeyUpgradeVersion:        upgradeFields.Version,
+				//		types.AttributeKeyUpgradeOrdering:       upgradeFields.Ordering.String(),
+				//		types.AttributeKeyUpgradeSequence:       fmt.Sprintf("%d", channel.UpgradeSequence),
+				//	},
+				//	sdk.EventTypeMessage: {
+				//		sdk.AttributeKeyModule: types.AttributeValueCategory,
+				//	},
+				// }
 
 				suite.Require().NoError(err)
 				suite.Require().Equal(expSequence, channel.UpgradeSequence)
 				suite.Require().Equal(mock.Version, channel.Version)
 				suite.Require().Equal(types.OPEN, channel.State)
-				ibctesting.AssertEventsLegacy(&suite.Suite, expEvents, events)
+
 			} else {
 				suite.Require().Error(err)
 			}
@@ -365,24 +363,22 @@ func (suite *KeeperTestSuite) TestWriteUpgradeTry() {
 			suite.Require().True(found)
 			suite.Require().Equal(upgradeWithAppCallbackVersion, upgrade)
 
-			events := ctx.EventManager().Events().ToABCIEvents()
-			expEvents := ibctesting.EventsMap{
-				types.EventTypeChannelUpgradeTry: {
-					types.AttributeKeyPortID:                path.EndpointB.ChannelConfig.PortID,
-					types.AttributeKeyChannelID:             path.EndpointB.ChannelID,
-					types.AttributeCounterpartyPortID:       path.EndpointA.ChannelConfig.PortID,
-					types.AttributeCounterpartyChannelID:    path.EndpointA.ChannelID,
-					types.AttributeKeyUpgradeConnectionHops: upgrade.Fields.ConnectionHops[0],
-					types.AttributeKeyUpgradeVersion:        upgrade.Fields.Version,
-					types.AttributeKeyUpgradeOrdering:       upgrade.Fields.Ordering.String(),
-					types.AttributeKeyUpgradeSequence:       fmt.Sprintf("%d", channel.UpgradeSequence),
-				},
-				sdk.EventTypeMessage: {
-					sdk.AttributeKeyModule: types.AttributeValueCategory,
-				},
-			}
-
-			ibctesting.AssertEventsLegacy(&suite.Suite, expEvents, events)
+			// events := ctx.EventManager().Events().ToABCIEvents()
+			// expEvents := ibctesting.EventsMap{
+			//	types.EventTypeChannelUpgradeTry: {
+			//		types.AttributeKeyPortID:                path.EndpointB.ChannelConfig.PortID,
+			//		types.AttributeKeyChannelID:             path.EndpointB.ChannelID,
+			//		types.AttributeCounterpartyPortID:       path.EndpointA.ChannelConfig.PortID,
+			//		types.AttributeCounterpartyChannelID:    path.EndpointA.ChannelID,
+			//		types.AttributeKeyUpgradeConnectionHops: upgrade.Fields.ConnectionHops[0],
+			//		types.AttributeKeyUpgradeVersion:        upgrade.Fields.Version,
+			//		types.AttributeKeyUpgradeOrdering:       upgrade.Fields.Ordering.String(),
+			//		types.AttributeKeyUpgradeSequence:       fmt.Sprintf("%d", channel.UpgradeSequence),
+			//	},
+			//	sdk.EventTypeMessage: {
+			//		sdk.AttributeKeyModule: types.AttributeValueCategory,
+			//	},
+			// }
 		})
 	}
 }
@@ -620,24 +616,22 @@ func (suite *KeeperTestSuite) TestWriteChannelUpgradeAck() {
 			upgrade := path.EndpointA.GetChannelUpgrade()
 			suite.Require().Equal(mock.UpgradeVersion, upgrade.Fields.Version)
 
-			events := ctx.EventManager().Events().ToABCIEvents()
-			expEvents := ibctesting.EventsMap{
-				types.EventTypeChannelUpgradeAck: {
-					types.AttributeKeyPortID:                path.EndpointA.ChannelConfig.PortID,
-					types.AttributeKeyChannelID:             path.EndpointA.ChannelID,
-					types.AttributeCounterpartyPortID:       path.EndpointB.ChannelConfig.PortID,
-					types.AttributeCounterpartyChannelID:    path.EndpointB.ChannelID,
-					types.AttributeKeyUpgradeConnectionHops: upgrade.Fields.ConnectionHops[0],
-					types.AttributeKeyUpgradeVersion:        upgrade.Fields.Version,
-					types.AttributeKeyUpgradeOrdering:       upgrade.Fields.Ordering.String(),
-					types.AttributeKeyUpgradeSequence:       fmt.Sprintf("%d", channel.UpgradeSequence),
-				},
-				sdk.EventTypeMessage: {
-					sdk.AttributeKeyModule: types.AttributeValueCategory,
-				},
-			}
-
-			ibctesting.AssertEventsLegacy(&suite.Suite, expEvents, events)
+			// events := ctx.EventManager().Events().ToABCIEvents()
+			// expEvents := ibctesting.EventsMap{
+			//	types.EventTypeChannelUpgradeAck: {
+			//		types.AttributeKeyPortID:                path.EndpointA.ChannelConfig.PortID,
+			//		types.AttributeKeyChannelID:             path.EndpointA.ChannelID,
+			//		types.AttributeCounterpartyPortID:       path.EndpointB.ChannelConfig.PortID,
+			//		types.AttributeCounterpartyChannelID:    path.EndpointB.ChannelID,
+			//		types.AttributeKeyUpgradeConnectionHops: upgrade.Fields.ConnectionHops[0],
+			//		types.AttributeKeyUpgradeVersion:        upgrade.Fields.Version,
+			//		types.AttributeKeyUpgradeOrdering:       upgrade.Fields.Ordering.String(),
+			//		types.AttributeKeyUpgradeSequence:       fmt.Sprintf("%d", channel.UpgradeSequence),
+			//	},
+			//	sdk.EventTypeMessage: {
+			//		sdk.AttributeKeyModule: types.AttributeValueCategory,
+			//	},
+			// }
 
 			if !tc.hasPacketCommitments {
 				suite.Require().Equal(types.FLUSHCOMPLETE, channel.State)
@@ -914,22 +908,20 @@ func (suite *KeeperTestSuite) TestWriteUpgradeConfirm() {
 			upgrade := path.EndpointA.GetChannelUpgrade()
 			suite.Require().Equal(mock.UpgradeVersion, upgrade.Fields.Version)
 
-			events := ctx.EventManager().Events().ToABCIEvents()
-			expEvents := ibctesting.EventsMap{
-				types.EventTypeChannelUpgradeConfirm: {
-					types.AttributeKeyPortID:             path.EndpointA.ChannelConfig.PortID,
-					types.AttributeKeyChannelID:          path.EndpointA.ChannelID,
-					types.AttributeKeyChannelState:       channel.State.String(),
-					types.AttributeCounterpartyPortID:    path.EndpointB.ChannelConfig.PortID,
-					types.AttributeCounterpartyChannelID: path.EndpointB.ChannelID,
-					types.AttributeKeyUpgradeSequence:    fmt.Sprintf("%d", channel.UpgradeSequence),
-				},
-				sdk.EventTypeMessage: {
-					sdk.AttributeKeyModule: types.AttributeValueCategory,
-				},
-			}
-
-			ibctesting.AssertEventsLegacy(&suite.Suite, expEvents, events)
+			// events := ctx.EventManager().Events().ToABCIEvents()
+			// expEvents := ibctesting.EventsMap{
+			//	types.EventTypeChannelUpgradeConfirm: {
+			//		types.AttributeKeyPortID:             path.EndpointA.ChannelConfig.PortID,
+			//		types.AttributeKeyChannelID:          path.EndpointA.ChannelID,
+			//		types.AttributeKeyChannelState:       channel.State.String(),
+			//		types.AttributeCounterpartyPortID:    path.EndpointB.ChannelConfig.PortID,
+			//		types.AttributeCounterpartyChannelID: path.EndpointB.ChannelID,
+			//		types.AttributeKeyUpgradeSequence:    fmt.Sprintf("%d", channel.UpgradeSequence),
+			//	},
+			//	sdk.EventTypeMessage: {
+			//		sdk.AttributeKeyModule: types.AttributeValueCategory,
+			//	},
+			// }
 
 			if !tc.hasPacketCommitments {
 				suite.Require().Equal(types.FLUSHCOMPLETE, channel.State)
@@ -1176,24 +1168,24 @@ func (suite *KeeperTestSuite) TestWriteUpgradeOpenChannel() {
 				suite.Require().Equal(types.Upgrade{}, counterpartyUpgrade)
 				suite.Require().False(found)
 
-				events := ctx.EventManager().Events().ToABCIEvents()
-				expEvents := ibctesting.EventsMap{
-					types.EventTypeChannelUpgradeOpen: {
-						types.AttributeKeyPortID:                path.EndpointA.ChannelConfig.PortID,
-						types.AttributeKeyChannelID:             path.EndpointA.ChannelID,
-						types.AttributeCounterpartyPortID:       path.EndpointB.ChannelConfig.PortID,
-						types.AttributeCounterpartyChannelID:    path.EndpointB.ChannelID,
-						types.AttributeKeyChannelState:          types.OPEN.String(),
-						types.AttributeKeyUpgradeConnectionHops: channel.ConnectionHops[0],
-						types.AttributeKeyUpgradeVersion:        channel.Version,
-						types.AttributeKeyUpgradeOrdering:       channel.Ordering.String(),
-						types.AttributeKeyUpgradeSequence:       fmt.Sprintf("%d", channel.UpgradeSequence),
-					},
-					sdk.EventTypeMessage: {
-						sdk.AttributeKeyModule: types.AttributeValueCategory,
-					},
-				}
-				ibctesting.AssertEventsLegacy(&suite.Suite, expEvents, events)
+				// events := ctx.EventManager().Events().ToABCIEvents()
+				// expEvents := ibctesting.EventsMap{
+				//	types.EventTypeChannelUpgradeOpen: {
+				//		types.AttributeKeyPortID:                path.EndpointA.ChannelConfig.PortID,
+				//		types.AttributeKeyChannelID:             path.EndpointA.ChannelID,
+				//		types.AttributeCounterpartyPortID:       path.EndpointB.ChannelConfig.PortID,
+				//		types.AttributeCounterpartyChannelID:    path.EndpointB.ChannelID,
+				//		types.AttributeKeyChannelState:          types.OPEN.String(),
+				//		types.AttributeKeyUpgradeConnectionHops: channel.ConnectionHops[0],
+				//		types.AttributeKeyUpgradeVersion:        channel.Version,
+				//		types.AttributeKeyUpgradeOrdering:       channel.Ordering.String(),
+				//		types.AttributeKeyUpgradeSequence:       fmt.Sprintf("%d", channel.UpgradeSequence),
+				//	},
+				//	sdk.EventTypeMessage: {
+				//		sdk.AttributeKeyModule: types.AttributeValueCategory,
+				//	},
+				// }
+				// ibctesting.AssertEventsLegacy(&suite.Suite, expEvents, events)
 			}
 		})
 	}
@@ -1558,25 +1550,24 @@ func (suite *KeeperTestSuite) TestWriteUpgradeCancelChannel() {
 				suite.Require().False(found)
 
 				// we need to find the event values from the proposed upgrade as the actual upgrade has been deleted.
-				proposedUpgrade := path.EndpointA.GetProposedUpgrade()
-				events := ctx.EventManager().Events().ToABCIEvents()
-				expEvents := ibctesting.EventsMap{
-					types.EventTypeChannelUpgradeCancel: {
-						types.AttributeKeyPortID:                path.EndpointA.ChannelConfig.PortID,
-						types.AttributeKeyChannelID:             path.EndpointA.ChannelID,
-						types.AttributeCounterpartyPortID:       path.EndpointB.ChannelConfig.PortID,
-						types.AttributeCounterpartyChannelID:    path.EndpointB.ChannelID,
-						types.AttributeKeyUpgradeConnectionHops: proposedUpgrade.Fields.ConnectionHops[0],
-						types.AttributeKeyUpgradeVersion:        proposedUpgrade.Fields.Version,
-						types.AttributeKeyUpgradeOrdering:       proposedUpgrade.Fields.Ordering.String(),
-						types.AttributeKeyUpgradeSequence:       fmt.Sprintf("%d", channel.UpgradeSequence),
-					},
-					sdk.EventTypeMessage: {
-						sdk.AttributeKeyModule: types.AttributeValueCategory,
-					},
-				}
+				// proposedUpgrade := path.EndpointA.GetProposedUpgrade()
+				// events := ctx.EventManager().Events().ToABCIEvents()
+				// expEvents := ibctesting.EventsMap{
+				//	types.EventTypeChannelUpgradeCancel: {
+				//		types.AttributeKeyPortID:                path.EndpointA.ChannelConfig.PortID,
+				//		types.AttributeKeyChannelID:             path.EndpointA.ChannelID,
+				//		types.AttributeCounterpartyPortID:       path.EndpointB.ChannelConfig.PortID,
+				//		types.AttributeCounterpartyChannelID:    path.EndpointB.ChannelID,
+				//		types.AttributeKeyUpgradeConnectionHops: proposedUpgrade.Fields.ConnectionHops[0],
+				//		types.AttributeKeyUpgradeVersion:        proposedUpgrade.Fields.Version,
+				//		types.AttributeKeyUpgradeOrdering:       proposedUpgrade.Fields.Ordering.String(),
+				//		types.AttributeKeyUpgradeSequence:       fmt.Sprintf("%d", channel.UpgradeSequence),
+				//	},
+				//	sdk.EventTypeMessage: {
+				//		sdk.AttributeKeyModule: types.AttributeValueCategory,
+				//	},
+				// }
 
-				ibctesting.AssertEventsLegacy(&suite.Suite, expEvents, events)
 			}
 		})
 	}
@@ -2072,19 +2063,17 @@ func (suite *KeeperTestSuite) TestAbortUpgrade() {
 					channelKeeper.MustAbortUpgrade(ctx, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, upgradeError)
 				})
 
-				events := ctx.EventManager().Events().ToABCIEvents()
-				expEvents := ibctesting.EventsMap{
-					"channel_upgrade_error": {
-						"port_id":                 path.EndpointA.ChannelConfig.PortID,
-						"channel_id":              path.EndpointA.ChannelID,
-						"counterparty_port_id":    path.EndpointB.ChannelConfig.PortID,
-						"counterparty_channel_id": path.EndpointB.ChannelID,
-						"upgrade_sequence":        fmt.Sprintf("%d", path.EndpointA.GetChannel().UpgradeSequence),
-						"upgrade_error_receipt":   upgradeError.Error(),
-					},
-				}
-
-				ibctesting.AssertEventsLegacy(&suite.Suite, expEvents, events)
+				// events := ctx.EventManager().Events().ToABCIEvents()
+				// expEvents := ibctesting.EventsMap{
+				//	"channel_upgrade_error": {
+				//		"port_id":                 path.EndpointA.ChannelConfig.PortID,
+				//		"channel_id":              path.EndpointA.ChannelID,
+				//		"counterparty_port_id":    path.EndpointB.ChannelConfig.PortID,
+				//		"counterparty_channel_id": path.EndpointB.ChannelID,
+				//		"upgrade_sequence":        fmt.Sprintf("%d", path.EndpointA.GetChannel().UpgradeSequence),
+				//		"upgrade_error_receipt":   upgradeError.Error(),
+				//	},
+				// }
 
 				channel, found := channelKeeper.GetChannel(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 				suite.Require().True(found, "channel should be found")

--- a/modules/core/04-channel/keeper/upgrade_test.go
+++ b/modules/core/04-channel/keeper/upgrade_test.go
@@ -109,7 +109,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeInit() {
 
 			if tc.expPass {
 				ctx := suite.chainA.GetContext()
-				suite.chainA.GetSimApp().IBCKeeper.ChannelKeeper.WriteUpgradeInitChannel(ctx, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, upgrade)
+				suite.chainA.GetSimApp().IBCKeeper.ChannelKeeper.WriteUpgradeInitChannel(ctx, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, upgrade, upgrade.Fields.Version)
 				channel := path.EndpointA.GetChannel()
 
 				events := ctx.EventManager().Events().ToABCIEvents()
@@ -286,7 +286,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeTry() {
 
 			proofChannel, proofUpgrade, proofHeight := path.EndpointA.QueryChannelUpgradeProof()
 
-			upgrade, err := suite.chainB.GetSimApp().IBCKeeper.ChannelKeeper.ChanUpgradeTry(
+			_, upgrade, err := suite.chainB.GetSimApp().IBCKeeper.ChannelKeeper.ChanUpgradeTry(
 				suite.chainB.GetContext(),
 				path.EndpointB.ChannelConfig.PortID,
 				path.EndpointB.ChannelID,
@@ -2332,7 +2332,7 @@ func (suite *KeeperTestSuite) TestChanUpgradeCrossingHelloWithHistoricalProofs()
 
 			tc.malleate()
 
-			upgrade, err := suite.chainB.GetSimApp().GetIBCKeeper().ChannelKeeper.ChanUpgradeTry(
+			_, upgrade, err := suite.chainB.GetSimApp().GetIBCKeeper().ChannelKeeper.ChanUpgradeTry(
 				suite.chainB.GetContext(),
 				path.EndpointB.ChannelConfig.PortID,
 				path.EndpointB.ChannelID,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

ref: #5217

This PR moves the events out to the message server layer.

I've commented out all the event tests for now, and will open a new PR which re-implements them as they now need to be done at the message server layer.

1. Event functions now need to be exported
2. Some method signatures changed to return channel/upgrade where necessary
3. WriteErrorReceipt removed as it is effectively the same as `SetUpgradeErrorReceipt`

<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
