### PR TITLE
test: added tests for `UpdateChannelParams`

### DIFF
--- a/modules/core/keeper/msg_server_test.go
+++ b/modules/core/keeper/msg_server_test.go
@@ -2056,13 +2056,18 @@ func (suite *KeeperTestSuite) TestUpdateChannelParams() {
 		tc := tc
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
-			_, err := keeper.Keeper.UpdateChannelParams(*suite.chainA.App.GetIBCKeeper(), suite.chainA.GetContext(), tc.msg)
+
+			resp, err := keeper.Keeper.UpdateChannelParams(*suite.chainA.App.GetIBCKeeper(), suite.chainA.GetContext(), tc.msg)
+
 			if tc.expPass {
 				suite.Require().NoError(err)
+				suite.Require().NotNil(resp)
+
 				p := suite.chainA.App.GetIBCKeeper().ChannelKeeper.GetParams(suite.chainA.GetContext())
 				suite.Require().Equal(tc.msg.Params, p)
 			} else {
 				suite.Require().Error(err)
+				suite.Require().Nil(resp)
 			}
 		})
 	}

--- a/modules/core/keeper/msg_server_test.go
+++ b/modules/core/keeper/msg_server_test.go
@@ -2017,6 +2017,57 @@ func (suite *KeeperTestSuite) TestUpdateConnectionParams() {
 	}
 }
 
+// TestUpdateChannelParams tests the UpdateChannelParams rpc handler
+func (suite *KeeperTestSuite) TestUpdateChannelParams() {
+	authority := suite.chainA.App.GetIBCKeeper().GetAuthority()
+	testCases := []struct {
+		name    string
+		msg     *channeltypes.MsgUpdateParams
+		expPass bool
+	}{
+		{
+			"success: valid authority and default params",
+			channeltypes.NewMsgUpdateChannelParams(authority, channeltypes.DefaultParams()),
+			true,
+		},
+		{
+			"failure: malformed authority address",
+			channeltypes.NewMsgUpdateChannelParams(ibctesting.InvalidID, channeltypes.DefaultParams()),
+			false,
+		},
+		{
+			"failure: empty authority address",
+			channeltypes.NewMsgUpdateChannelParams("", channeltypes.DefaultParams()),
+			false,
+		},
+		{
+			"failure: whitespace authority address",
+			channeltypes.NewMsgUpdateChannelParams("    ", channeltypes.DefaultParams()),
+			false,
+		},
+		{
+			"failure: unauthorized authority address",
+			channeltypes.NewMsgUpdateChannelParams(ibctesting.TestAccAddress, channeltypes.DefaultParams()),
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+			_, err := keeper.Keeper.UpdateChannelParams(*suite.chainA.App.GetIBCKeeper(), suite.chainA.GetContext(), tc.msg)
+			if tc.expPass {
+				suite.Require().NoError(err)
+				p := suite.chainA.App.GetIBCKeeper().ChannelKeeper.GetParams(suite.chainA.GetContext())
+				suite.Require().Equal(tc.msg.Params, p)
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}
+
 func (suite *KeeperTestSuite) TestPruneAcknowledgements() {
 	var msg *channeltypes.MsgPruneAcknowledgements
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Added tests for `UpdateChannelParams` in [msg_server_test.go](https://github.com/cosmos/ibc-go/blob/28f757a52c1075e78aa16322f1adab35a6e94e7d/modules/core/keeper/msg_server_test.go).

closes: #5479

### Commit Message / Changelog Entry

```text
test: added tests for `UpdateChannelParams`
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [X] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [X] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [X] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Review `Codecov Report` in the comment section below once CI passes.
