### PR TITLE
chore: split key and path functions in separate files

### DIFF
--- a/modules/core/24-host/channel_keys.go
+++ b/modules/core/24-host/channel_keys.go
@@ -1,49 +1,13 @@
 package host
 
-import "fmt"
-
-const (
-	KeyChannelEndPrefix        = "channelEnds"
-	KeyChannelPrefix           = "channels"
-	KeyChannelUpgradePrefix    = "channelUpgrades"
-	KeyUpgradePrefix           = "upgrades"
-	KeyUpgradeErrorPrefix      = "upgradeError"
-	KeyCounterpartyUpgrade     = "counterpartyUpgrade"
-	KeyChannelCapabilityPrefix = "capabilities"
-)
-
-// ICS04
-// The following paths are the keys to the store as defined in https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#store-paths
-
-// ChannelPath defines the path under which channels are stored
-func ChannelPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s", KeyChannelEndPrefix, channelPath(portID, channelID))
-}
-
 // ChannelKey returns the store key for a particular channel
 func ChannelKey(portID, channelID string) []byte {
 	return []byte(ChannelPath(portID, channelID))
 }
 
-// ChannelCapabilityPath defines the path under which capability keys associated
-// with a channel are stored
-func ChannelCapabilityPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s", KeyChannelCapabilityPrefix, channelPath(portID, channelID))
-}
-
-// ChannelUpgradeErrorPath defines the path under which the ErrorReceipt is stored in the case that a chain does not accept the proposed upgrade
-func ChannelUpgradeErrorPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s/%s", KeyChannelUpgradePrefix, KeyUpgradeErrorPrefix, channelPath(portID, channelID))
-}
-
 // ChannelUpgradeErrorKey returns the store key for a particular channelEnd used to stor the ErrorReceipt in the case that a chain does not accept the proposed upgrade
 func ChannelUpgradeErrorKey(portID, channelID string) []byte {
 	return []byte(ChannelUpgradeErrorPath(portID, channelID))
-}
-
-// ChannelUpgradePath defines the path which stores the information related to an upgrade attempt
-func ChannelUpgradePath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s/%s", KeyChannelUpgradePrefix, KeyUpgradePrefix, channelPath(portID, channelID))
 }
 
 // ChannelUpgradeKey returns the store key for a particular channel upgrade attempt
@@ -54,13 +18,4 @@ func ChannelUpgradeKey(portID, channelID string) []byte {
 // ChannelCounterpartyUpgradeKey returns the store key for the upgrade used on the counterparty channel.
 func ChannelCounterpartyUpgradeKey(portID, channelID string) []byte {
 	return []byte(ChannelCounterpartyUpgradePath(portID, channelID))
-}
-
-// ChannelCounterpartyUpgradePath defines the path under which the upgrade used on the counterparty channel is stored.
-func ChannelCounterpartyUpgradePath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s/%s", KeyChannelUpgradePrefix, KeyCounterpartyUpgrade, channelPath(portID, channelID))
-}
-
-func channelPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s/%s/%s", KeyPortPrefix, portID, KeyChannelPrefix, channelID)
 }

--- a/modules/core/24-host/channel_paths.go
+++ b/modules/core/24-host/channel_paths.go
@@ -1,0 +1,46 @@
+package host
+
+import "fmt"
+
+const (
+	KeyChannelEndPrefix        = "channelEnds"
+	KeyChannelPrefix           = "channels"
+	KeyChannelUpgradePrefix    = "channelUpgrades"
+	KeyUpgradePrefix           = "upgrades"
+	KeyUpgradeErrorPrefix      = "upgradeError"
+	KeyCounterpartyUpgrade     = "counterpartyUpgrade"
+	KeyChannelCapabilityPrefix = "capabilities"
+)
+
+// ICS04
+// The following paths are the keys to the store as defined in https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#store-paths
+
+// ChannelPath defines the path under which channels are stored
+func ChannelPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s", KeyChannelEndPrefix, channelPath(portID, channelID))
+}
+
+// ChannelCapabilityPath defines the path under which capability keys associated
+// with a channel are stored
+func ChannelCapabilityPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s", KeyChannelCapabilityPrefix, channelPath(portID, channelID))
+}
+
+// ChannelUpgradeErrorPath defines the path under which the ErrorReceipt is stored in the case that a chain does not accept the proposed upgrade
+func ChannelUpgradeErrorPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s/%s", KeyChannelUpgradePrefix, KeyUpgradeErrorPrefix, channelPath(portID, channelID))
+}
+
+// ChannelUpgradePath defines the path which stores the information related to an upgrade attempt
+func ChannelUpgradePath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s/%s", KeyChannelUpgradePrefix, KeyUpgradePrefix, channelPath(portID, channelID))
+}
+
+// ChannelCounterpartyUpgradePath defines the path under which the upgrade used on the counterparty channel is stored.
+func ChannelCounterpartyUpgradePath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s/%s", KeyChannelUpgradePrefix, KeyCounterpartyUpgrade, channelPath(portID, channelID))
+}
+
+func channelPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", KeyPortPrefix, portID, KeyChannelPrefix, channelID)
+}

