### PR TITLE
fix: add MsgPruneAcknowledgements to codec registration

### DIFF
--- a/modules/core/04-channel/types/codec.go
+++ b/modules/core/04-channel/types/codec.go
@@ -46,6 +46,7 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		&MsgChannelUpgradeOpen{},
 		&MsgChannelUpgradeTimeout{},
 		&MsgChannelUpgradeCancel{},
+		&MsgPruneAcknowledgements{},
 		&MsgUpdateParams{},
 	)
 

--- a/modules/core/04-channel/types/codec_test.go
+++ b/modules/core/04-channel/types/codec_test.go
@@ -84,6 +84,51 @@ func TestCodecTypeRegistration(t *testing.T) {
 			true,
 		},
 		{
+			"success: MsgChannelUpgradeInit",
+			sdk.MsgTypeURL(&types.MsgChannelUpgradeInit{}),
+			true,
+		},
+		{
+			"success: MsgChannelUpgradeTry",
+			sdk.MsgTypeURL(&types.MsgChannelUpgradeTry{}),
+			true,
+		},
+		{
+			"success: MsgChannelUpgradeAck",
+			sdk.MsgTypeURL(&types.MsgChannelUpgradeAck{}),
+			true,
+		},
+		{
+			"success: MsgChannelUpgradeConfirm",
+			sdk.MsgTypeURL(&types.MsgChannelUpgradeConfirm{}),
+			true,
+		},
+		{
+			"success: MsgChannelUpgradeOpen",
+			sdk.MsgTypeURL(&types.MsgChannelUpgradeOpen{}),
+			true,
+		},
+		{
+			"success: MsgChannelUpgradeTimeout",
+			sdk.MsgTypeURL(&types.MsgChannelUpgradeTimeout{}),
+			true,
+		},
+		{
+			"success: MsgChannelUpgradeCancel",
+			sdk.MsgTypeURL(&types.MsgChannelUpgradeCancel{}),
+			true,
+		},
+		{
+			"success: MsgPruneAcknowledgements",
+			sdk.MsgTypeURL(&types.MsgPruneAcknowledgements{}),
+			true,
+		},
+		{
+			"success: MsgUpdateParams",
+			sdk.MsgTypeURL(&types.MsgUpdateParams{}),
+			true,
+		},
+		{
 			"type not registered on codec",
 			"ibc.invalid.MsgTypeURL",
 			false,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Added missing codec registration.
- Added tests

<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
