### PR TITLE
e2e: Restructure to reduce number of runners used

### DIFF
--- a/.github/workflows/e2e-test-workflow-call.yml
+++ b/.github/workflows/e2e-test-workflow-call.yml
@@ -202,7 +202,7 @@ jobs:
         with:
           go-version: '1.21'
       - id: set-matrix
-        run: echo "matrix=$(go run cmd/build_test_matrix/main.go)" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(go run cmd/build_test_suite_matrix/main.go)" >> $GITHUB_OUTPUT
         env:
           TEST_ENTRYPOINT: '${{ inputs.test-entry-point }}'
           TEST_EXCLUSIONS: '${{ inputs.test-exclusions }}'
@@ -241,12 +241,12 @@ jobs:
         id: e2e_test
         run: |
           cd e2e
-          make e2e-test test=${{ matrix.test }}
+          make e2e-test-suite entrypoint=${{ matrix.entrypoint }}
       - name: Upload Diagnostics
         uses: actions/upload-artifact@v3
         if: ${{ failure() && inputs.upload-logs }}
         continue-on-error: true
         with:
-          name: '${{ matrix.entrypoint }}-${{ matrix.test }}'
+          name: '${{ matrix.entrypoint }}'
           path: e2e/diagnostics
           retention-days: 5

--- a/cmd/build_test_suite_matrix/main.go
+++ b/cmd/build_test_suite_matrix/main.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	testSuitePrefix    = "Test"
+	testSuiteSuffix    = "Suite"
+	testFileNameSuffix = "_test.go"
+	e2eTestDirectory   = "e2e"
+	// testEntryPointEnv specifes a single test function to run if provided.
+	testEntryPointEnv = "TEST_ENTRYPOINT"
+	// testExclusionsEnv is a comma separated list of test function names that will not be included
+	// in the results of this script.
+	testSuiteExclusionsEnv = "TEST_SUITE_EXCLUSIONS"
+	// testNameEnv if provided returns a single test entry so that only one test is actually run.
+)
+
+// GithubActionTestMatrix represents
+type GithubActionTestMatrix struct {
+	Include []TestSuite `json:"include"`
+}
+
+type TestSuite struct {
+	EntryPoint string `json:"entrypoint"`
+}
+
+func main() {
+	githubActionMatrix, err := getGithubActionMatrixForTests(e2eTestDirectory, getTestEntrypointToRun(), getExcludedTestSuiteFunctions())
+	if err != nil {
+		fmt.Printf("error generating github action json: %s", err)
+		os.Exit(1)
+	}
+
+	ghBytes, err := json.Marshal(githubActionMatrix)
+	if err != nil {
+		fmt.Printf("error marshalling github action json: %s", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(ghBytes))
+}
+
+// getTestEntrypointToRun returns the specified test function to run if present, otherwise
+// it returns an empty string which will result in running all test suites.
+func getTestEntrypointToRun() string {
+	testSuite, ok := os.LookupEnv(testEntryPointEnv)
+	if !ok {
+		return ""
+	}
+	return testSuite
+}
+
+// getExcludedTestFunctions returns a list of test functions that we don't want to run.
+func getExcludedTestSuiteFunctions() []string {
+	exclusions, ok := os.LookupEnv(testSuiteExclusionsEnv)
+	if !ok {
+		return nil
+	}
+	return strings.Split(exclusions, ",")
+}
+
+func contains(s string, items []string) bool {
+	for _, elem := range items {
+		if elem == s {
+			return true
+		}
+	}
+	return false
+}
+
+// getGithubActionMatrixForTests returns a json string representing the contents that should go in the matrix
+// field in a github action workflow. This string can be used with `fromJSON(str)` to dynamically build
+// the workflow matrix to include all E2E tests under the e2eRootDirectory directory.
+func getGithubActionMatrixForTests(e2eRootDirectory, suite string, excludedItems []string) (GithubActionTestMatrix, error) {
+	testSuite := []string{}
+	fset := token.NewFileSet()
+	err := filepath.Walk(e2eRootDirectory, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("error walking e2e directory: %s", err)
+		}
+
+		// only look at test files
+		if !strings.HasSuffix(path, testFileNameSuffix) {
+			return nil
+		}
+
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return fmt.Errorf("failed parsing file: %s", err)
+		}
+
+		suiteNameForFile, err := extractSuite(f)
+		if err != nil {
+			return fmt.Errorf("failed extracting test suite name: %s", err)
+		}
+
+		if contains(suiteNameForFile, excludedItems) {
+			return nil
+		}
+
+		if suiteNameForFile != "" {
+			testSuite = append(testSuite, suiteNameForFile)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return GithubActionTestMatrix{}, err
+	}
+
+	gh := GithubActionTestMatrix{
+		Include: []TestSuite{},
+	}
+
+	for _, testSuiteName := range testSuite {
+		gh.Include = append(gh.Include, TestSuite{
+			EntryPoint: testSuiteName,
+		})
+	}
+
+	return gh, nil
+}
+
+// extractSuiteAndTestNames extracts the name of the test suite function as well
+// as all tests associated with it in the same file.
+func extractSuite(file *ast.File) (string, error) {
+	var suiteNameForFile string
+
+	for _, d := range file.Decls {
+		if f, ok := d.(*ast.FuncDecl); ok {
+			functionName := f.Name.Name
+			if isTestSuiteMethod(f) {
+				if suiteNameForFile != "" {
+					return "", fmt.Errorf("found a second test function: %s when %s was already found", f.Name.Name, suiteNameForFile)
+				}
+				suiteNameForFile = functionName
+				continue
+			}
+		}
+	}
+	return suiteNameForFile, nil
+}
+
+// isTestSuiteMethod returns true if the function is a test suite function.
+// e.g. func TestFeeMiddlewareTestSuite(t *testing.T) { ... }
+func isTestSuiteMethod(f *ast.FuncDecl) bool {
+	return strings.HasPrefix(f.Name.Name, testSuitePrefix) && strings.HasSuffix(f.Name.Name, testSuiteSuffix)
+}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -13,6 +13,9 @@ init:
 e2e-test: init cleanup-ibc-test-containers
 	./scripts/run-e2e.sh $(test) $(entrypoint)
 
+e2e-test-suite: init cleanup-ibc-test-containers
+	./scripts/run-e2e-suite.sh $(entrypoint)
+
 compatibility-tests:
 	./scripts/run-compatibility-tests.sh $(release_branch)
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -273,17 +273,17 @@ func (s *FeeMiddlewareTestSuite) TestC() {}
 // e2e/file_two_test.go
 package e2e
 