--- a/modules/core/24-host/client_keys.go
+++ b/modules/core/24-host/client_keys.go
@@ -1,24 +1,8 @@
 package host
 
 import (
-	"fmt"
-
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
 )
-
-// KeyClientStorePrefix defines the KVStore key prefix for IBC clients
-var KeyClientStorePrefix = []byte("clients")
-
-const (
-	KeyClientState          = "clientState"
-	KeyConsensusStatePrefix = "consensusStates"
-)
-
-// FullClientPath returns the full path of a specific client path in the format:
-// "clients/{clientID}/{path}" as a string.
-func FullClientPath(clientID string, path string) string {
-	return fmt.Sprintf("%s/%s/%s", KeyClientStorePrefix, clientID, path)
-}
 
 // FullClientKey returns the full path of specific client path in the format:
 // "clients/{clientID}/{path}" as a byte array.
@@ -26,27 +10,11 @@ func FullClientKey(clientID string, path []byte) []byte {
 	return []byte(FullClientPath(clientID, string(path)))
 }
 
-// PrefixedClientStorePath returns a key path which can be used for prefixed
-// key store iteration. The prefix may be a clientType, clientID, or any
-// valid key prefix which may be concatenated with the client store constant.
-func PrefixedClientStorePath(prefix []byte) string {
-	return fmt.Sprintf("%s/%s", KeyClientStorePrefix, prefix)
-}
-
 // PrefixedClientStoreKey returns a key which can be used for prefixed
 // key store iteration. The prefix may be a clientType, clientID, or any
 // valid key prefix which may be concatenated with the client store constant.
 func PrefixedClientStoreKey(prefix []byte) []byte {
 	return []byte(PrefixedClientStorePath(prefix))
-}
-
-// ICS02
-// The following paths are the keys to the store as defined in https://github.com/cosmos/ibc/tree/master/spec/core/ics-002-client-semantics#path-space
-
-// FullClientStatePath takes a client identifier and returns a Path under which to store a
-// particular client state
-func FullClientStatePath(clientID string) string {
-	return FullClientPath(clientID, KeyClientState)
 }
 
 // FullClientStateKey takes a client identifier and returns a Key under which to store a
@@ -61,22 +29,10 @@ func ClientStateKey() []byte {
 	return []byte(KeyClientState)
 }
 
-// FullConsensusStatePath takes a client identifier and returns a Path under which to
-// store the consensus state of a client.
-func FullConsensusStatePath(clientID string, height exported.Height) string {
-	return FullClientPath(clientID, ConsensusStatePath(height))
-}
-
 // FullConsensusStateKey returns the store key for the consensus state of a particular
 // client.
 func FullConsensusStateKey(clientID string, height exported.Height) []byte {
 	return []byte(FullConsensusStatePath(clientID, height))
-}
-
-// ConsensusStatePath returns the suffix store key for the consensus state at a
-// particular height stored in a client prefixed store.
-func ConsensusStatePath(height exported.Height) string {
-	return fmt.Sprintf("%s/%s", KeyConsensusStatePrefix, height)
 }
 
 // ConsensusStateKey returns the store key for a the consensus state of a particular

