### PR TITLE
fix(msg): register proto interface

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/types/codec.go
+++ b/modules/apps/27-interchain-accounts/controller/types/codec.go
@@ -3,6 +3,7 @@ package types
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterInterfaces registers the interchain accounts controller message types using the provided InterfaceRegistry
@@ -13,4 +14,5 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		&MsgSendTx{},
 		&MsgUpdateParams{},
 	)
+	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }


### PR DESCRIPTION
Register the proto interfaces for InterchainAccounts, that way when submitting a transaction and it responds with `MsgRegisterInterchainAccountResponse` or `MsgSendTxResponse` it does not fail with the following error:

![image](https://github.com/cosmos/ibc-go/assets/49301655/d3ac6a8c-8297-4978-9934-7cd3c25fdbb6)