-func TestTransferTestSuite(t *testing.T) {
-  suite.Run(t, new(TransferTestSuite))
+func TestExampleTestSuite(t *testing.T) {
+  suite.Run(t, new(ExampleTestSuite))
 }
 
-type TransferTestSuite struct {
+type ExampleTestSuite struct {
   testsuite.E2ETestSuite
 }
 
-func (s *TransferTestSuite) TestD() {}
-func (s *TransferTestSuite) TestE() {}
-func (s *TransferTestSuite) TestF() {}
+func (s *ExampleTestSuite) TestD() {}
+func (s *ExampleTestSuite) TestE() {}
+func (s *ExampleTestSuite) TestF() {}
 
 ```
 
@@ -305,15 +305,15 @@ In the above example, the following would be generated.
       "test": "TestC"
     },
     {
-      "entrypoint": "TestTransferTestSuite",
+      "entrypoint": "TestExampleTestSuite",
       "test": "TestD"
     },
     {
-      "entrypoint": "TestTransferTestSuite",
+      "entrypoint": "TestExampleTestSuite",
       "test": "TestE"
     },
     {
-      "entrypoint": "TestTransferTestSuite",
+      "entrypoint": "TestExampleTestSuite",
       "test": "TestF"
     }
   ]

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -262,6 +262,7 @@ require (
 replace (
 	github.com/ChainSafe/go-schnorrkel => github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d
 	github.com/ChainSafe/go-schnorrkel/1 => github.com/ChainSafe/go-schnorrkel v1.0.0
+	github.com/strangelove-ventures/interchaintest/v8 => github.com/decentrio/interchaintest/v8 v8.0.1-0.20231204174445-4c0a01717be4
 	github.com/vedhavyas/go-subkey => github.com/strangelove-ventures/go-subkey v1.0.7
 )
 

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -404,6 +404,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decentrio/interchaintest/v8 v8.0.1-0.20231204174445-4c0a01717be4 h1:v4EobGU555WQYBYUPwpVxu9iq7y3k98nA/miakN6oPM=
+github.com/decentrio/interchaintest/v8 v8.0.1-0.20231204174445-4c0a01717be4/go.mod h1:0LEZ1dXKlAYOm18X6s8AC4y5e6uAjJ0L69A6JpUkjDc=
 github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
 github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
@@ -1076,8 +1078,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.17.0 h1:I5txKw7MJasPL/BrfkbA0Jyo/oELqVmux4pR/UxOMfI=
 github.com/spf13/viper v1.17.0/go.mod h1:BmMMMLQXSbcHK6KAOiFLz0l5JHrU89OdIRHvsk0+yVI=
-github.com/strangelove-ventures/interchaintest/v8 v8.0.0 h1:z6hz23NJEhRJxZUH1vuDNTVscRwnUii+K4En9lfyndc=
-github.com/strangelove-ventures/interchaintest/v8 v8.0.0/go.mod h1:0LEZ1dXKlAYOm18X6s8AC4y5e6uAjJ0L69A6JpUkjDc=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/e2e/scripts/run-e2e-suite.sh
+++ b/e2e/scripts/run-e2e-suite.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eo pipefail
+
+ENTRY_POINT="${1}"
+
+function _verify_jq() {
+      if ! command -v jq > /dev/null ; then
+          echo "jq is required to extract test entrypoint."
+          exit 1
+      fi
+}
+
+
+function _verify_dependencies() {
+    # jq is always required to determine the entrypoint of the test.
+    _verify_jq
+}
+
+_verify_dependencies
+
+# if jq is installed, we can automatically determine the test entrypoint.
+# if command -v jq > /dev/null; then
+#    cd ..
+#    ENTRY_POINT="$(go run -mod=readonly cmd/build_test_matrix/main.go | jq -r --arg TEST "${TEST}" '.include[] | select( .test == $TEST)  | .entrypoint')"
+#    cd - > /dev/null
+# fi
+
+# find the name of the file that has this test in it.
+test_file="$(grep --recursive --files-with-matches './' -e "${ENTRY_POINT}(t")"
+
+# we run the test on the directory as specific files may reference types in other files but within the package.
+test_dir="$(dirname $test_file)"
+
+# run the test file directly, this allows log output to be streamed directly in the terminal sessions
+# without needed to wait for the test to finish.
+# it shouldn't take 30m, but the wasm test can be quite slow, so we can be generous.
+go test -v "${test_dir}" --run ${ENTRY_POINT} -timeout 150m

--- a/e2e/tests/core/03-connection/connection_test.go
+++ b/e2e/tests/core/03-connection/connection_test.go
@@ -30,6 +30,15 @@ func TestConnectionTestSuite(t *testing.T) {
 
 type ConnectionTestSuite struct {
 	testsuite.E2ETestSuite
+	chainA ibc.Chain
+	chainB ibc.Chain
+	rly    ibc.Relayer
+}
+
+func (s *ConnectionTestSuite) SetupTest() {
+	ctx := context.TODO()
+	s.chainA, s.chainB = s.GetChains()
+	s.rly = s.SetupRelayer(ctx, s.TransferChannelOptions(), s.chainA, s.chainB)
 }
 
 // QueryMaxExpectedTimePerBlockParam queries the on-chain max expected time per block param for 03-connection
@@ -62,59 +71,60 @@ func (s *ConnectionTestSuite) TestMaxExpectedTimePerBlockParam() {
 	t := s.T()
 	ctx := context.TODO()
 
-	relayer, channelA := s.SetupChainsRelayerAndChannel(ctx, s.TransferChannelOptions())
-	chainA, chainB := s.GetChains()
-	chainAVersion := chainA.Config().Images[0].Version
+	channelA, err := s.rly.GetChannels(ctx, s.GetRelayerExecReporter(), s.chainA.Config().ChainID)
+	s.Require().NoError(err)
+	chainAChannels := channelA[len(channelA)-1]
+	chainAVersion := s.chainA.Config().Images[0].Version
 
-	chainBDenom := chainB.Config().Denom
-	chainAIBCToken := testsuite.GetIBCToken(chainBDenom, channelA.PortID, channelA.ChannelID)
+	chainBDenom := s.chainB.Config().Denom
+	chainAIBCToken := testsuite.GetIBCToken(chainBDenom, chainAChannels.PortID, chainAChannels.ChannelID)
 
-	chainAWallet := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount)
+	chainAWallet := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount, s.chainA)
 	chainAAddress := chainAWallet.FormattedAddress()
 
-	chainBWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount)
+	chainBWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount, s.chainB)
 	chainBAddress := chainBWallet.FormattedAddress()
 
-	s.Require().NoError(test.WaitForBlocks(ctx, 1, chainA, chainB), "failed to wait for blocks")
+	s.Require().NoError(test.WaitForBlocks(ctx, 1, s.chainA, s.chainB), "failed to wait for blocks")
 
 	t.Run("ensure delay is set to the default of 30 seconds", func(t *testing.T) {
-		delay := s.QueryMaxExpectedTimePerBlockParam(ctx, chainA)
+		delay := s.QueryMaxExpectedTimePerBlockParam(ctx, s.chainA)
 		s.Require().Equal(uint64(connectiontypes.DefaultTimePerBlock), delay)
 	})
 
 	t.Run("change the delay to 60 seconds", func(t *testing.T) {
 		delay := uint64(1 * time.Minute)
 		if testvalues.SelfParamsFeatureReleases.IsSupported(chainAVersion) {
-			authority, err := s.QueryModuleAccountAddress(ctx, govtypes.ModuleName, chainA)
+			authority, err := s.QueryModuleAccountAddress(ctx, govtypes.ModuleName, s.chainA)
 			s.Require().NoError(err)
 			s.Require().NotNil(authority)
 
 			msg := connectiontypes.NewMsgUpdateParams(authority.String(), connectiontypes.NewParams(delay))
-			s.ExecuteAndPassGovV1Proposal(ctx, msg, chainA, chainAWallet)
+			s.ExecuteAndPassGovV1Proposal(ctx, msg, s.chainA, chainAWallet)
 		} else {
 			changes := []paramsproposaltypes.ParamChange{
 				paramsproposaltypes.NewParamChange(ibcexported.ModuleName, string(connectiontypes.KeyMaxExpectedTimePerBlock), fmt.Sprintf(`"%d"`, delay)),
 			}
 
 			proposal := paramsproposaltypes.NewParameterChangeProposal(ibctesting.Title, ibctesting.Description, changes)
-			s.ExecuteAndPassGovV1Beta1Proposal(ctx, chainA, chainAWallet, proposal)
+			s.ExecuteAndPassGovV1Beta1Proposal(ctx, s.chainA, chainAWallet, proposal, s.chainB)
 		}
 	})
 
 	t.Run("validate the param was successfully changed", func(t *testing.T) {
 		expectedDelay := uint64(1 * time.Minute)
-		delay := s.QueryMaxExpectedTimePerBlockParam(ctx, chainA)
+		delay := s.QueryMaxExpectedTimePerBlockParam(ctx, s.chainA)
 		s.Require().Equal(expectedDelay, delay)
 	})
 
 	t.Run("ensure packets can be received, send from chainB to chainA", func(t *testing.T) {
 		t.Run("send tokens from chainB to chainA", func(t *testing.T) {
-			transferTxResp := s.Transfer(ctx, chainB, chainBWallet, channelA.Counterparty.PortID, channelA.Counterparty.ChannelID, testvalues.DefaultTransferAmount(chainBDenom), chainBAddress, chainAAddress, s.GetTimeoutHeight(ctx, chainA), 0, "")
+			transferTxResp := s.Transfer(ctx, s.chainB, chainBWallet, chainAChannels.Counterparty.PortID, chainAChannels.Counterparty.ChannelID, testvalues.DefaultTransferAmount(chainBDenom), chainBAddress, chainAAddress, s.GetTimeoutHeight(ctx, s.chainA), 0, "", s.chainA)
 			s.AssertTxSuccess(transferTxResp)
 		})
 
 		t.Run("tokens are escrowed", func(t *testing.T) {
-			actualBalance, err := s.GetChainBNativeBalance(ctx, chainBWallet)
+			actualBalance, err := s.GetChainBNativeBalance(ctx, chainBWallet, s.chainB)
 			s.Require().NoError(err)
 
 			expected := testvalues.StartingTokenAmount - testvalues.IBCTransferAmount
@@ -122,13 +132,13 @@ func (s *ConnectionTestSuite) TestMaxExpectedTimePerBlockParam() {
 		})
 
 		t.Run("start relayer", func(t *testing.T) {
-			s.StartRelayer(relayer)
+			s.StartRelayer(s.rly)
 		})
 
 		t.Run("packets are relayed", func(t *testing.T) {
-			s.AssertPacketRelayed(ctx, chainA, channelA.Counterparty.PortID, channelA.Counterparty.ChannelID, 1)
+			s.AssertPacketRelayed(ctx, s.chainA, chainAChannels.Counterparty.PortID, chainAChannels.Counterparty.ChannelID, 1)
 
-			actualBalance, err := s.QueryBalance(ctx, chainA, chainAAddress, chainAIBCToken.IBCDenom())
+			actualBalance, err := s.QueryBalance(ctx, s.chainA, chainAAddress, chainAIBCToken.IBCDenom())
 
 			s.Require().NoError(err)
 
@@ -137,7 +147,7 @@ func (s *ConnectionTestSuite) TestMaxExpectedTimePerBlockParam() {
 		})
 
 		t.Run("stop relayer", func(t *testing.T) {
-			s.StopRelayer(ctx, relayer)
+			s.StopRelayer(ctx, s.rly)
 		})
 	})
 }

--- a/e2e/tests/interchain_accounts/incentivized_test.go
+++ b/e2e/tests/interchain_accounts/incentivized_test.go
@@ -11,7 +11,6 @@ import (
 	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	test "github.com/strangelove-ventures/interchaintest/v8/testutil"
-	testifysuite "github.com/stretchr/testify/suite"
 
 	sdkmath "cosmossdk.io/math"
 
@@ -26,108 +25,100 @@ import (
 	ibctesting "github.com/cosmos/ibc-go/v8/testing"
 )
 
-func TestIncentivizedInterchainAccountsTestSuite(t *testing.T) {
-	testifysuite.Run(t, new(IncentivizedInterchainAccountsTestSuite))
-}
-
-type IncentivizedInterchainAccountsTestSuite struct {
-	InterchainAccountsTestSuite
-}
-
-func (s *IncentivizedInterchainAccountsTestSuite) TestMsgSendTx_SuccessfulBankSend_Incentivized() {
+func (s *InterchainAccountsTestSuite) TestMsgSendTx_SuccessfulBankSend_Incentivized() {
 	t := s.T()
 	ctx := context.TODO()
 
 	// setup relayers and connection-0 between two chains
 	// channel-0 is a transfer channel but it will not be used in this test case
-	relayer, _ := s.SetupChainsRelayerAndChannel(ctx, nil)
-	chainA, chainB := s.GetChains()
+	_, err := s.rly.GetChannels(ctx, s.GetRelayerExecReporter(), s.chainA.Config().ChainID)
+	s.Require().NoError(err)
 
 	var (
-		chainADenom   = chainA.Config().Denom
+		chainADenom   = s.chainA.Config().Denom
 		interchainAcc = ""
 		testFee       = testvalues.DefaultFee(chainADenom)
 	)
 
 	t.Run("relayer wallets recovered", func(t *testing.T) {
-		err := s.RecoverRelayerWallets(ctx, relayer)
+		err := s.RecoverRelayerWallets(ctx, s.rly, s.chainA, s.chainB)
 		s.Require().NoError(err)
 	})
 
-	chainARelayerWallet, chainBRelayerWallet, err := s.GetRelayerWallets(relayer)
+	chainARelayerWallet, chainBRelayerWallet, err := s.GetRelayerWallets(s.rly, s.chainA, s.chainB)
 	t.Run("relayer wallets fetched", func(t *testing.T) {
 		s.Require().NoError(err)
 	})
 
-	s.Require().NoError(test.WaitForBlocks(ctx, 5, chainA, chainB), "failed to wait for blocks")
+	s.Require().NoError(test.WaitForBlocks(ctx, 5, s.chainA, s.chainB), "failed to wait for blocks")
 
-	chainARelayerUser, chainBRelayerUser := s.GetRelayerUsers(ctx)
+	chainARelayerUser, chainBRelayerUser := s.GetRelayerUsers(ctx, s.chainA, s.chainB)
 	relayerAStartingBalance, err := s.GetChainANativeBalance(ctx, chainARelayerUser)
 	s.Require().NoError(err)
 	t.Logf("relayer A user starting with balance: %d", relayerAStartingBalance)
 
-	controllerAccount := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount)
-	chainBAccount := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount)
+	controllerAccount := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount, s.chainA)
+	chainBAccount := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount, s.chainB)
 
 	t.Run("broadcast MsgRegisterInterchainAccount", func(t *testing.T) {
 		version := "" // allow version to be specified by the controller chain since both chains should support incentivized channels
 		msgRegisterAccount := controllertypes.NewMsgRegisterInterchainAccount(ibctesting.FirstConnectionID, controllerAccount.FormattedAddress(), version)
 
-		txResp := s.BroadcastMessages(ctx, chainA, controllerAccount, msgRegisterAccount)
+		txResp := s.BroadcastMessages(ctx, s.chainA, controllerAccount, s.chainA, msgRegisterAccount)
 		s.AssertTxSuccess(txResp)
 	})
 
 	t.Run("start relayer", func(t *testing.T) {
-		s.StartRelayer(relayer)
+		s.StartRelayer(s.rly)
 	})
 
 	var channelOutput ibc.ChannelOutput
 	t.Run("verify interchain account", func(t *testing.T) {
 		var err error
-		interchainAcc, err = s.QueryInterchainAccount(ctx, chainA, controllerAccount.FormattedAddress(), ibctesting.FirstConnectionID)
+		interchainAcc, err = s.QueryInterchainAccount(ctx, s.chainA, controllerAccount.FormattedAddress(), ibctesting.FirstConnectionID)
 		s.Require().NoError(err)
 		s.Require().NotZero(len(interchainAcc))
 
-		channels, err := relayer.GetChannels(ctx, s.GetRelayerExecReporter(), chainA.Config().ChainID)
+		channels, err := s.rly.GetChannels(ctx, s.GetRelayerExecReporter(), s.chainA.Config().ChainID)
 		s.Require().NoError(err)
 		s.Require().Equal(len(channels), 2)
 
 		// interchain accounts channel at index: 0
 		channelOutput = channels[0]
 
-		s.Require().NoError(test.WaitForBlocks(ctx, 2, chainA, chainB))
+		s.Require().NoError(test.WaitForBlocks(ctx, 2, s.chainA, s.chainB))
 	})
 
 	t.Run("execute interchain account bank send through controller", func(t *testing.T) {
 		t.Run("fund interchain account wallet on host chainB", func(t *testing.T) {
 			// fund the interchain account so it has some $$ to send
-			err := chainB.SendFunds(ctx, interchaintest.FaucetAccountKeyName, ibc.WalletAmount{
+			err := s.chainB.SendFunds(ctx, interchaintest.FaucetAccountKeyName, ibc.WalletAmount{
 				Address: interchainAcc,
 				Amount:  sdkmath.NewInt(testvalues.StartingTokenAmount),
-				Denom:   chainB.Config().Denom,
+				Denom:   s.chainB.Config().Denom,
 			})
 			s.Require().NoError(err)
 		})
 
 		t.Run("register counterparty payee", func(t *testing.T) {
-			resp := s.RegisterCounterPartyPayee(ctx, chainB, chainBRelayerUser, channelOutput.Counterparty.PortID, channelOutput.Counterparty.ChannelID, chainBRelayerWallet.FormattedAddress(), chainARelayerWallet.FormattedAddress())
+			resp := s.RegisterCounterPartyPayee(ctx, s.chainB, chainBRelayerUser, channelOutput.Counterparty.PortID, channelOutput.Counterparty.ChannelID, chainBRelayerWallet.FormattedAddress(), chainARelayerWallet.FormattedAddress(), s.chainA)
 			s.AssertTxSuccess(resp)
 		})
 
 		t.Run("verify counterparty payee", func(t *testing.T) {
-			address, err := s.QueryCounterPartyPayee(ctx, chainB, chainBRelayerWallet.FormattedAddress(), channelOutput.Counterparty.ChannelID)
+			address, err := s.QueryCounterPartyPayee(ctx, s.chainB, chainBRelayerWallet.FormattedAddress(), channelOutput.Counterparty.ChannelID)
 			s.Require().NoError(err)
 			s.Require().Equal(chainARelayerWallet.FormattedAddress(), address)
 		})
 
 		t.Run("no incentivized packets", func(t *testing.T) {
-			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, chainA, channelOutput.PortID, channelOutput.ChannelID)
+			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, s.chainA, channelOutput.PortID, channelOutput.ChannelID)
 			s.Require().NoError(err)
 			s.Require().Empty(packets)
 		})
 
 		t.Run("stop relayer", func(t *testing.T) {
-			s.StopRelayer(ctx, relayer)
+			s.StopRelayer(ctx, s.rly)
 		})
 
 		t.Run("broadcast incentivized MsgSendTx", func(t *testing.T) {
@@ -141,7 +132,7 @@ func (s *IncentivizedInterchainAccountsTestSuite) TestMsgSendTx_SuccessfulBankSe
 			msgSend := &banktypes.MsgSend{
 				FromAddress: interchainAcc,
 				ToAddress:   chainBAccount.FormattedAddress(),
-				Amount:      sdk.NewCoins(testvalues.DefaultTransferAmount(chainB.Config().Denom)),
+				Amount:      sdk.NewCoins(testvalues.DefaultTransferAmount(s.chainB.Config().Denom)),
 			}
 
 			cdc := testsuite.Codec()
@@ -156,14 +147,14 @@ func (s *IncentivizedInterchainAccountsTestSuite) TestMsgSendTx_SuccessfulBankSe
 
 			msgSendTx := controllertypes.NewMsgSendTx(controllerAccount.FormattedAddress(), ibctesting.FirstConnectionID, uint64(time.Hour.Nanoseconds()), packetData)
 
-			resp := s.BroadcastMessages(ctx, chainA, controllerAccount, msgPayPacketFee, msgSendTx)
+			resp := s.BroadcastMessages(ctx, s.chainA, controllerAccount, s.chainB, msgPayPacketFee, msgSendTx)
 			s.AssertTxSuccess(resp)
 
-			s.Require().NoError(test.WaitForBlocks(ctx, 1, chainA, chainB))
+			s.Require().NoError(test.WaitForBlocks(ctx, 1, s.chainA, s.chainB))
 		})
 
 		t.Run("there should be incentivized packets", func(t *testing.T) {
-			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, chainA, channelOutput.PortID, channelOutput.ChannelID)
+			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, s.chainA, channelOutput.PortID, channelOutput.ChannelID)
 			s.Require().NoError(err)
 			s.Require().Len(packets, 1)
 			actualFee := packets[0].PacketFees[0].Fee
@@ -174,20 +165,20 @@ func (s *IncentivizedInterchainAccountsTestSuite) TestMsgSendTx_SuccessfulBankSe
 		})
 
 		t.Run("start relayer", func(t *testing.T) {
-			s.StartRelayer(relayer)
+			s.StartRelayer(s.rly)
 		})
 
 		t.Run("packets are relayed", func(t *testing.T) {
-			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, chainA, channelOutput.PortID, channelOutput.ChannelID)
+			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, s.chainA, channelOutput.PortID, channelOutput.ChannelID)
 			s.Require().NoError(err)
 			s.Require().Empty(packets)
 		})
 
 		t.Run("verify interchain account sent tokens", func(t *testing.T) {
-			balance, err := s.QueryBalance(ctx, chainB, chainBAccount.FormattedAddress(), chainB.Config().Denom)
+			balance, err := s.QueryBalance(ctx, s.chainB, chainBAccount.FormattedAddress(), s.chainB.Config().Denom)
 			s.Require().NoError(err)
 
-			_, err = s.QueryBalance(ctx, chainB, interchainAcc, chainB.Config().Denom)
+			_, err = s.QueryBalance(ctx, s.chainB, interchainAcc, s.chainB.Config().Denom)
 			s.Require().NoError(err)
 
 			expected := testvalues.IBCTransferAmount + testvalues.StartingTokenAmount
@@ -212,90 +203,90 @@ func (s *IncentivizedInterchainAccountsTestSuite) TestMsgSendTx_SuccessfulBankSe
 	})
 }
 
-func (s *IncentivizedInterchainAccountsTestSuite) TestMsgSendTx_FailedBankSend_Incentivized() {
+func (s *InterchainAccountsTestSuite) TestMsgSendTx_FailedBankSend_Incentivized() {
 	t := s.T()
 	ctx := context.TODO()
 
 	// setup relayers and connection-0 between two chains
 	// channel-0 is a transfer channel but it will not be used in this test case
-	relayer, _ := s.SetupChainsRelayerAndChannel(ctx, nil)
-	chainA, chainB := s.GetChains()
+	_, err := s.rly.GetChannels(ctx, s.GetRelayerExecReporter(), s.chainA.Config().ChainID)
+	s.Require().NoError(err)
 
 	var (
-		chainADenom   = chainA.Config().Denom
+		chainADenom   = s.chainA.Config().Denom
 		interchainAcc = ""
 		testFee       = testvalues.DefaultFee(chainADenom)
 	)
 
 	t.Run("relayer wallets recovered", func(t *testing.T) {
-		err := s.RecoverRelayerWallets(ctx, relayer)
+		err := s.RecoverRelayerWallets(ctx, s.rly, s.chainA, s.chainB)
 		s.Require().NoError(err)
 	})
 
-	chainARelayerWallet, chainBRelayerWallet, err := s.GetRelayerWallets(relayer)
+	chainARelayerWallet, chainBRelayerWallet, err := s.GetRelayerWallets(s.rly, s.chainA, s.chainB)
 	t.Run("relayer wallets fetched", func(t *testing.T) {
 		s.Require().NoError(err)
 	})
 
-	s.Require().NoError(test.WaitForBlocks(ctx, 5, chainA, chainB), "failed to wait for blocks")
+	s.Require().NoError(test.WaitForBlocks(ctx, 5, s.chainA, s.chainB), "failed to wait for blocks")
 
-	chainARelayerUser, chainBRelayerUser := s.GetRelayerUsers(ctx)
+	chainARelayerUser, chainBRelayerUser := s.GetRelayerUsers(ctx, s.chainA, s.chainB)
 	relayerAStartingBalance, err := s.GetChainANativeBalance(ctx, chainARelayerUser)
 	s.Require().NoError(err)
 	t.Logf("relayer A user starting with balance: %d", relayerAStartingBalance)
 
-	controllerAccount := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount)
-	chainBAccount := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount)
+	controllerAccount := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount, s.chainA)
+	chainBAccount := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount, s.chainB)
 
 	t.Run("broadcast MsgRegisterInterchainAccount", func(t *testing.T) {
 		version := "" // allow version to be specified by the controller chain since both chains should support incentivized channels
 		msgRegisterAccount := controllertypes.NewMsgRegisterInterchainAccount(ibctesting.FirstConnectionID, controllerAccount.FormattedAddress(), version)
 
-		txResp := s.BroadcastMessages(ctx, chainA, controllerAccount, msgRegisterAccount)
+		txResp := s.BroadcastMessages(ctx, s.chainA, controllerAccount, s.chainB, msgRegisterAccount)
 		s.AssertTxSuccess(txResp)
 	})
 
 	t.Run("start relayer", func(t *testing.T) {
-		s.StartRelayer(relayer)
+		s.StartRelayer(s.rly)
 	})
 
 	var channelOutput ibc.ChannelOutput
 	t.Run("verify interchain account", func(t *testing.T) {
 		var err error
-		interchainAcc, err = s.QueryInterchainAccount(ctx, chainA, controllerAccount.FormattedAddress(), ibctesting.FirstConnectionID)
+		interchainAcc, err = s.QueryInterchainAccount(ctx, s.chainA, controllerAccount.FormattedAddress(), ibctesting.FirstConnectionID)
 		s.Require().NoError(err)
 		s.Require().NotZero(len(interchainAcc))
 
-		channels, err := relayer.GetChannels(ctx, s.GetRelayerExecReporter(), chainA.Config().ChainID)
+		channels, err := s.rly.GetChannels(ctx, s.GetRelayerExecReporter(), s.chainA.Config().ChainID)
 		s.Require().NoError(err)
 		s.Require().Equal(len(channels), 2)
 
 		// interchain accounts channel at index: 0
 		channelOutput = channels[0]
 
-		s.Require().NoError(test.WaitForBlocks(ctx, 2, chainA, chainB))
+		s.Require().NoError(test.WaitForBlocks(ctx, 2, s.chainA, s.chainB))
 	})
 
 	t.Run("execute interchain account bank send through controller", func(t *testing.T) {
 		t.Run("register counterparty payee", func(t *testing.T) {
-			resp := s.RegisterCounterPartyPayee(ctx, chainB, chainBRelayerUser, channelOutput.Counterparty.PortID, channelOutput.Counterparty.ChannelID, chainBRelayerWallet.FormattedAddress(), chainARelayerWallet.FormattedAddress())
+			resp := s.RegisterCounterPartyPayee(ctx, s.chainB, chainBRelayerUser, channelOutput.Counterparty.PortID, channelOutput.Counterparty.ChannelID, chainBRelayerWallet.FormattedAddress(), chainARelayerWallet.FormattedAddress(), s.chainA)
 			s.AssertTxSuccess(resp)
 		})
 
 		t.Run("verify counterparty payee", func(t *testing.T) {
-			address, err := s.QueryCounterPartyPayee(ctx, chainB, chainBRelayerWallet.FormattedAddress(), channelOutput.Counterparty.ChannelID)
+			address, err := s.QueryCounterPartyPayee(ctx, s.chainB, chainBRelayerWallet.FormattedAddress(), channelOutput.Counterparty.ChannelID)
 			s.Require().NoError(err)
 			s.Require().Equal(chainARelayerWallet.FormattedAddress(), address)
 		})
 
 		t.Run("no incentivized packets", func(t *testing.T) {
-			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, chainA, channelOutput.PortID, channelOutput.ChannelID)
+			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, s.chainA, channelOutput.PortID, channelOutput.ChannelID)
 			s.Require().NoError(err)
 			s.Require().Empty(packets)
 		})
 
 		t.Run("stop relayer", func(t *testing.T) {
-			err := relayer.StopRelayer(ctx, s.GetRelayerExecReporter())
+			err := s.rly.StopRelayer(ctx, s.GetRelayerExecReporter())
 			s.Require().NoError(err)
 		})
 
@@ -310,7 +301,7 @@ func (s *IncentivizedInterchainAccountsTestSuite) TestMsgSendTx_FailedBankSend_I
 			msgSend := &banktypes.MsgSend{
 				FromAddress: interchainAcc,
 				ToAddress:   chainBAccount.FormattedAddress(),
-				Amount:      sdk.NewCoins(testvalues.DefaultTransferAmount(chainB.Config().Denom)),
+				Amount:      sdk.NewCoins(testvalues.DefaultTransferAmount(s.chainB.Config().Denom)),
 			}
 
 			cdc := testsuite.Codec()
@@ -325,14 +316,14 @@ func (s *IncentivizedInterchainAccountsTestSuite) TestMsgSendTx_FailedBankSend_I
 
 			msgSendTx := controllertypes.NewMsgSendTx(controllerAccount.FormattedAddress(), ibctesting.FirstConnectionID, uint64(time.Hour.Nanoseconds()), packetData)
 
-			resp := s.BroadcastMessages(ctx, chainA, controllerAccount, msgPayPacketFee, msgSendTx)
+			resp := s.BroadcastMessages(ctx, s.chainA, controllerAccount, s.chainB, msgPayPacketFee, msgSendTx)
 			s.AssertTxSuccess(resp)
 
-			s.Require().NoError(test.WaitForBlocks(ctx, 1, chainA, chainB))
+			s.Require().NoError(test.WaitForBlocks(ctx, 1, s.chainA, s.chainB))
 		})
 
 		t.Run("there should be incentivized packets", func(t *testing.T) {
-			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, chainA, channelOutput.PortID, channelOutput.ChannelID)
+			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, s.chainA, channelOutput.PortID, channelOutput.ChannelID)
 			s.Require().NoError(err)
 			s.Require().Len(packets, 1)
 			actualFee := packets[0].PacketFees[0].Fee
@@ -343,20 +334,20 @@ func (s *IncentivizedInterchainAccountsTestSuite) TestMsgSendTx_FailedBankSend_I
 		})
 
 		t.Run("start relayer", func(t *testing.T) {
-			s.StartRelayer(relayer)
+			s.StartRelayer(s.rly)
 		})
 
 		t.Run("packets are relayed", func(t *testing.T) {
-			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, chainA, channelOutput.PortID, channelOutput.ChannelID)
+			packets, err := s.QueryIncentivizedPacketsForChannel(ctx, s.chainA, channelOutput.PortID, channelOutput.ChannelID)
 			s.Require().NoError(err)
 			s.Require().Empty(packets)
 		})
 
 		t.Run("verify interchain account did not send tokens", func(t *testing.T) {
-			balance, err := s.QueryBalance(ctx, chainB, chainBAccount.FormattedAddress(), chainB.Config().Denom)
+			balance, err := s.QueryBalance(ctx, s.chainB, chainBAccount.FormattedAddress(), s.chainB.Config().Denom)
 			s.Require().NoError(err)
 
-			_, err = s.QueryBalance(ctx, chainB, interchainAcc, chainB.Config().Denom)
+			_, err = s.QueryBalance(ctx, s.chainB, interchainAcc, s.chainB.Config().Denom)
 			s.Require().NoError(err)
 
 			expected := testvalues.StartingTokenAmount

--- a/e2e/tests/interchain_accounts/params_test.go
+++ b/e2e/tests/interchain_accounts/params_test.go
@@ -7,12 +7,10 @@ import (
 	"testing"
 
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	testifysuite "github.com/stretchr/testify/suite"
 
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	paramsproposaltypes "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 
-	"github.com/cosmos/ibc-go/e2e/testsuite"
 	"github.com/cosmos/ibc-go/e2e/testvalues"
 	controllertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
 	hosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
@@ -20,16 +18,8 @@ import (
 	ibctesting "github.com/cosmos/ibc-go/v8/testing"
 )
 
-func TestInterchainAccountsParamsTestSuite(t *testing.T) {
-	testifysuite.Run(t, new(InterchainAccountsParamsTestSuite))
-}
-
-type InterchainAccountsParamsTestSuite struct {
-	testsuite.E2ETestSuite
-}
-
 // QueryControllerParams queries the params for the controller
-func (s *InterchainAccountsParamsTestSuite) QueryControllerParams(ctx context.Context, chain ibc.Chain) controllertypes.Params {
+func (s *InterchainAccountsTestSuite) QueryControllerParams(ctx context.Context, chain ibc.Chain) controllertypes.Params {
 	queryClient := s.GetChainGRCPClients(chain).ICAControllerQueryClient
 	res, err := queryClient.Params(ctx, &controllertypes.QueryParamsRequest{})
 	s.Require().NoError(err)
@@ -38,7 +28,7 @@ func (s *InterchainAccountsParamsTestSuite) QueryControllerParams(ctx context.Co
 }
 
 // QueryHostParams queries the host chain for the params
-func (s *InterchainAccountsParamsTestSuite) QueryHostParams(ctx context.Context, chain ibc.Chain) hosttypes.Params {
+func (s *InterchainAccountsTestSuite) QueryHostParams(ctx context.Context, chain ibc.Chain) hosttypes.Params {
 	queryClient := s.GetChainGRCPClients(chain).ICAHostQueryClient
 	res, err := queryClient.Params(ctx, &hosttypes.QueryParamsRequest{})
 	s.Require().NoError(err)
@@ -47,28 +37,29 @@ func (s *InterchainAccountsParamsTestSuite) QueryHostParams(ctx context.Context,
 }
 
 // TestControllerEnabledParam tests that changing the ControllerEnabled param works as expected
-func (s *InterchainAccountsParamsTestSuite) TestControllerEnabledParam() {
+func (s *InterchainAccountsTestSuite) TestControllerEnabledParam() {
 	t := s.T()
+	t.Parallel()
 	ctx := context.TODO()
 
 	// setup relayers and connection-0 between two chains
 	// channel-0 is a transfer channel but it will not be used in this test case
-	_, _ = s.SetupChainsRelayerAndChannel(ctx, nil)
-	chainA, _ := s.GetChains()
-	chainAVersion := chainA.Config().Images[0].Version
+	_, err := s.rly.GetChannels(ctx, s.GetRelayerExecReporter(), s.chainA.Config().ChainID)
+	s.Require().NoError(err)
+	chainAVersion := s.chainA.Config().Images[0].Version
 
 	// setup controller account on chainA
-	controllerAccount := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount)
+	controllerAccount := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount, s.chainA)
 	controllerAddress := controllerAccount.FormattedAddress()
 
 	t.Run("ensure the controller is enabled", func(t *testing.T) {
-		params := s.QueryControllerParams(ctx, chainA)
+		params := s.QueryControllerParams(ctx, s.chainA)
 		s.Require().True(params.ControllerEnabled)
 	})
 
 	t.Run("disable the controller", func(t *testing.T) {
 		if testvalues.SelfParamsFeatureReleases.IsSupported(chainAVersion) {
-			authority, err := s.QueryModuleAccountAddress(ctx, govtypes.ModuleName, chainA)
+			authority, err := s.QueryModuleAccountAddress(ctx, govtypes.ModuleName, s.chainA)
 			s.Require().NoError(err)
 			s.Require().NotNil(authority)
 
@@ -76,19 +67,19 @@ func (s *InterchainAccountsParamsTestSuite) TestControllerEnabledParam() {
 				Signer: authority.String(),
 				Params: controllertypes.NewParams(false),
 			}
-			s.ExecuteAndPassGovV1Proposal(ctx, &msg, chainA, controllerAccount)
+			s.ExecuteAndPassGovV1Proposal(ctx, &msg, s.chainA, controllerAccount)
 		} else {
 			changes := []paramsproposaltypes.ParamChange{
 				paramsproposaltypes.NewParamChange(controllertypes.StoreKey, string(controllertypes.KeyControllerEnabled), "false"),
 			}
 
 			proposal := paramsproposaltypes.NewParameterChangeProposal(ibctesting.Title, ibctesting.Description, changes)
-			s.ExecuteAndPassGovV1Beta1Proposal(ctx, chainA, controllerAccount, proposal)
+			s.ExecuteAndPassGovV1Beta1Proposal(ctx, s.chainA, controllerAccount, proposal, s.chainB)
 		}
 	})
 
 	t.Run("ensure controller is disabled", func(t *testing.T) {
-		params := s.QueryControllerParams(ctx, chainA)
+		params := s.QueryControllerParams(ctx, s.chainA)
 		s.Require().False(params.ControllerEnabled)
 	})
 
@@ -97,35 +88,36 @@ func (s *InterchainAccountsParamsTestSuite) TestControllerEnabledParam() {
 		version := icatypes.NewDefaultMetadataString(ibctesting.FirstConnectionID, ibctesting.FirstConnectionID)
 		msgRegisterAccount := controllertypes.NewMsgRegisterInterchainAccount(ibctesting.FirstConnectionID, controllerAddress, version)
 
-		txResp := s.BroadcastMessages(ctx, chainA, controllerAccount, msgRegisterAccount)
+		txResp := s.BroadcastMessages(ctx, s.chainA, controllerAccount, s.chainB, msgRegisterAccount)
 		s.AssertTxFailure(txResp, controllertypes.ErrControllerSubModuleDisabled)
 	})
 }
 
-func (s *InterchainAccountsParamsTestSuite) TestHostEnabledParam() {
+func (s *InterchainAccountsTestSuite) TestHostEnabledParam() {
 	t := s.T()
+	t.Parallel()
 	ctx := context.TODO()
 
 	// setup relayers and connection-0 between two chains
 	// channel-0 is a transfer channel but it will not be used in this test case
-	_, _ = s.SetupChainsRelayerAndChannel(ctx, nil)
-	_, chainB := s.GetChains()
-	chainBVersion := chainB.Config().Images[0].Version
+	_, err := s.rly.GetChannels(ctx, s.GetRelayerExecReporter(), s.chainA.Config().ChainID)
+	s.Require().NoError(err)
+	chainBVersion := s.chainB.Config().Images[0].Version
 
 	// setup 2 accounts: controller account on chain A, a second chain B account.
 	// host account will be created when the ICA is registered
-	chainBUser := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount)
+	chainBUser := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount, s.chainB)
 
 	// Assert that default value for enabled is true.
 	t.Run("ensure the host is enabled", func(t *testing.T) {
-		params := s.QueryHostParams(ctx, chainB)
+		params := s.QueryHostParams(ctx, s.chainB)
 		s.Require().True(params.HostEnabled)
 		s.Require().Equal([]string{hosttypes.AllowAllHostMsgs}, params.AllowMessages)
 	})
 
 	t.Run("disable the host", func(t *testing.T) {
 		if testvalues.SelfParamsFeatureReleases.IsSupported(chainBVersion) {
-			authority, err := s.QueryModuleAccountAddress(ctx, govtypes.ModuleName, chainB)
+			authority, err := s.QueryModuleAccountAddress(ctx, govtypes.ModuleName, s.chainB)
 			s.Require().NoError(err)
 			s.Require().NotNil(authority)
 
@@ -133,19 +125,19 @@ func (s *InterchainAccountsParamsTestSuite) TestHostEnabledParam() {
 				Signer: authority.String(),
 				Params: hosttypes.NewParams(false, []string{hosttypes.AllowAllHostMsgs}),
 			}
-			s.ExecuteAndPassGovV1Proposal(ctx, &msg, chainB, chainBUser)
+			s.ExecuteAndPassGovV1Proposal(ctx, &msg, s.chainB, chainBUser)
 		} else {
 			changes := []paramsproposaltypes.ParamChange{
 				paramsproposaltypes.NewParamChange(hosttypes.StoreKey, string(hosttypes.KeyHostEnabled), "false"),
 			}
 
 			proposal := paramsproposaltypes.NewParameterChangeProposal(ibctesting.Title, ibctesting.Description, changes)
-			s.ExecuteAndPassGovV1Beta1Proposal(ctx, chainB, chainBUser, proposal)
+			s.ExecuteAndPassGovV1Beta1Proposal(ctx, s.chainB, chainBUser, proposal, s.chainA)
 		}
 	})
 
 	t.Run("ensure the host is disabled", func(t *testing.T) {
-		params := s.QueryHostParams(ctx, chainB)
+		params := s.QueryHostParams(ctx, s.chainB)
 		s.Require().False(params.HostEnabled)
 	})
 }

--- a/e2e/tests/wasm/grandpa_test.go
+++ b/e2e/tests/wasm/grandpa_test.go
@@ -73,7 +73,6 @@ type GrandpaTestSuite struct {
 // * send transfer over ibc
 func (s *GrandpaTestSuite) TestMsgTransfer_Succeeds_GrandpaContract() {
 	ctx := context.Background()
-	t := s.T()
 
 	chainA, chainB := s.GetGrandpaTestChains()
 
@@ -87,9 +86,9 @@ func (s *GrandpaTestSuite) TestMsgTransfer_Succeeds_GrandpaContract() {
 
 	s.InitGRPCClients(cosmosChain)
 
-	cosmosWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount)
+	cosmosWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount, chainB)
 
-	file, err := os.Open("contracts/ics10_grandpa_cw.wasm.gz")
+	file, err := os.Open("contracts/ics10_grandpa_cw.wasm")
 	s.Require().NoError(err)
 
 	checksum := s.PushNewWasmClientProposal(ctx, cosmosChain, cosmosWallet, file)
@@ -109,15 +108,6 @@ func (s *GrandpaTestSuite) TestMsgTransfer_Succeeds_GrandpaContract() {
 	// Fund users on both cosmos and parachain, mints Asset 1 for Alice
 	fundAmount := int64(12_333_000_000_000)
 	polkadotUser, cosmosUser := s.fundUsers(ctx, fundAmount, polkadotChain, cosmosChain)
-
-	// TODO: this can be refactored to broadcast a MsgTransfer instead of CLI.
-	// https://github.com/cosmos/ibc-go/issues/4963
-	amountToSend := int64(1_770_000)
-	transfer := ibc.WalletAmount{
-		Address: polkadotUser.FormattedAddress(),
-		Denom:   cosmosChain.Config().Denom,
-		Amount:  math.NewInt(amountToSend),
-	}
 
 	pathName := s.GetPathName(0)
 
@@ -145,188 +135,79 @@ func (s *GrandpaTestSuite) TestMsgTransfer_Succeeds_GrandpaContract() {
 	// Start relayer
 	s.Require().NoError(r.StartRelayer(ctx, eRep, pathName))
 
-	t.Run("send successful IBC transfer from Cosmos to Polkadot parachain", func(t *testing.T) {
-		// Send 1.77 stake from cosmosUser to parachainUser
-		tx, err := cosmosChain.SendIBCTransfer(ctx, "channel-0", cosmosUser.KeyName(), transfer, ibc.TransferOptions{})
-		s.Require().NoError(tx.Validate(), "source ibc transfer tx is invalid")
-		s.Require().NoError(err)
-		// verify token balance for cosmos user has decreased
-		balance, err := cosmosChain.GetBalance(ctx, cosmosUser.FormattedAddress(), cosmosChain.Config().Denom)
-		s.Require().NoError(err)
-		s.Require().Equal(balance, math.NewInt(fundAmount-amountToSend), "unexpected cosmos user balance after first tx")
-		err = testutil.WaitForBlocks(ctx, 15, cosmosChain, polkadotChain)
-		s.Require().NoError(err)
-
-		// Verify tokens arrived on parachain user
-		parachainUserStake, err := polkadotChain.GetIbcBalance(ctx, string(polkadotUser.Address()), 2)
-		s.Require().NoError(err)
-		s.Require().Equal(amountToSend, parachainUserStake.Amount.Int64(), "unexpected parachain user balance after first tx")
-	})
-
-	t.Run("send two successful IBC transfers from Polkadot parachain to Cosmos, first with ibc denom, second with parachain denom", func(t *testing.T) {
-		// Send 1.16 stake from parachainUser to cosmosUser
-		amountToReflect := int64(1_160_000)
-		reflectTransfer := ibc.WalletAmount{
-			Address: cosmosUser.FormattedAddress(),
-			Denom:   "2", // stake
-			Amount:  math.NewInt(amountToReflect),
-		}
-		_, err := polkadotChain.SendIBCTransfer(ctx, "channel-0", polkadotUser.KeyName(), reflectTransfer, ibc.TransferOptions{})
-		s.Require().NoError(err)
-
-		// Send 1.88 "UNIT" from Alice to cosmosUser
-		amountUnits := math.NewInt(1_880_000_000_000)
-		unitTransfer := ibc.WalletAmount{
-			Address: cosmosUser.FormattedAddress(),
-			Denom:   "1", // UNIT
-			Amount:  amountUnits,
-		}
-		_, err = polkadotChain.SendIBCTransfer(ctx, "channel-0", "alice", unitTransfer, ibc.TransferOptions{})
-		s.Require().NoError(err)
-
-		// Wait for MsgRecvPacket on cosmos chain
-		finalStakeBal := math.NewInt(fundAmount - amountToSend + amountToReflect)
-		err = cosmos.PollForBalance(ctx, cosmosChain, 20, ibc.WalletAmount{
-			Address: cosmosUser.FormattedAddress(),
-			Denom:   cosmosChain.Config().Denom,
-			Amount:  finalStakeBal,
-		})
-		s.Require().NoError(err)
-
-		// Wait for a new update state
-		err = testutil.WaitForBlocks(ctx, 5, cosmosChain, polkadotChain)
-		s.Require().NoError(err)
-
-		// Verify cosmos user's final "stake" balance
-		cosmosUserStakeBal, err := cosmosChain.GetBalance(ctx, cosmosUser.FormattedAddress(), cosmosChain.Config().Denom)
-		s.Require().NoError(err)
-		s.Require().True(cosmosUserStakeBal.Equal(finalStakeBal))
-
-		// Verify cosmos user's final "unit" balance
-		unitDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom("transfer", "channel-0", "UNIT"))
-		cosmosUserUnitBal, err := cosmosChain.GetBalance(ctx, cosmosUser.FormattedAddress(), unitDenomTrace.IBCDenom())
-		s.Require().NoError(err)
-		s.Require().True(cosmosUserUnitBal.Equal(amountUnits))
-
-		// Verify parachain user's final "unit" balance (will be less than expected due gas costs for stake tx)
-		parachainUserUnits, err := polkadotChain.GetIbcBalance(ctx, string(polkadotUser.Address()), 1)
-		s.Require().NoError(err)
-		s.Require().True(parachainUserUnits.Amount.LTE(math.NewInt(fundAmount)), "parachain user's final unit amount not expected")
-
-		// Verify parachain user's final "stake" balance
-		parachainUserStake, err := polkadotChain.GetIbcBalance(ctx, string(polkadotUser.Address()), 2)
-		s.Require().NoError(err)
-		s.Require().True(parachainUserStake.Amount.Equal(math.NewInt(amountToSend-amountToReflect)), "parachain user's final stake amount not expected")
-	})
-}
-
-// TestMsgTransfer_TimesOut_GrandpaContract
-// sets up cosmos and polkadot chains, hyperspace relayer, and funds users on both chains
-// * sends transfer over ibc channel, this transfer should timeout
-func (s *GrandpaTestSuite) TestMsgTransfer_TimesOut_GrandpaContract() {
-	ctx := context.Background()
-	t := s.T()
-
-	chainA, chainB := s.GetGrandpaTestChains()
-
-	polkadotChain := chainA.(*polkadot.PolkadotChain)
-	cosmosChain := chainB.(*cosmos.CosmosChain)
-
-	// we explicitly skip path creation as the contract needs to be uploaded before we can create clients.
-	r := s.ConfigureRelayer(ctx, polkadotChain, cosmosChain, nil, func(options *interchaintest.InterchainBuildOptions) {
-		options.SkipPathCreation = true
-	})
-
-	s.InitGRPCClients(cosmosChain)
-
-	cosmosWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount)
-
-	file, err := os.Open("contracts/ics10_grandpa_cw.wasm.gz")
-	s.Require().NoError(err)
-
-	checksum := s.PushNewWasmClientProposal(ctx, cosmosChain, cosmosWallet, file)
-
-	s.Require().NotEmpty(checksum, "checksum was empty but should not have been")
-
-	eRep := s.GetRelayerExecReporter()
-
-	// Set client contract hash in cosmos chain config
-	err = r.SetClientContractHash(ctx, eRep, cosmosChain.Config(), checksum)
-	s.Require().NoError(err)
-
-	// Ensure parachain has started (starts 1 session/epoch after relay chain)
-	err = testutil.WaitForBlocks(ctx, 1, polkadotChain)
-	s.Require().NoError(err, "polkadot chain failed to make blocks")
-
-	// Fund users on both cosmos and parachain, mints Asset 1 for Alice
-	fundAmount := int64(12_333_000_000_000)
-	polkadotUser, cosmosUser := s.fundUsers(ctx, fundAmount, polkadotChain, cosmosChain)
-
 	// TODO: this can be refactored to broadcast a MsgTransfer instead of CLI.
 	// https://github.com/cosmos/ibc-go/issues/4963
+	// Send 1.77 stake from cosmosUser to parachainUser
 	amountToSend := int64(1_770_000)
 	transfer := ibc.WalletAmount{
 		Address: polkadotUser.FormattedAddress(),
 		Denom:   cosmosChain.Config().Denom,
 		Amount:  math.NewInt(amountToSend),
 	}
-
-	pathName := s.GetPathName(0)
-
-	err = r.GeneratePath(ctx, eRep, cosmosChain.Config().ChainID, polkadotChain.Config().ChainID, pathName)
+	tx, err := cosmosChain.SendIBCTransfer(ctx, "channel-0", cosmosUser.KeyName(), transfer, ibc.TransferOptions{})
+	s.Require().NoError(err)
+	s.Require().NoError(tx.Validate()) // test source wallet has decreased funds
+	err = testutil.WaitForBlocks(ctx, 15, cosmosChain, polkadotChain)
 	s.Require().NoError(err)
 
-	// Create new clients
-	err = r.CreateClients(ctx, eRep, pathName, ibc.DefaultClientOpts())
+	// Verify tokens arrived on parachain user
+	parachainUserStake, err := polkadotChain.GetIbcBalance(ctx, string(polkadotUser.Address()), 2)
 	s.Require().NoError(err)
-	err = testutil.WaitForBlocks(ctx, 1, cosmosChain, polkadotChain) // these 1 block waits seem to be needed to reduce flakiness
-	s.Require().NoError(err)
+	s.Require().Equal(amountToSend, parachainUserStake.Amount.Int64(), "parachain user's stake amount not expected after first tx")
 
-	// Create a new connection
-	err = r.CreateConnections(ctx, eRep, pathName)
-	s.Require().NoError(err)
-	err = testutil.WaitForBlocks(ctx, 1, cosmosChain, polkadotChain)
-	s.Require().NoError(err)
-
-	// Create a new channel & get channels from each chain
-	err = r.CreateChannel(ctx, eRep, pathName, ibc.DefaultChannelOpts())
-	s.Require().NoError(err)
-	err = testutil.WaitForBlocks(ctx, 1, cosmosChain, polkadotChain)
+	// Send 1.16 stake from parachainUser to cosmosUser
+	amountToReflect := int64(1_160_000)
+	reflectTransfer := ibc.WalletAmount{
+		Address: cosmosUser.FormattedAddress(),
+		Denom:   "2", // stake
+		Amount:  math.NewInt(amountToReflect),
+	}
+	_, err = polkadotChain.SendIBCTransfer(ctx, "channel-0", polkadotUser.KeyName(), reflectTransfer, ibc.TransferOptions{})
 	s.Require().NoError(err)
 
-	// Start relayer
-	s.Require().NoError(r.StartRelayer(ctx, eRep, pathName))
+	// Send 1.88 "UNIT" from Alice to cosmosUser
+	amountUnits := math.NewInt(1_880_000_000_000)
+	unitTransfer := ibc.WalletAmount{
+		Address: cosmosUser.FormattedAddress(),
+		Denom:   "1", // UNIT
+		Amount:  amountUnits,
+	}
+	_, err = polkadotChain.SendIBCTransfer(ctx, "channel-0", "alice", unitTransfer, ibc.TransferOptions{})
+	s.Require().NoError(err)
 
-	t.Run("IBC transfer from Cosmos chain to Polkadot parachain times out", func(t *testing.T) {
-		// Stop relayer
-		s.Require().NoError(r.StopRelayer(ctx, s.GetRelayerExecReporter()))
-
-		tx, err := cosmosChain.SendIBCTransfer(ctx, "channel-0", cosmosUser.KeyName(), transfer, ibc.TransferOptions{Timeout: testvalues.ImmediatelyTimeout()})
-		s.Require().NoError(err)
-		s.Require().NoError(tx.Validate(), "source ibc transfer tx is invalid")
-		time.Sleep(time.Nanosecond * 1) // want it to timeout immediately
-
-		// check that tokens are escrowed
-		actualBalance, err := cosmosChain.GetBalance(ctx, cosmosUser.FormattedAddress(), cosmosChain.Config().Denom)
-		s.Require().NoError(err)
-		expected := fundAmount - amountToSend
-		s.Require().Equal(expected, actualBalance.Int64())
-
-		// start relayer
-		s.Require().NoError(r.StartRelayer(ctx, s.GetRelayerExecReporter(), s.GetPathName(0)))
-		err = testutil.WaitForBlocks(ctx, 15, polkadotChain, cosmosChain)
-		s.Require().NoError(err)
-
-		// ensure that receiver on parachain did not receive any tokens
-		receiverBalance, err := polkadotChain.GetIbcBalance(ctx, polkadotUser.FormattedAddress(), 2)
-		s.Require().NoError(err)
-		s.Require().Equal(int64(0), receiverBalance.Amount.Int64())
-
-		// check that tokens have been refunded to sender address
-		senderBalance, err := cosmosChain.GetBalance(ctx, cosmosUser.FormattedAddress(), cosmosChain.Config().Denom)
-		s.Require().NoError(err)
-		s.Require().Equal(fundAmount, senderBalance.Int64())
+	// Wait for MsgRecvPacket on cosmos chain
+	finalStakeBal := math.NewInt(fundAmount - amountToSend + amountToReflect)
+	err = cosmos.PollForBalance(ctx, cosmosChain, 20, ibc.WalletAmount{
+		Address: cosmosUser.FormattedAddress(),
+		Denom:   cosmosChain.Config().Denom,
+		Amount:  finalStakeBal,
 	})
+	s.Require().NoError(err)
+
+	// Wait for a new update state
+	err = testutil.WaitForBlocks(ctx, 5, cosmosChain, polkadotChain)
+	s.Require().NoError(err)
+
+	// Verify cosmos user's final "stake" balance
+	cosmosUserStakeBal, err := cosmosChain.GetBalance(ctx, cosmosUser.FormattedAddress(), cosmosChain.Config().Denom)
+	s.Require().NoError(err)
+	s.Require().True(cosmosUserStakeBal.Equal(finalStakeBal))
+
+	// Verify cosmos user's final "unit" balance
+	unitDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom("transfer", "channel-0", "UNIT"))
+	cosmosUserUnitBal, err := cosmosChain.GetBalance(ctx, cosmosUser.FormattedAddress(), unitDenomTrace.IBCDenom())
+	s.Require().NoError(err)
+	s.Require().True(cosmosUserUnitBal.Equal(amountUnits))
+
+	// Verify parachain user's final "unit" balance (will be less than expected due gas costs for stake tx)
+	parachainUserUnits, err := polkadotChain.GetIbcBalance(ctx, string(polkadotUser.Address()), 1)
+	s.Require().NoError(err)
+	s.Require().True(parachainUserUnits.Amount.LTE(math.NewInt(fundAmount)), "parachain user's final unit amount not expected")
+
+	// Verify parachain user's final "stake" balance
+	parachainUserStake, err = polkadotChain.GetIbcBalance(ctx, string(polkadotUser.Address()), 2)
+	s.Require().NoError(err)
+	s.Require().True(parachainUserStake.Amount.Equal(math.NewInt(amountToSend-amountToReflect)), "parachain user's final stake amount not expected")
 }
 
 // TestMsgMigrateContract_Success_GrandpaContract features
@@ -353,9 +234,9 @@ func (s *GrandpaTestSuite) TestMsgMigrateContract_Success_GrandpaContract() {
 
 	s.InitGRPCClients(cosmosChain)
 
-	cosmosWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount)
+	cosmosWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount, chainB)
 
-	file, err := os.Open("contracts/ics10_grandpa_cw.wasm.gz")
+	file, err := os.Open("contracts/ics10_grandpa_cw.wasm")
 	s.Require().NoError(err)
 
 	checksum := s.PushNewWasmClientProposal(ctx, cosmosChain, cosmosWallet, file)
@@ -440,9 +321,9 @@ func (s *GrandpaTestSuite) TestMsgMigrateContract_ContractError_GrandpaContract(
 
 	s.InitGRPCClients(cosmosChain)
 
-	cosmosWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount)
+	cosmosWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount, chainB)
 
-	file, err := os.Open("contracts/ics10_grandpa_cw.wasm.gz")
+	file, err := os.Open("contracts/ics10_grandpa_cw.wasm")
 	s.Require().NoError(err)
 	checksum := s.PushNewWasmClientProposal(ctx, cosmosChain, cosmosWallet, file)
 
@@ -527,7 +408,7 @@ func (s *GrandpaTestSuite) TestRecoverClient_Succeeds_GrandpaContract() {
 
 	s.InitGRPCClients(cosmosChain)
 
-	cosmosWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount)
+	cosmosWallet := s.CreateUserOnChainB(ctx, testvalues.StartingTokenAmount, chainB)
 
 	file, err := os.Open("contracts/ics10_grandpa_cw_expiry.wasm.gz")
 	s.Require().NoError(err)

--- a/e2e/testsuite/tx.go
+++ b/e2e/testsuite/tx.go
@@ -33,7 +33,48 @@ import (
 
 // BroadcastMessages broadcasts the provided messages to the given chain and signs them on behalf of the provided user.
 // Once the broadcast response is returned, we wait for a few blocks to be created on both chain A and chain B.
-func (s *E2ETestSuite) BroadcastMessages(ctx context.Context, chain ibc.Chain, user ibc.Wallet, msgs ...sdk.Msg) sdk.TxResponse {
+func (s *E2ETestSuite) BroadcastMessages(ctx context.Context, chainA ibc.Chain, user ibc.Wallet, chainB ibc.Chain, msgs ...sdk.Msg) sdk.TxResponse {
+	cosmosChain, ok := chainA.(*cosmos.CosmosChain)
+	if !ok {
+		panic("BroadcastMessages expects a cosmos.CosmosChain")
+	}
+
+	broadcaster := cosmos.NewBroadcaster(s.T(), cosmosChain)
+
+	// strip out any fields that may not be supported for the given chain version.
+	msgs = sanitize.Messages(cosmosChain.Nodes()[0].Image.Version, msgs...)
+
+	broadcaster.ConfigureClientContextOptions(func(clientContext client.Context) client.Context {
+		// use a codec with all the types our tests care about registered.
+		// BroadcastTx will deserialize the response and will not be able to otherwise.
+		cdc := Codec()
+		return clientContext.WithCodec(cdc).WithTxConfig(authtx.NewTxConfig(cdc, []signingtypes.SignMode{signingtypes.SignMode_SIGN_MODE_DIRECT}))
+	})
+
+	broadcaster.ConfigureFactoryOptions(func(factory tx.Factory) tx.Factory {
+		return factory.WithGas(DefaultGasValue)
+	})
+
+	// Retry the operation a few times if the user signing the transaction is a relayer. (See issue #3264)
+	var resp sdk.TxResponse
+	var err error
+	broadcastFunc := func() (sdk.TxResponse, error) {
+		return cosmos.BroadcastTx(ctx, broadcaster, user, msgs...)
+	}
+	if s.relayers.ContainsRelayer(s.T().Name(), user) {
+		// Retry five times, the value of 5 chosen is arbitrary.
+		resp, err = s.retryNtimes(broadcastFunc, 5)
+	} else {
+		resp, err = broadcastFunc()
+	}
+	s.Require().NoError(err)
+
+	s.Require().NoError(test.WaitForBlocks(ctx, 2, chainA, chainB))
+
+	return resp
+}
+
+func (s *E2ETestSuite) BroadcastMessagesWithoutChainAB(ctx context.Context, chain ibc.Chain, user ibc.Wallet, msgs ...sdk.Msg) sdk.TxResponse {
 	cosmosChain, ok := chain.(*cosmos.CosmosChain)
 	if !ok {
 		panic("BroadcastMessages expects a cosmos.CosmosChain")
@@ -70,6 +111,7 @@ func (s *E2ETestSuite) BroadcastMessages(ctx context.Context, chain ibc.Chain, u
 	s.Require().NoError(err)
 
 	chainA, chainB := s.GetChains()
+
 	s.Require().NoError(test.WaitForBlocks(ctx, 2, chainA, chainB))
 
 	return resp
@@ -169,7 +211,7 @@ func (s *E2ETestSuite) ExecuteGovV1Proposal(ctx context.Context, msg sdk.Msg, ch
 	)
 	s.Require().NoError(err)
 
-	resp := s.BroadcastMessages(ctx, cosmosChain, user, msgSubmitProposal)
+	resp := s.BroadcastMessagesWithoutChainAB(ctx, cosmosChain, user, msgSubmitProposal)
 	s.AssertTxSuccess(resp)
 
 	s.Require().NoError(cosmosChain.VoteOnProposalAllValidators(ctx, strconv.Itoa(int(proposalID)), cosmos.ProposalVoteYes))
@@ -201,7 +243,39 @@ func (s *E2ETestSuite) waitForGovV1ProposalToPass(ctx context.Context, chain ibc
 
 // ExecuteAndPassGovV1Beta1Proposal submits the given v1beta1 governance proposal using the provided user and uses all validators to vote yes on the proposal.
 // It ensures the proposal successfully passes.
-func (s *E2ETestSuite) ExecuteAndPassGovV1Beta1Proposal(ctx context.Context, chain ibc.Chain, user ibc.Wallet, content govtypesv1beta1.Content) {
+func (s *E2ETestSuite) ExecuteAndPassGovV1Beta1Proposal(ctx context.Context, chainA ibc.Chain, user ibc.Wallet, content govtypesv1beta1.Content, chainB ibc.Chain) {
+	cosmosChain, ok := chainA.(*cosmos.CosmosChain)
+	if !ok {
+		panic("ExecuteAndPassGovV1Beta1Proposal must be passed a cosmos.CosmosChain")
+	}
+	fmt.Println("1111")
+	proposalID := s.proposalIDs[chainA.Config().ChainID]
+	defer func() {
+		s.proposalIDs[chainA.Config().ChainID] = proposalID + 1
+	}()
+	fmt.Println("1111")
+	txResp := s.ExecuteGovV1Beta1Proposal(ctx, cosmosChain, user, content, chainB)
+	s.AssertTxSuccess(txResp)
+	// TODO: replace with parsed proposal ID from MsgSubmitProposalResponse
+	// https://github.com/cosmos/ibc-go/issues/2122
+	fmt.Println("1111")
+	proposal, err := s.QueryProposalV1Beta1(ctx, cosmosChain, proposalID)
+	s.Require().NoError(err)
+	s.Require().Equal(govtypesv1beta1.StatusVotingPeriod, proposal.Status)
+	fmt.Println("1111")
+	err = cosmosChain.VoteOnProposalAllValidators(ctx, fmt.Sprintf("%d", proposalID), cosmos.ProposalVoteYes)
+	s.Require().NoError(err)
+	fmt.Println("1111")
+	// ensure voting period has not passed before validators finished voting
+	proposal, err = s.QueryProposalV1Beta1(ctx, cosmosChain, proposalID)
+	s.Require().NoError(err)
+	s.Require().Equal(govtypesv1beta1.StatusVotingPeriod, proposal.Status)
+
+	err = s.waitForGovV1Beta1ProposalToPass(ctx, cosmosChain, proposalID)
+	s.Require().NoError(err)
+}
+
+func (s *E2ETestSuite) ExecuteAndPassGovV1Beta1ProposalWithoutChainAB(ctx context.Context, chain ibc.Chain, user ibc.Wallet, content govtypesv1beta1.Content) {
 	cosmosChain, ok := chain.(*cosmos.CosmosChain)
 	if !ok {
 		panic("ExecuteAndPassGovV1Beta1Proposal must be passed a cosmos.CosmosChain")
@@ -212,7 +286,7 @@ func (s *E2ETestSuite) ExecuteAndPassGovV1Beta1Proposal(ctx context.Context, cha
 		s.proposalIDs[chain.Config().ChainID] = proposalID + 1
 	}()
 
-	txResp := s.ExecuteGovV1Beta1Proposal(ctx, cosmosChain, user, content)
+	txResp := s.ExecuteGovV1Beta1ProposalWithoutChainAB(ctx, cosmosChain, user, content)
 	s.AssertTxSuccess(txResp)
 
 	// TODO: replace with parsed proposal ID from MsgSubmitProposalResponse
@@ -248,40 +322,51 @@ func (s *E2ETestSuite) waitForGovV1Beta1ProposalToPass(ctx context.Context, chai
 }
 
 // ExecuteGovV1Beta1Proposal submits a v1beta1 governance proposal using the provided content.
-func (s *E2ETestSuite) ExecuteGovV1Beta1Proposal(ctx context.Context, chain ibc.Chain, user ibc.Wallet, content govtypesv1beta1.Content) sdk.TxResponse {
+func (s *E2ETestSuite) ExecuteGovV1Beta1Proposal(ctx context.Context, chainA ibc.Chain, user ibc.Wallet, content govtypesv1beta1.Content, chainB ibc.Chain) sdk.TxResponse {
+	sender, err := sdk.AccAddressFromBech32(user.FormattedAddress())
+	s.Require().NoError(err)
+
+	msgSubmitProposal, err := govtypesv1beta1.NewMsgSubmitProposal(content, sdk.NewCoins(sdk.NewCoin(chainA.Config().Denom, govtypesv1beta1.DefaultMinDepositTokens)), sender)
+	s.Require().NoError(err)
+
+	return s.BroadcastMessages(ctx, chainA, user, chainB, msgSubmitProposal)
+}
+
+func (s *E2ETestSuite) ExecuteGovV1Beta1ProposalWithoutChainAB(ctx context.Context, chain ibc.Chain, user ibc.Wallet, content govtypesv1beta1.Content) sdk.TxResponse {
 	sender, err := sdk.AccAddressFromBech32(user.FormattedAddress())
 	s.Require().NoError(err)
 
 	msgSubmitProposal, err := govtypesv1beta1.NewMsgSubmitProposal(content, sdk.NewCoins(sdk.NewCoin(chain.Config().Denom, govtypesv1beta1.DefaultMinDepositTokens)), sender)
 	s.Require().NoError(err)
 
-	return s.BroadcastMessages(ctx, chain, user, msgSubmitProposal)
+	return s.BroadcastMessagesWithoutChainAB(ctx, chain, user, msgSubmitProposal)
 }
 
 // Transfer broadcasts a MsgTransfer message.
-func (s *E2ETestSuite) Transfer(ctx context.Context, chain ibc.Chain, user ibc.Wallet,
-	portID, channelID string, token sdk.Coin, sender, receiver string, timeoutHeight clienttypes.Height, timeoutTimestamp uint64, memo string,
+func (s *E2ETestSuite) Transfer(ctx context.Context, chainA ibc.Chain, user ibc.Wallet,
+	portID, channelID string, token sdk.Coin, sender, receiver string, timeoutHeight clienttypes.Height, timeoutTimestamp uint64, memo string, chainB ibc.Chain,
 ) sdk.TxResponse {
 	msg := transfertypes.NewMsgTransfer(portID, channelID, token, sender, receiver, timeoutHeight, timeoutTimestamp, memo)
-	return s.BroadcastMessages(ctx, chain, user, msg)
+	return s.BroadcastMessages(ctx, chainA, user, chainB, msg)
 }
 
 // RegisterCounterPartyPayee broadcasts a MsgRegisterCounterpartyPayee message.
-func (s *E2ETestSuite) RegisterCounterPartyPayee(ctx context.Context, chain ibc.Chain,
-	user ibc.Wallet, portID, channelID, relayerAddr, counterpartyPayeeAddr string,
+func (s *E2ETestSuite) RegisterCounterPartyPayee(ctx context.Context, chainA ibc.Chain,
+	user ibc.Wallet, portID, channelID, relayerAddr, counterpartyPayeeAddr string, chainB ibc.Chain,
 ) sdk.TxResponse {
 	msg := feetypes.NewMsgRegisterCounterpartyPayee(portID, channelID, relayerAddr, counterpartyPayeeAddr)
-	return s.BroadcastMessages(ctx, chain, user, msg)
+	return s.BroadcastMessages(ctx, chainA, user, chainB, msg)
 }
 
 // PayPacketFeeAsync broadcasts a MsgPayPacketFeeAsync message.
 func (s *E2ETestSuite) PayPacketFeeAsync(
 	ctx context.Context,
-	chain ibc.Chain,
+	chainA ibc.Chain,
 	user ibc.Wallet,
 	packetID channeltypes.PacketId,
 	packetFee feetypes.PacketFee,
+	chainB ibc.Chain,
 ) sdk.TxResponse {
 	msg := feetypes.NewMsgPayPacketFeeAsync(packetID, packetFee)
-	return s.BroadcastMessages(ctx, chain, user, msg)
+	return s.BroadcastMessages(ctx, chainA, user, chainB, msg)
 }


### PR DESCRIPTION


## Description
Restructure to run 1 test suite per runner. And we can still run individual tests the way we do now locally.

Implementation the following:

1. Setup of test suite would create docker resources
2. Setup of test would create a new channel/connection
3. Perform test as usual with the addition of t.Parallel()

closes: #5062 


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