--- a/modules/core/24-host/client_paths.go
+++ b/modules/core/24-host/client_paths.go
@@ -1,0 +1,49 @@
+package host
+
+import (
+	"fmt"
+
+	"github.com/cosmos/ibc-go/v8/modules/core/exported"
+)
+
+// KeyClientStorePrefix defines the KVStore key prefix for IBC clients
+var KeyClientStorePrefix = []byte("clients")
+
+const (
+	KeyClientState          = "clientState"
+	KeyConsensusStatePrefix = "consensusStates"
+)
+
+// FullClientPath returns the full path of a specific client path in the format:
+// "clients/{clientID}/{path}" as a string.
+func FullClientPath(clientID string, path string) string {
+	return fmt.Sprintf("%s/%s/%s", KeyClientStorePrefix, clientID, path)
+}
+
+// PrefixedClientStorePath returns a key path which can be used for prefixed
+// key store iteration. The prefix may be a clientType, clientID, or any
+// valid key prefix which may be concatenated with the client store constant.
+func PrefixedClientStorePath(prefix []byte) string {
+	return fmt.Sprintf("%s/%s", KeyClientStorePrefix, prefix)
+}
+
+// ICS02
+// The following paths are the keys to the store as defined in https://github.com/cosmos/ibc/tree/master/spec/core/ics-002-client-semantics#path-space
+
+// FullClientStatePath takes a client identifier and returns a Path under which to store a
+// particular client state
+func FullClientStatePath(clientID string) string {
+	return FullClientPath(clientID, KeyClientState)
+}
+
+// FullConsensusStatePath takes a client identifier and returns a Path under which to
+// store the consensus state of a client.
+func FullConsensusStatePath(clientID string, height exported.Height) string {
+	return FullClientPath(clientID, ConsensusStatePath(height))
+}
+
+// ConsensusStatePath returns the suffix store key for the consensus state at a
+// particular height stored in a client prefixed store.
+func ConsensusStatePath(height exported.Height) string {
+	return fmt.Sprintf("%s/%s", KeyConsensusStatePrefix, height)
+}

--- a/modules/core/24-host/connection_keys.go
+++ b/modules/core/24-host/connection_keys.go
@@ -1,25 +1,8 @@
 package host
 
-import "fmt"
-
-const KeyConnectionPrefix = "connections"
-
-// ICS03
-// The following paths are the keys to the store as defined in https://github.com/cosmos/ibc/blob/master/spec/core/ics-003-connection-semantics#store-paths
-
-// ClientConnectionsPath defines a reverse mapping from clients to a set of connections
-func ClientConnectionsPath(clientID string) string {
-	return FullClientPath(clientID, KeyConnectionPrefix)
-}
-
 // ClientConnectionsKey returns the store key for the connections of a given client
 func ClientConnectionsKey(clientID string) []byte {
 	return []byte(ClientConnectionsPath(clientID))
-}
-
-// ConnectionPath defines the path under which connection paths are stored
-func ConnectionPath(connectionID string) string {
-	return fmt.Sprintf("%s/%s", KeyConnectionPrefix, connectionID)
 }
 
 // ConnectionKey returns the store key for a particular connection

--- a/modules/core/24-host/connection_paths.go
+++ b/modules/core/24-host/connection_paths.go
@@ -1,0 +1,18 @@
+package host
+
+import "fmt"
+
+const KeyConnectionPrefix = "connections"
+
+// ICS03
+// The following paths are the keys to the store as defined in https://github.com/cosmos/ibc/blob/master/spec/core/ics-003-connection-semantics#store-paths
+
+// ClientConnectionsPath defines a reverse mapping from clients to a set of connections
+func ClientConnectionsPath(clientID string) string {
+	return FullClientPath(clientID, KeyConnectionPrefix)
+}
+
+// ConnectionPath defines the path under which connection paths are stored
+func ConnectionPath(connectionID string) string {
+	return fmt.Sprintf("%s/%s", KeyConnectionPrefix, connectionID)
+}

--- a/modules/core/24-host/packet_keys.go
+++ b/modules/core/24-host/packet_keys.go
@@ -1,36 +1,9 @@
 package host
 
