### PR TITLE
02-client routing: implement `RecoverClient` in light client modules

### DIFF
--- a/modules/core/02-client/keeper/client.go
+++ b/modules/core/02-client/keeper/client.go
@@ -187,10 +187,9 @@ func (k Keeper) RecoverClient(ctx sdk.Context, subjectClientID, substituteClient
 		return errorsmod.Wrapf(types.ErrClientNotFound, "clientID (%s)", subjectClientID)
 	}
 
-	// TODO: change after https://github.com/cosmos/ibc-go/pull/5817 is merged
-	lightClientModule, found := k.router.GetRoute(clientType)
+	lightClientModule, found := k.router.GetRoute(subjectClientID)
 	if !found {
-		return errorsmod.Wrap(types.ErrRouteNotFound, clientType)
+		return errorsmod.Wrap(types.ErrRouteNotFound, subjectClientID)
 	}
 
 	if err := lightClientModule.RecoverClient(ctx, subjectClientID, substituteClientID); err != nil {

--- a/modules/core/02-client/keeper/client_test.go
+++ b/modules/core/02-client/keeper/client_test.go
@@ -591,7 +591,7 @@ func (suite *KeeperTestSuite) TestRecoverClient() {
 			func() {
 				substitute = ibctesting.InvalidID
 			},
-			clienttypes.ErrClientNotFound,
+			clienttypes.ErrClientNotActive,
 		},
 		{
 			"subject and substitute have equal latest height",

--- a/modules/core/02-client/keeper/client_test.go
+++ b/modules/core/02-client/keeper/client_test.go
@@ -594,26 +594,6 @@ func (suite *KeeperTestSuite) TestRecoverClient() {
 			clienttypes.ErrClientNotActive,
 		},
 		{
-			"subject and substitute have equal latest height",
-			func() {
-				tmClientState, ok := subjectClientState.(*ibctm.ClientState)
-				suite.Require().True(ok)
-				tmClientState.LatestHeight = substituteClientState.GetLatestHeight().(clienttypes.Height)
-				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subject, tmClientState)
-			},
-			clienttypes.ErrInvalidHeight,
-		},
-		{
-			"subject height is greater than substitute height",
-			func() {
-				tmClientState, ok := subjectClientState.(*ibctm.ClientState)
-				suite.Require().True(ok)
-				tmClientState.LatestHeight = substituteClientState.GetLatestHeight().Increment().(clienttypes.Height)
-				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subject, tmClientState)
-			},
-			clienttypes.ErrInvalidHeight,
-		},
-		{
 			"substitute is frozen",
 			func() {
 				tmClientState, ok := substituteClientState.(*ibctm.ClientState)
@@ -624,7 +604,7 @@ func (suite *KeeperTestSuite) TestRecoverClient() {
 			clienttypes.ErrClientNotActive,
 		},
 		{
-			"CheckSubstituteAndUpdateState fails, substitute client trust level doesn't match subject client trust level",
+			"light client module RecoverClient fails, substitute client trust level doesn't match subject client trust level",
 			func() {
 				tmClientState, ok := substituteClientState.(*ibctm.ClientState)
 				suite.Require().True(ok)

--- a/modules/core/exported/client.go
+++ b/modules/core/exported/client.go
@@ -148,10 +148,6 @@ type ClientState interface {
 	// Used to verify upgrades
 	ZeroCustomFields() ClientState
 
-	// CheckSubstituteAndUpdateState must verify that the provided substitute may be used to update the subject client.
-	// The light client must set the updated client and consensus states within the clientStore for the subject client.
-	CheckSubstituteAndUpdateState(ctx sdk.Context, cdc codec.BinaryCodec, subjectClientStore, substituteClientStore storetypes.KVStore, substituteClient ClientState) error
-
 	// Upgrade functions
 	// NOTE: proof heights are not included as upgrade to a new revision is expected to pass only on the last
 	// height committed by the current revision. Clients are responsible for ensuring that the planned last

--- a/modules/core/exported/client.go
+++ b/modules/core/exported/client.go
@@ -110,9 +110,8 @@ type LightClientModule interface {
 		height Height, // TODO: change to concrete type
 	) (uint64, error)
 
-	// CheckSubstituteAndUpdateState must verify that the provided substitute may be used to update the subject client.
+	// RecoverClient must verify that the provided substitute may be used to update the subject client.
 	// The light client must set the updated client and consensus states within the clientStore for the subject client.
-	// DEPRECATED: will be removed as performs internal functionality
 	RecoverClient(ctx sdk.Context, clientID, substituteClientID string) error
 
 	// Upgrade functions

--- a/modules/light-clients/06-solomachine/light_client_module.go
+++ b/modules/light-clients/06-solomachine/light_client_module.go
@@ -215,11 +215,44 @@ func validateClientID(clientID string) error {
 	return nil
 }
 
-// // CheckSubstituteAndUpdateState must verify that the provided substitute may be used to update the subject client.
-// // The light client must set the updated client and consensus states within the clientStore for the subject client.
-// // DEPRECATED: will be removed as performs internal functionality
-func (l LightClientModule) RecoverClient(ctx sdk.Context, clientID, substituteClientID string) error {
-	return nil
+// RecoverClient must verify that the provided substitute may be used to update the subject client.
+// The light client must set the updated client and consensus states within the clientStore for the subject client.
+func (lcm LightClientModule) RecoverClient(ctx sdk.Context, clientID, substituteClientID string) error {
+	clientType, _, err := clienttypes.ParseClientIdentifier(clientID)
+	if err != nil {
+		return err
+	}
+
+	if clientType != exported.Solomachine {
+		return errorsmod.Wrapf(clienttypes.ErrInvalidClientType, "expected: %s, got: %s", exported.Solomachine, clientType)
+	}
+
+	substituteClientType, _, err := clienttypes.ParseClientIdentifier(substituteClientID)
+	if err != nil {
+		return err
+	}
+
+	if substituteClientType != exported.Solomachine {
+		return errorsmod.Wrapf(clienttypes.ErrInvalidClientType, "expected: %s, got: %s", exported.Solomachine, substituteClientType)
+	}
+
+	clientStore := lcm.storeProvider.ClientStore(ctx, clientID)
+	clientState, found := getClientState(clientStore, lcm.cdc)
+	if !found {
+		return errorsmod.Wrap(clienttypes.ErrClientNotFound, clientID)
+	}
+
+	substituteClientStore := lcm.storeProvider.ClientStore(ctx, substituteClientID)
+	substituteClient, found := getClientState(substituteClientStore, lcm.cdc)
+	if !found {
+		return errorsmod.Wrap(clienttypes.ErrClientNotFound, substituteClientID)
+	}
+
+	if clientState.GetLatestHeight().GTE(substituteClient.GetLatestHeight()) {
+		return errorsmod.Wrapf(clienttypes.ErrInvalidHeight, "subject client state latest height is greater or equal to substitute client state latest height (%s >= %s)", clientState.GetLatestHeight(), substituteClient.GetLatestHeight())
+	}
+
+	return clientState.CheckSubstituteAndUpdateState(ctx, lcm.cdc, clientStore, substituteClientStore, substituteClient)
 }
 
 // // Upgrade functions

--- a/modules/light-clients/06-solomachine/light_client_module_test.go
+++ b/modules/light-clients/06-solomachine/light_client_module_test.go
@@ -107,7 +107,7 @@ func (suite *SoloMachineTestSuite) TestRecoverClient() {
 
 			substituteClientID = suite.chainA.App.GetIBCKeeper().ClientKeeper.GenerateClientIdentifier(ctx, exported.Solomachine)
 			substitute := ibctesting.NewSolomachine(suite.T(), suite.chainA.Codec, substituteClientID, "testing", 1)
-			substitute.Sequence += 1 // increase sequence so that latest height of substitute is > than subject's latest height
+			substitute.Sequence++ // increase sequence so that latest height of substitute is > than subject's latest height
 			substituteClientState = substitute.ClientState()
 
 			clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(ctx, substituteClientID)

--- a/modules/light-clients/06-solomachine/light_client_module_test.go
+++ b/modules/light-clients/06-solomachine/light_client_module_test.go
@@ -9,9 +9,8 @@ import (
 )
 
 const (
-	smClientID        = "06-solomachine-100"
-	wasmClientID      = "08-wasm-0"
-	malformedClientID = "malformed-clientid"
+	smClientID   = "06-solomachine-100"
+	wasmClientID = "08-wasm-0"
 )
 
 func (suite *SoloMachineTestSuite) TestRecoverClient() {
@@ -34,7 +33,7 @@ func (suite *SoloMachineTestSuite) TestRecoverClient() {
 		{
 			"cannot parse malformed subject client ID",
 			func() {
-				subjectClientID = malformedClientID
+				subjectClientID = ibctesting.InvalidID
 			},
 			host.ErrInvalidID,
 		},
@@ -48,7 +47,7 @@ func (suite *SoloMachineTestSuite) TestRecoverClient() {
 		{
 			"cannot parse malformed substitute client ID",
 			func() {
-				substituteClientID = malformedClientID
+				substituteClientID = ibctesting.InvalidID
 			},
 			host.ErrInvalidID,
 		},

--- a/modules/light-clients/06-solomachine/light_client_module_test.go
+++ b/modules/light-clients/06-solomachine/light_client_module_test.go
@@ -1,0 +1,149 @@
+package solomachine_test
+
+import (
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
+	"github.com/cosmos/ibc-go/v8/modules/core/exported"
+	solomachine "github.com/cosmos/ibc-go/v8/modules/light-clients/06-solomachine"
+	ibctesting "github.com/cosmos/ibc-go/v8/testing"
+)
+
+const (
+	smClientID        = "06-solomachine-100"
+	wasmClientID      = "08-wasm-0"
+	malformedClientID = "malformed-clientid"
+)
+
+func (suite *SoloMachineTestSuite) TestRecoverClient() {
+	var (
+		subjectClientID, substituteClientID       string
+		subjectClientState, substituteClientState exported.ClientState
+	)
+
+	testCases := []struct {
+		name     string
+		malleate func()
+		expErr   error
+	}{
+		{
+			"success",
+			func() {
+			},
+			nil,
+		},
+		{
+			"cannot parse malformed subject client ID",
+			func() {
+				subjectClientID = malformedClientID
+			},
+			host.ErrInvalidID,
+		},
+		{
+			"subject client ID does not contain 06-machine prefix",
+			func() {
+				subjectClientID = wasmClientID
+			},
+			clienttypes.ErrInvalidClientType,
+		},
+		{
+			"cannot parse malformed substitute client ID",
+			func() {
+				substituteClientID = malformedClientID
+			},
+			host.ErrInvalidID,
+		},
+		{
+			"substitute client ID does not contain 06-solomachine prefix",
+			func() {
+				substituteClientID = wasmClientID
+			},
+			clienttypes.ErrInvalidClientType,
+		},
+		{
+			"cannot find subject client state",
+			func() {
+				subjectClientID = smClientID
+			},
+			clienttypes.ErrClientNotFound,
+		},
+		{
+			"cannot find substitute client state",
+			func() {
+				substituteClientID = smClientID
+			},
+			clienttypes.ErrClientNotFound,
+		},
+		{
+			"subject and substitute have equal latest height",
+			func() {
+				smClientState, ok := subjectClientState.(*solomachine.ClientState)
+				suite.Require().True(ok)
+				smClientState.Sequence = substituteClientState.GetLatestHeight().GetRevisionHeight()
+				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectClientID, smClientState)
+			},
+			clienttypes.ErrInvalidHeight,
+		},
+		{
+			"subject height is greater than substitute height",
+			func() {
+				smClientState, ok := subjectClientState.(*solomachine.ClientState)
+				suite.Require().True(ok)
+				smClientState.Sequence = substituteClientState.GetLatestHeight().GetRevisionHeight() + 1
+				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectClientID, smClientState)
+			},
+			clienttypes.ErrInvalidHeight,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupTest() // reset
+			cdc := suite.chainA.Codec
+			ctx := suite.chainA.GetContext()
+
+			subjectClientID = suite.chainA.App.GetIBCKeeper().ClientKeeper.GenerateClientIdentifier(ctx, exported.Solomachine)
+			subject := ibctesting.NewSolomachine(suite.T(), suite.chainA.Codec, substituteClientID, "testing", 1)
+			subjectClientState = subject.ClientState()
+
+			substituteClientID = suite.chainA.App.GetIBCKeeper().ClientKeeper.GenerateClientIdentifier(ctx, exported.Solomachine)
+			substitute := ibctesting.NewSolomachine(suite.T(), suite.chainA.Codec, substituteClientID, "testing", 1)
+			substitute.Sequence += 1 // increase sequence so that latest height of substitute is > than subject's latest height
+			substituteClientState = substitute.ClientState()
+
+			clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(ctx, substituteClientID)
+			clientStore.Get(host.ClientStateKey())
+			bz := clienttypes.MustMarshalClientState(cdc, substituteClientState)
+			clientStore.Set(host.ClientStateKey(), bz)
+
+			smClientState, ok := subjectClientState.(*solomachine.ClientState)
+			suite.Require().True(ok)
+			smClientState.IsFrozen = true
+			suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(ctx, subjectClientID, smClientState)
+
+			lightClientModule, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetRouter().GetRoute(subjectClientID)
+			suite.Require().True(found)
+
+			tc.malleate()
+
+			err := lightClientModule.RecoverClient(ctx, subjectClientID, substituteClientID)
+
+			expPass := tc.expErr == nil
+			if expPass {
+				suite.Require().NoError(err)
+
+				// assert that status of subject client is now Active
+				clientStore = suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(ctx, subjectClientID)
+				bz = clientStore.Get(host.ClientStateKey())
+				smClientState := clienttypes.MustUnmarshalClientState(cdc, bz).(*solomachine.ClientState)
+
+				suite.Require().Equal(substituteClientState.(*solomachine.ClientState).ConsensusState, smClientState.ConsensusState)
+				suite.Require().Equal(substituteClientState.(*solomachine.ClientState).Sequence, smClientState.Sequence)
+				suite.Require().Equal(exported.Active, smClientState.Status(ctx, clientStore, cdc))
+			} else {
+				suite.Require().Error(err)
+				suite.Require().ErrorIs(err, tc.expErr)
+			}
+		})
+	}
+}

--- a/modules/light-clients/07-tendermint/light_client_module.go
+++ b/modules/light-clients/07-tendermint/light_client_module.go
@@ -261,9 +261,18 @@ func (lcm LightClientModule) RecoverClient(ctx sdk.Context, clientID, substitute
 		return errorsmod.Wrapf(clienttypes.ErrInvalidClientType, "expected: %s, got: %s", exported.Tendermint, clientType)
 	}
 
-	clientStore := lcm.storeProvider.ClientStore(ctx, clientID)
+	substituteClientType, _, err := clienttypes.ParseClientIdentifier(substituteClientID)
+	if err != nil {
+		return err
+	}
+
+	if substituteClientType != exported.Tendermint {
+		return errorsmod.Wrapf(clienttypes.ErrInvalidClientType, "expected: %s, got: %s", exported.Tendermint, substituteClientType)
+	}
+
 	cdc := lcm.keeper.Codec()
 
+	clientStore := lcm.storeProvider.ClientStore(ctx, clientID)
 	clientState, found := getClientState(clientStore, cdc)
 	if !found {
 		return errorsmod.Wrap(clienttypes.ErrClientNotFound, clientID)
@@ -273,6 +282,10 @@ func (lcm LightClientModule) RecoverClient(ctx sdk.Context, clientID, substitute
 	substituteClient, found := getClientState(substituteClientStore, cdc)
 	if !found {
 		return errorsmod.Wrap(clienttypes.ErrClientNotFound, substituteClientID)
+	}
+
+	if clientState.GetLatestHeight().GTE(substituteClient.GetLatestHeight()) {
+		return errorsmod.Wrapf(clienttypes.ErrInvalidHeight, "subject client state latest height is greater or equal to substitute client state latest height (%s >= %s)", clientState.GetLatestHeight(), substituteClient.GetLatestHeight())
 	}
 
 	return clientState.CheckSubstituteAndUpdateState(ctx, cdc, clientStore, substituteClientStore, substituteClient)

--- a/modules/light-clients/07-tendermint/light_client_module_test.go
+++ b/modules/light-clients/07-tendermint/light_client_module_test.go
@@ -8,9 +8,9 @@ import (
 	ibctesting "github.com/cosmos/ibc-go/v8/testing"
 )
 
-const (
-	tmClientID   = "07-tendermint-100"
-	wasmClientID = "08-wasm-0"
+var (
+	tmClientID          = clienttypes.FormatClientIdentifier(exported.Tendermint, 100)
+	solomachineClientID = clienttypes.FormatClientIdentifier(exported.Solomachine, 0)
 )
 
 func (suite *TendermintTestSuite) TestRecoverClient() {
@@ -40,7 +40,7 @@ func (suite *TendermintTestSuite) TestRecoverClient() {
 		{
 			"subject client ID does not contain 07-tendermint prefix",
 			func() {
-				subjectClientID = wasmClientID
+				subjectClientID = solomachineClientID
 			},
 			clienttypes.ErrInvalidClientType,
 		},
@@ -54,7 +54,7 @@ func (suite *TendermintTestSuite) TestRecoverClient() {
 		{
 			"substitute client ID does not contain 07-tendermint prefix",
 			func() {
-				substituteClientID = wasmClientID
+				substituteClientID = solomachineClientID
 			},
 			clienttypes.ErrInvalidClientType,
 		},

--- a/modules/light-clients/07-tendermint/light_client_module_test.go
+++ b/modules/light-clients/07-tendermint/light_client_module_test.go
@@ -9,9 +9,8 @@ import (
 )
 
 const (
-	tmClientID        = "07-tendermint-100"
-	wasmClientID      = "08-wasm-0"
-	malformedClientID = "malformed-clientid"
+	tmClientID   = "07-tendermint-100"
+	wasmClientID = "08-wasm-0"
 )
 
 func (suite *TendermintTestSuite) TestRecoverClient() {
@@ -34,7 +33,7 @@ func (suite *TendermintTestSuite) TestRecoverClient() {
 		{
 			"cannot parse malformed subject client ID",
 			func() {
-				subjectClientID = malformedClientID
+				subjectClientID = ibctesting.InvalidID
 			},
 			host.ErrInvalidID,
 		},
@@ -48,7 +47,7 @@ func (suite *TendermintTestSuite) TestRecoverClient() {
 		{
 			"cannot parse malformed substitute client ID",
 			func() {
-				substituteClientID = malformedClientID
+				substituteClientID = ibctesting.InvalidID
 			},
 			host.ErrInvalidID,
 		},

--- a/modules/light-clients/07-tendermint/light_client_module_test.go
+++ b/modules/light-clients/07-tendermint/light_client_module_test.go
@@ -1,0 +1,145 @@
+package tendermint_test
+
+import (
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
+	"github.com/cosmos/ibc-go/v8/modules/core/exported"
+	ibctm "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
+	ibctesting "github.com/cosmos/ibc-go/v8/testing"
+)
+
+const (
+	tmClientID        = "07-tendermint-100"
+	wasmClientID      = "08-wasm-0"
+	malformedClientID = "malformed-clientid"
+)
+
+func (suite *TendermintTestSuite) TestRecoverClient() {
+	var (
+		subjectClientID, substituteClientID       string
+		subjectClientState, substituteClientState exported.ClientState
+	)
+
+	testCases := []struct {
+		name     string
+		malleate func()
+		expErr   error
+	}{
+		{
+			"success",
+			func() {
+			},
+			nil,
+		},
+		{
+			"cannot parse malformed subject client ID",
+			func() {
+				subjectClientID = malformedClientID
+			},
+			host.ErrInvalidID,
+		},
+		{
+			"subject client ID does not contain 07-tendermint prefix",
+			func() {
+				subjectClientID = wasmClientID
+			},
+			clienttypes.ErrInvalidClientType,
+		},
+		{
+			"cannot parse malformed substitute client ID",
+			func() {
+				substituteClientID = malformedClientID
+			},
+			host.ErrInvalidID,
+		},
+		{
+			"substitute client ID does not contain 07-tendermint prefix",
+			func() {
+				substituteClientID = wasmClientID
+			},
+			clienttypes.ErrInvalidClientType,
+		},
+		{
+			"cannot find subject client state",
+			func() {
+				subjectClientID = tmClientID
+			},
+			clienttypes.ErrClientNotFound,
+		},
+		{
+			"cannot find substitute client state",
+			func() {
+				substituteClientID = tmClientID
+			},
+			clienttypes.ErrClientNotFound,
+		},
+		{
+			"subject and substitute have equal latest height",
+			func() {
+				tmClientState, ok := subjectClientState.(*ibctm.ClientState)
+				suite.Require().True(ok)
+				tmClientState.LatestHeight = substituteClientState.GetLatestHeight().(clienttypes.Height)
+				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectClientID, tmClientState)
+			},
+			clienttypes.ErrInvalidHeight,
+		},
+		{
+			"subject height is greater than substitute height",
+			func() {
+				tmClientState, ok := subjectClientState.(*ibctm.ClientState)
+				suite.Require().True(ok)
+				tmClientState.LatestHeight = substituteClientState.GetLatestHeight().Increment().(clienttypes.Height)
+				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectClientID, tmClientState)
+			},
+			clienttypes.ErrInvalidHeight,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupTest() // reset
+
+			subjectPath := ibctesting.NewPath(suite.chainA, suite.chainB)
+			subjectPath.SetupClients()
+			subjectClientID = subjectPath.EndpointA.ClientID
+			subjectClientState = suite.chainA.GetClientState(subjectClientID)
+
+			substitutePath := ibctesting.NewPath(suite.chainA, suite.chainB)
+			substitutePath.SetupClients()
+			substituteClientID = substitutePath.EndpointA.ClientID
+
+			// // update substitute twice
+			// err := substitutePath.EndpointA.UpdateClient()
+			// suite.Require().NoError(err)
+			// err = substitutePath.EndpointA.UpdateClient()
+			// suite.Require().NoError(err)
+			substituteClientState = suite.chainA.GetClientState(substituteClientID)
+
+			tmClientState, ok := subjectClientState.(*ibctm.ClientState)
+			suite.Require().True(ok)
+			tmClientState.FrozenHeight = tmClientState.LatestHeight
+			suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectPath.EndpointA.ClientID, tmClientState)
+
+			lightClientModule, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetRouter().GetRoute(subjectClientID)
+			suite.Require().True(found)
+
+			tc.malleate()
+
+			err := lightClientModule.RecoverClient(suite.chainA.GetContext(), subjectClientID, substituteClientID)
+
+			expPass := tc.expErr == nil
+			if expPass {
+				suite.Require().NoError(err)
+
+				// assert that status of subject client is now Active
+				clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), subjectClientID)
+				tmClientState := subjectPath.EndpointA.GetClientState().(*ibctm.ClientState)
+				suite.Require().Equal(tmClientState.Status(suite.chainA.GetContext(), clientStore, suite.chainA.App.AppCodec()), exported.Active)
+			} else {
+				suite.Require().Error(err)
+				suite.Require().ErrorIs(err, tc.expErr)
+			}
+		})
+	}
+}

--- a/modules/light-clients/08-wasm/light_client_module.go
+++ b/modules/light-clients/08-wasm/light_client_module.go
@@ -234,11 +234,47 @@ func validateClientID(clientID string) error {
 	return nil
 }
 
-// // CheckSubstituteAndUpdateState must verify that the provided substitute may be used to update the subject client.
-// // The light client must set the updated client and consensus states within the clientStore for the subject client.
-// // DEPRECATED: will be removed as performs internal functionality
-func (l LightClientModule) RecoverClient(ctx sdk.Context, clientID, substituteClientID string) error {
-	return nil
+// RecoverClient must verify that the provided substitute may be used to update the subject client.
+// The light client must set the updated client and consensus states within the clientStore for the subject client.
+func (lcm LightClientModule) RecoverClient(ctx sdk.Context, clientID, substituteClientID string) error {
+	clientType, _, err := clienttypes.ParseClientIdentifier(clientID)
+	if err != nil {
+		return err
+	}
+
+	if clientType != types.Wasm {
+		return errorsmod.Wrapf(clienttypes.ErrInvalidClientType, "expected: %s, got: %s", types.Wasm, clientType)
+	}
+
+	substituteClientType, _, err := clienttypes.ParseClientIdentifier(substituteClientID)
+	if err != nil {
+		return err
+	}
+
+	if substituteClientType != types.Wasm {
+		return errorsmod.Wrapf(clienttypes.ErrInvalidClientType, "expected: %s, got: %s", types.Wasm, substituteClientType)
+	}
+
+	cdc := lcm.keeper.Codec()
+
+	clientStore := lcm.storeProvider.ClientStore(ctx, clientID)
+	clientState, found := types.GetClientState(clientStore, cdc)
+	if !found {
+		return errorsmod.Wrap(clienttypes.ErrClientNotFound, clientID)
+	}
+
+	substituteClientStore := lcm.storeProvider.ClientStore(ctx, substituteClientID)
+	substituteClient, found := types.GetClientState(substituteClientStore, cdc)
+	if !found {
+		return errorsmod.Wrap(clienttypes.ErrClientNotFound, substituteClientID)
+	}
+
+	if clientState.GetLatestHeight().GTE(substituteClient.GetLatestHeight()) {
+		return errorsmod.Wrapf(clienttypes.ErrInvalidHeight, "subject client state latest height is greater or equal to substitute client state latest height (%s >= %s)", clientState.GetLatestHeight(), substituteClient.GetLatestHeight())
+	}
+
+	return clientState.CheckSubstituteAndUpdateState(ctx, cdc, clientStore, substituteClientStore, substituteClient)
+
 }
 
 // // Upgrade functions

--- a/modules/light-clients/08-wasm/light_client_module_test.go
+++ b/modules/light-clients/08-wasm/light_client_module_test.go
@@ -17,7 +17,7 @@ const (
 func (suite *WasmTestSuite) TestRecoverClient() {
 	var (
 		expectedClientStateBz                     []byte
-		subjectEndpoint, substituteEndpoint       *wasmtesting.WasmEndpoint
+		subjectClientID, substituteClientID       string
 		subjectClientState, substituteClientState exported.ClientState
 	)
 
@@ -36,42 +36,42 @@ func (suite *WasmTestSuite) TestRecoverClient() {
 		{
 			"cannot parse malformed subject client ID",
 			func() {
-				subjectEndpoint.ClientID = malformedClientID
+				subjectClientID = malformedClientID
 			},
 			host.ErrInvalidID,
 		},
 		{
 			"subject client ID does not contain 08-wasm prefix",
 			func() {
-				subjectEndpoint.ClientID = tmClientID
+				subjectClientID = tmClientID
 			},
 			clienttypes.ErrInvalidClientType,
 		},
 		{
 			"cannot parse malformed substitute client ID",
 			func() {
-				substituteEndpoint.ClientID = malformedClientID
+				substituteClientID = malformedClientID
 			},
 			host.ErrInvalidID,
 		},
 		{
 			"substitute client ID does not contain 08-wasm prefix",
 			func() {
-				substituteEndpoint.ClientID = tmClientID
+				substituteClientID = tmClientID
 			},
 			clienttypes.ErrInvalidClientType,
 		},
 		{
 			"cannot find subject client state",
 			func() {
-				subjectEndpoint.ClientID = wasmClientID
+				subjectClientID = wasmClientID
 			},
 			clienttypes.ErrClientNotFound,
 		},
 		{
 			"cannot find substitute client state",
 			func() {
-				substituteEndpoint.ClientID = wasmClientID
+				substituteClientID = wasmClientID
 			},
 			clienttypes.ErrClientNotFound,
 		},
@@ -81,7 +81,7 @@ func (suite *WasmTestSuite) TestRecoverClient() {
 				wasmClientState, ok := subjectClientState.(*wasmtypes.ClientState)
 				suite.Require().True(ok)
 				wasmClientState.LatestHeight = substituteClientState.GetLatestHeight().(clienttypes.Height)
-				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectEndpoint.ClientID, wasmClientState)
+				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectClientID, wasmClientState)
 			},
 			clienttypes.ErrInvalidHeight,
 		},
@@ -91,7 +91,7 @@ func (suite *WasmTestSuite) TestRecoverClient() {
 				wasmClientState, ok := subjectClientState.(*wasmtypes.ClientState)
 				suite.Require().True(ok)
 				wasmClientState.LatestHeight = substituteClientState.GetLatestHeight().Increment().(clienttypes.Height)
-				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectEndpoint.ClientID, wasmClientState)
+				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectClientID, wasmClientState)
 			},
 			clienttypes.ErrInvalidHeight,
 		},

--- a/modules/light-clients/08-wasm/light_client_module_test.go
+++ b/modules/light-clients/08-wasm/light_client_module_test.go
@@ -103,25 +103,27 @@ func (suite *WasmTestSuite) TestRecoverClient() {
 			suite.SetupWasmWithMockVM()
 			expectedClientStateBz = nil
 
-			subjectEndpoint = wasmtesting.NewWasmEndpoint(suite.chainA)
+			subjectEndpoint := wasmtesting.NewWasmEndpoint(suite.chainA)
 			err := subjectEndpoint.CreateClient()
 			suite.Require().NoError(err)
+			subjectClientID = subjectEndpoint.ClientID
 
 			subjectClientState = subjectEndpoint.GetClientState()
-			subjectClientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), subjectEndpoint.ClientID)
+			subjectClientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), subjectClientID)
 
-			substituteEndpoint = wasmtesting.NewWasmEndpoint(suite.chainA)
+			substituteEndpoint := wasmtesting.NewWasmEndpoint(suite.chainA)
 			err = substituteEndpoint.CreateClient()
 			suite.Require().NoError(err)
+			substituteClientID = substituteEndpoint.ClientID
 
 			substituteClientState = substituteEndpoint.GetClientState()
 
-			lightClientModule, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetRouter().GetRoute(subjectEndpoint.ClientID)
+			lightClientModule, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetRouter().GetRoute(subjectClientID)
 			suite.Require().True(found)
 
 			tc.malleate()
 
-			err = lightClientModule.RecoverClient(suite.chainA.GetContext(), subjectEndpoint.ClientID, substituteEndpoint.ClientID)
+			err = lightClientModule.RecoverClient(suite.chainA.GetContext(), subjectClientID, substituteClientID)
 
 			expPass := tc.expErr == nil
 			if expPass {

--- a/modules/light-clients/08-wasm/light_client_module_test.go
+++ b/modules/light-clients/08-wasm/light_client_module_test.go
@@ -6,12 +6,12 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
+	ibctesting "github.com/cosmos/ibc-go/v8/testing"
 )
 
 const (
-	tmClientID        = "07-tendermint-0"
-	wasmClientID      = "08-wasm-100"
-	malformedClientID = "malformed-clientid"
+	tmClientID   = "07-tendermint-0"
+	wasmClientID = "08-wasm-100"
 )
 
 func (suite *WasmTestSuite) TestRecoverClient() {
@@ -36,7 +36,7 @@ func (suite *WasmTestSuite) TestRecoverClient() {
 		{
 			"cannot parse malformed subject client ID",
 			func() {
-				subjectClientID = malformedClientID
+				subjectClientID = ibctesting.InvalidID
 			},
 			host.ErrInvalidID,
 		},
@@ -50,7 +50,7 @@ func (suite *WasmTestSuite) TestRecoverClient() {
 		{
 			"cannot parse malformed substitute client ID",
 			func() {
-				substituteClientID = malformedClientID
+				substituteClientID = ibctesting.InvalidID
 			},
 			host.ErrInvalidID,
 		},

--- a/modules/light-clients/08-wasm/light_client_module_test.go
+++ b/modules/light-clients/08-wasm/light_client_module_test.go
@@ -1,0 +1,137 @@
+package wasm_test
+
+import (
+	wasmtesting "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/testing"
+	wasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
+	"github.com/cosmos/ibc-go/v8/modules/core/exported"
+)
+
+const (
+	tmClientID        = "07-tendermint-0"
+	wasmClientID      = "08-wasm-100"
+	malformedClientID = "malformed-clientid"
+)
+
+func (suite *WasmTestSuite) TestRecoverClient() {
+	var (
+		expectedClientStateBz                     []byte
+		subjectEndpoint, substituteEndpoint       *wasmtesting.WasmEndpoint
+		subjectClientState, substituteClientState exported.ClientState
+	)
+
+	testCases := []struct {
+		name     string
+		malleate func()
+		expErr   error
+	}{
+		// TODO(02-client routing): add successful test when light client module does not call into 08-wasm ClientState
+		// {
+		// 	"success",
+		// 	func() {
+		// 	},
+		// 	nil,
+		// },
+		{
+			"cannot parse malformed subject client ID",
+			func() {
+				subjectEndpoint.ClientID = malformedClientID
+			},
+			host.ErrInvalidID,
+		},
+		{
+			"subject client ID does not contain 08-wasm prefix",
+			func() {
+				subjectEndpoint.ClientID = tmClientID
+			},
+			clienttypes.ErrInvalidClientType,
+		},
+		{
+			"cannot parse malformed substitute client ID",
+			func() {
+				substituteEndpoint.ClientID = malformedClientID
+			},
+			host.ErrInvalidID,
+		},
+		{
+			"substitute client ID does not contain 08-wasm prefix",
+			func() {
+				substituteEndpoint.ClientID = tmClientID
+			},
+			clienttypes.ErrInvalidClientType,
+		},
+		{
+			"cannot find subject client state",
+			func() {
+				subjectEndpoint.ClientID = wasmClientID
+			},
+			clienttypes.ErrClientNotFound,
+		},
+		{
+			"cannot find substitute client state",
+			func() {
+				substituteEndpoint.ClientID = wasmClientID
+			},
+			clienttypes.ErrClientNotFound,
+		},
+		{
+			"subject and substitute have equal latest height",
+			func() {
+				wasmClientState, ok := subjectClientState.(*wasmtypes.ClientState)
+				suite.Require().True(ok)
+				wasmClientState.LatestHeight = substituteClientState.GetLatestHeight().(clienttypes.Height)
+				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectEndpoint.ClientID, wasmClientState)
+			},
+			clienttypes.ErrInvalidHeight,
+		},
+		{
+			"subject height is greater than substitute height",
+			func() {
+				wasmClientState, ok := subjectClientState.(*wasmtypes.ClientState)
+				suite.Require().True(ok)
+				wasmClientState.LatestHeight = substituteClientState.GetLatestHeight().Increment().(clienttypes.Height)
+				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), subjectEndpoint.ClientID, wasmClientState)
+			},
+			clienttypes.ErrInvalidHeight,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupWasmWithMockVM()
+			expectedClientStateBz = nil
+
+			subjectEndpoint = wasmtesting.NewWasmEndpoint(suite.chainA)
+			err := subjectEndpoint.CreateClient()
+			suite.Require().NoError(err)
+
+			subjectClientState = subjectEndpoint.GetClientState()
+			subjectClientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), subjectEndpoint.ClientID)
+
+			substituteEndpoint = wasmtesting.NewWasmEndpoint(suite.chainA)
+			err = substituteEndpoint.CreateClient()
+			suite.Require().NoError(err)
+
+			substituteClientState = substituteEndpoint.GetClientState()
+
+			lightClientModule, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetRouter().GetRoute(subjectEndpoint.ClientID)
+			suite.Require().True(found)
+
+			tc.malleate()
+
+			err = lightClientModule.RecoverClient(suite.chainA.GetContext(), subjectEndpoint.ClientID, substituteEndpoint.ClientID)
+
+			expPass := tc.expErr == nil
+			if expPass {
+				suite.Require().NoError(err)
+
+				clientStateBz := subjectClientStore.Get(host.ClientStateKey())
+				suite.Require().Equal(expectedClientStateBz, clientStateBz)
+			} else {
+				suite.Require().ErrorIs(err, tc.expErr)
+			}
+		})
+	}
+}

--- a/modules/light-clients/08-wasm/types/proposal_handle_test.go
+++ b/modules/light-clients/08-wasm/types/proposal_handle_test.go
@@ -95,7 +95,7 @@ func (suite *TypesTestSuite) TestCheckSubstituteAndUpdateState() {
 			suite.Require().NoError(err)
 
 			subjectClientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), endpointA.ClientID)
-			subjectClientState := endpointA.GetClientState()
+			subjectClientState := endpointA.GetClientState().(*types.ClientState)
 
 			substituteEndpoint := wasmtesting.NewWasmEndpoint(suite.chainA)
 			err = substituteEndpoint.CreateClient()

--- a/modules/light-clients/08-wasm/wasm_test.go
+++ b/modules/light-clients/08-wasm/wasm_test.go
@@ -1,0 +1,126 @@
+package wasm_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	wasmvm "github.com/CosmWasm/wasmvm"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	dbm "github.com/cosmos/cosmos-db"
+	testifysuite "github.com/stretchr/testify/suite"
+
+	"cosmossdk.io/log"
+	storetypes "cosmossdk.io/store/types"
+
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	wasmtesting "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/testing"
+	simapp "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/testing/simapp"
+	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
+	"github.com/cosmos/ibc-go/v8/modules/core/exported"
+	ibctesting "github.com/cosmos/ibc-go/v8/testing"
+)
+
+type WasmTestSuite struct {
+	testifysuite.Suite
+	coordinator *ibctesting.Coordinator
+	chainA      *ibctesting.TestChain
+	mockVM      *wasmtesting.MockWasmEngine
+
+	checksum types.Checksum
+}
+
+func TestWasmTestSuite(t *testing.T) {
+	testifysuite.Run(t, new(WasmTestSuite))
+}
+
+func (suite *WasmTestSuite) SetupTest() {
+	ibctesting.DefaultTestingAppInit = setupTestingApp
+
+	suite.coordinator = ibctesting.NewCoordinator(suite.T(), 1)
+	suite.chainA = suite.coordinator.GetChain(ibctesting.GetChainID(1))
+}
+
+func init() {
+	ibctesting.DefaultTestingAppInit = setupTestingApp
+}
+
+// GetSimApp returns the duplicated SimApp from within the 08-wasm directory.
+// This must be used instead of chain.GetSimApp() for tests within this directory.
+func GetSimApp(chain *ibctesting.TestChain) *simapp.SimApp {
+	app, ok := chain.App.(*simapp.SimApp)
+	if !ok {
+		panic(errors.New("chain is not a simapp.SimApp"))
+	}
+	return app
+}
+
+// setupTestingApp provides the duplicated simapp which is specific to the 08-wasm module on chain creation.
+func setupTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {
+	db := dbm.NewMemDB()
+	app := simapp.NewSimApp(log.NewNopLogger(), db, nil, true, simtestutil.EmptyAppOptions{}, nil)
+	return app, app.DefaultGenesis()
+}
+
+// SetupWasmWithMockVM sets up mock cometbft chain with a mock vm.
+func (suite *WasmTestSuite) SetupWasmWithMockVM() {
+	ibctesting.DefaultTestingAppInit = suite.setupWasmWithMockVM
+
+	suite.coordinator = ibctesting.NewCoordinator(suite.T(), 1)
+	suite.chainA = suite.coordinator.GetChain(ibctesting.GetChainID(1))
+	suite.checksum = storeWasmCode(suite, wasmtesting.Code)
+}
+
+func (suite *WasmTestSuite) setupWasmWithMockVM() (ibctesting.TestingApp, map[string]json.RawMessage) {
+	suite.mockVM = wasmtesting.NewMockWasmEngine()
+
+	suite.mockVM.InstantiateFn = func(checksum wasmvm.Checksum, env wasmvmtypes.Env, info wasmvmtypes.MessageInfo, initMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error) {
+		var payload types.InstantiateMessage
+		err := json.Unmarshal(initMsg, &payload)
+		suite.Require().NoError(err)
+
+		wrappedClientState := clienttypes.MustUnmarshalClientState(suite.chainA.App.AppCodec(), payload.ClientState)
+
+		clientState := types.NewClientState(payload.ClientState, payload.Checksum, wrappedClientState.GetLatestHeight().(clienttypes.Height))
+		clientStateBz := clienttypes.MustMarshalClientState(suite.chainA.App.AppCodec(), clientState)
+		store.Set(host.ClientStateKey(), clientStateBz)
+
+		consensusState := types.NewConsensusState(payload.ConsensusState)
+		consensusStateBz := clienttypes.MustMarshalConsensusState(suite.chainA.App.AppCodec(), consensusState)
+		store.Set(host.ConsensusStateKey(clientState.GetLatestHeight()), consensusStateBz)
+
+		resp, err := json.Marshal(types.EmptyResult{})
+		suite.Require().NoError(err)
+
+		return &wasmvmtypes.Response{Data: resp}, 0, nil
+	}
+
+	suite.mockVM.RegisterQueryCallback(types.StatusMsg{}, func(checksum wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
+		resp, err := json.Marshal(types.StatusResult{Status: exported.Active.String()})
+		suite.Require().NoError(err)
+		return resp, wasmtesting.DefaultGasUsed, nil
+	})
+
+	db := dbm.NewMemDB()
+	app := simapp.NewSimApp(log.NewNopLogger(), db, nil, true, simtestutil.EmptyAppOptions{}, suite.mockVM)
+
+	// reset DefaultTestingAppInit to its original value
+	ibctesting.DefaultTestingAppInit = setupTestingApp
+	return app, app.DefaultGenesis()
+}
+
+// storeWasmCode stores the wasm code on chain and returns the checksum.
+func storeWasmCode(suite *WasmTestSuite, wasmCode []byte) types.Checksum {
+	ctx := suite.chainA.GetContext().WithBlockGasMeter(storetypes.NewInfiniteGasMeter())
+
+	msg := types.NewMsgStoreCode(authtypes.NewModuleAddress(govtypes.ModuleName).String(), wasmCode)
+	response, err := GetSimApp(suite.chainA).WasmClientKeeper.StoreCode(ctx, msg)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(response.Checksum)
+	return response.Checksum
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX


### Commit Message / Changelog Entry

```text
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
