### PR TITLE
Refactor UpgradeError to use bullt in errors functions

### DIFF
--- a/modules/core/04-channel/types/upgrade.go
+++ b/modules/core/04-channel/types/upgrade.go
@@ -83,13 +83,21 @@ func (u *UpgradeError) Error() string {
 	return u.err.Error()
 }
 
-// Is returns true if the underlying error is of the given err type.
-func (u *UpgradeError) Is(err error) bool {
-	return errors.Is(u.err, err)
+// Is returns true if the of the provided error is an upgrade error.
+func (*UpgradeError) Is(err error) bool {
+	_, ok := err.(*UpgradeError)
+	return ok
 }
 
-// Unwrap returns the base error that caused the upgrade to fail.
+// Unwrap returns the next error in the error chain.
+// If there is no next error, Unwrap returns nil.
 func (u *UpgradeError) Unwrap() error {
+	return u.err
+}
+
+// Cause implements the sdk error interface which uses this function to unwrap the error in various functions such as `wrappedError.Is()`.
+// Cause returns the underlying error which caused the upgrade to fail.
+func (u *UpgradeError) Cause() error {
 	baseError := u.err
 	for {
 		if err := errors.Unwrap(baseError); err != nil {
@@ -98,12 +106,6 @@ func (u *UpgradeError) Unwrap() error {
 			return baseError
 		}
 	}
-}
-
-// Cause implements the sdk error interface which uses this function to unwrap the error in various functions such as `wrappedError.Is()`.
-// Cause returns the underlying error which caused the upgrade to fail.
-func (u *UpgradeError) Cause() error {
-	return u.err
 }
 
 // GetErrorReceipt returns an error receipt with the code from the underlying error type stripped.
@@ -122,14 +124,5 @@ func (u *UpgradeError) GetErrorReceipt() ErrorReceipt {
 // IsUpgradeError returns true if err is of type UpgradeError or contained
 // in the error chain of err and false otherwise.
 func IsUpgradeError(err error) bool {
-	for {
-		_, ok := err.(*UpgradeError)
-		if ok {
-			return true
-		}
-
-		if err = errors.Unwrap(err); err == nil {
-			return false
-		}
-	}
+	return errors.Is(err, &UpgradeError{})
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR does a refactor to utilize the `errors.Is` and `errors.Unwrap`  functions.

@DimitrisJim pointed out we were using the `Unrwap` and `Cause` incorrectly. The implementations have been updated to reflect their intended use case.


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