-import "fmt"
-
-const (
-	KeySequencePrefix         = "sequences"
-	KeyNextSeqSendPrefix      = "nextSequenceSend"
-	KeyNextSeqRecvPrefix      = "nextSequenceRecv"
-	KeyNextSeqAckPrefix       = "nextSequenceAck"
-	KeyPacketCommitmentPrefix = "commitments"
-	KeyPacketAckPrefix        = "acks"
-	KeyPacketReceiptPrefix    = "receipts"
-	KeyPruningSequenceStart   = "pruningSequenceStart"
-	KeyPruningSequenceEnd     = "pruningSequenceEnd"
-)
-
-// ICS04
-// The following paths are the keys to the store as defined in https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#store-paths
-
-// NextSequenceSendPath defines the next send sequence counter store path
-func NextSequenceSendPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s", KeyNextSeqSendPrefix, channelPath(portID, channelID))
-}
-
 // NextSequenceSendKey returns the store key for the send sequence of a particular
 // channel binded to a specific port.
 func NextSequenceSendKey(portID, channelID string) []byte {
 	return []byte(NextSequenceSendPath(portID, channelID))
-}
-
-// NextSequenceRecvPath defines the next receive sequence counter store path.
-func NextSequenceRecvPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s", KeyNextSeqRecvPrefix, channelPath(portID, channelID))
 }
 
 // NextSequenceRecvKey returns the store key for the receive sequence of a particular
@@ -39,20 +12,10 @@ func NextSequenceRecvKey(portID, channelID string) []byte {
 	return []byte(NextSequenceRecvPath(portID, channelID))
 }
 
-// NextSequenceAckPath defines the next acknowledgement sequence counter store path
-func NextSequenceAckPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s", KeyNextSeqAckPrefix, channelPath(portID, channelID))
-}
-
 // NextSequenceAckKey returns the store key for the acknowledgement sequence of
 // a particular channel binded to a specific port.
 func NextSequenceAckKey(portID, channelID string) []byte {
 	return []byte(NextSequenceAckPath(portID, channelID))
-}
-
-// PacketCommitmentPath defines the commitments to packet data fields store path
-func PacketCommitmentPath(portID, channelID string, sequence uint64) string {
-	return fmt.Sprintf("%s/%d", PacketCommitmentPrefixPath(portID, channelID), sequence)
 }
 
 // PacketCommitmentKey returns the store key of under which a packet commitment
@@ -61,30 +24,10 @@ func PacketCommitmentKey(portID, channelID string, sequence uint64) []byte {
 	return []byte(PacketCommitmentPath(portID, channelID, sequence))
 }
 
-// PacketCommitmentPrefixPath defines the prefix for commitments to packet data fields store path.
-func PacketCommitmentPrefixPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s/%s", KeyPacketCommitmentPrefix, channelPath(portID, channelID), KeySequencePrefix)
-}
-
-// PacketAcknowledgementPath defines the packet acknowledgement store path
-func PacketAcknowledgementPath(portID, channelID string, sequence uint64) string {
-	return fmt.Sprintf("%s/%d", PacketAcknowledgementPrefixPath(portID, channelID), sequence)
-}
-
 // PacketAcknowledgementKey returns the store key of under which a packet
 // acknowledgement is stored
 func PacketAcknowledgementKey(portID, channelID string, sequence uint64) []byte {
 	return []byte(PacketAcknowledgementPath(portID, channelID, sequence))
-}
-
-// PacketAcknowledgementPrefixPath defines the prefix for commitments to packet data fields store path.
-func PacketAcknowledgementPrefixPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s/%s", KeyPacketAckPrefix, channelPath(portID, channelID), KeySequencePrefix)
-}
-
-// PacketReceiptPath defines the packet receipt store path
-func PacketReceiptPath(portID, channelID string, sequence uint64) string {
-	return fmt.Sprintf("%s/%s/%s", KeyPacketReceiptPrefix, channelPath(portID, channelID), sequencePath(sequence))
 }
 
 // PacketReceiptKey returns the store key of under which a packet
@@ -93,26 +36,12 @@ func PacketReceiptKey(portID, channelID string, sequence uint64) []byte {
 	return []byte(PacketReceiptPath(portID, channelID, sequence))
 }
 
-// PruningSequenceStartPath defines the path under which the pruning sequence starting value is stored
-func PruningSequenceStartPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s", KeyPruningSequenceStart, channelPath(portID, channelID))
-}
-
 // PruningSequenceStartKey returns the store key for the pruning sequence start of a particular channel
 func PruningSequenceStartKey(portID, channelID string) []byte {
 	return []byte(PruningSequenceStartPath(portID, channelID))
 }
 
