### PR TITLE
chore: recurring typo

### DIFF
--- a/docs/docs/01-ibc/10-roadmap.md
+++ b/docs/docs/01-ibc/10-roadmap.md
@@ -7,7 +7,7 @@ slug: /ibc/roadmap
 
 # Roadmap ibc-go
 
-*Lastest update: December 4th, 2023*
+*Latest update: December 4th, 2023*
 
 This document endeavours to inform the wider IBC community about plans and priorities for work on ibc-go by the team at Interchain GmbH. It is intended to broadly inform all users of ibc-go, including developers and operators of IBC, relayer, chain and wallet applications.
 

--- a/modules/light-clients/07-tendermint/tendermint.pb.go
+++ b/modules/light-clients/07-tendermint/tendermint.pb.go
@@ -38,7 +38,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type ClientState struct {
 	ChainId    string   `protobuf:"bytes,1,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
 	TrustLevel Fraction `protobuf:"bytes,2,opt,name=trust_level,json=trustLevel,proto3" json:"trust_level"`
-	// duration of the period since the LastestTimestamp during which the
+	// duration of the period since the LatestTimestamp during which the
 	// submitted headers are valid for upgrade
 	TrustingPeriod time.Duration `protobuf:"bytes,3,opt,name=trusting_period,json=trustingPeriod,proto3,stdduration" json:"trusting_period"`
 	// duration of the staking unbonding period

--- a/proto/ibc/lightclients/tendermint/v1/tendermint.proto
+++ b/proto/ibc/lightclients/tendermint/v1/tendermint.proto
@@ -20,7 +20,7 @@ message ClientState {
 
   string   chain_id    = 1;
   Fraction trust_level = 2 [(gogoproto.nullable) = false];
-  // duration of the period since the LastestTimestamp during which the
+  // duration of the period since the LatestTimestamp during which the
   // submitted headers are valid for upgrade
   google.protobuf.Duration trusting_period = 3 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
   // duration of the staking unbonding period

--- a/testing/endpoint.go
+++ b/testing/endpoint.go
@@ -62,7 +62,7 @@ func NewDefaultEndpoint(chain *TestChain) *Endpoint {
 	}
 }
 
-// QueryProof queries proof associated with this endpoint using the lastest client state
+// QueryProof queries proof associated with this endpoint using the latest client state
 // height on the counterparty chain.
 func (endpoint *Endpoint) QueryProof(key []byte) ([]byte, clienttypes.Height) {
 	// obtain the counterparty client representing the chain associated with the endpoint


### PR DESCRIPTION
Fixed one recurring typo "lastest". It also appears in the versioned_docs but I believe I shouldn't edit them.
Doesn't require testing or changelog entry.
Have a nice evening.