-// PruningSequenceEndPath defines the path under which the pruning sequence end is stored
-func PruningSequenceEndPath(portID, channelID string) string {
-	return fmt.Sprintf("%s/%s", KeyPruningSequenceEnd, channelPath(portID, channelID))
-}
-
 // PruningSequenceEndKey returns the store key for the pruning sequence end of a particular channel
 func PruningSequenceEndKey(portID, channelID string) []byte {
 	return []byte(PruningSequenceEndPath(portID, channelID))
-}
-
-func sequencePath(sequence uint64) string {
-	return fmt.Sprintf("%s/%d", KeySequencePrefix, sequence)
 }

--- a/modules/core/24-host/packet_paths.go
+++ b/modules/core/24-host/packet_paths.go
@@ -1,0 +1,72 @@
+package host
+
+import "fmt"
+
+const (
+	KeySequencePrefix         = "sequences"
+	KeyNextSeqSendPrefix      = "nextSequenceSend"
+	KeyNextSeqRecvPrefix      = "nextSequenceRecv"
+	KeyNextSeqAckPrefix       = "nextSequenceAck"
+	KeyPacketCommitmentPrefix = "commitments"
+	KeyPacketAckPrefix        = "acks"
+	KeyPacketReceiptPrefix    = "receipts"
+	KeyPruningSequenceStart   = "pruningSequenceStart"
+	KeyPruningSequenceEnd     = "pruningSequenceEnd"
+)
+
+// ICS04
+// The following paths are the keys to the store as defined in https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#store-paths
+
+// NextSequenceSendPath defines the next send sequence counter store path
+func NextSequenceSendPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s", KeyNextSeqSendPrefix, channelPath(portID, channelID))
+}
+
+// NextSequenceRecvPath defines the next receive sequence counter store path.
+func NextSequenceRecvPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s", KeyNextSeqRecvPrefix, channelPath(portID, channelID))
+}
+
+// NextSequenceAckPath defines the next acknowledgement sequence counter store path
+func NextSequenceAckPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s", KeyNextSeqAckPrefix, channelPath(portID, channelID))
+}
+
+// PacketCommitmentPath defines the commitments to packet data fields store path
+func PacketCommitmentPath(portID, channelID string, sequence uint64) string {
+	return fmt.Sprintf("%s/%d", PacketCommitmentPrefixPath(portID, channelID), sequence)
+}
+
+// PacketCommitmentPrefixPath defines the prefix for commitments to packet data fields store path.
+func PacketCommitmentPrefixPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s/%s", KeyPacketCommitmentPrefix, channelPath(portID, channelID), KeySequencePrefix)
+}
+
+// PacketAcknowledgementPath defines the packet acknowledgement store path
+func PacketAcknowledgementPath(portID, channelID string, sequence uint64) string {
+	return fmt.Sprintf("%s/%d", PacketAcknowledgementPrefixPath(portID, channelID), sequence)
+}
+
+// PacketAcknowledgementPrefixPath defines the prefix for commitments to packet data fields store path.
+func PacketAcknowledgementPrefixPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s/%s", KeyPacketAckPrefix, channelPath(portID, channelID), KeySequencePrefix)
+}
+
+// PacketReceiptPath defines the packet receipt store path
+func PacketReceiptPath(portID, channelID string, sequence uint64) string {
+	return fmt.Sprintf("%s/%s/%s", KeyPacketReceiptPrefix, channelPath(portID, channelID), sequencePath(sequence))
+}
+
+// PruningSequenceStartPath defines the path under which the pruning sequence starting value is stored
+func PruningSequenceStartPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s", KeyPruningSequenceStart, channelPath(portID, channelID))
+}
+
+// PruningSequenceEndPath defines the path under which the pruning sequence end is stored
+func PruningSequenceEndPath(portID, channelID string) string {
+	return fmt.Sprintf("%s/%s", KeyPruningSequenceEnd, channelPath(portID, channelID))
+}
+
+func sequencePath(sequence uint64) string {
+	return fmt.Sprintf("%s/%d", KeySequencePrefix, sequence)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

A quick low-hanging fruit PR to close a golden oldie issue. From all the points mentioned in the issue the only one that is still valid is splitting the `...Key` and `...Path` functions in separate files. If team prefers not to have separate files, that's also fine; I will then just close the PR and the corresponding issue.

closes: #28 


### Commit Message / Changelog Entry

```text
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
