### PR TITLE
imp: custom self client validation for 08 wasm tendermint clients

### DIFF
--- a/.github/workflows/build-wasm-simd-image-from-tag.yml
+++ b/.github/workflows/build-wasm-simd-image-from-tag.yml
@@ -34,8 +34,11 @@ jobs:
               password: ${{ secrets.GITHUB_TOKEN }}
          - name: Build image
            run: | 
+            version="$(scripts/get-libwasm-version.py --get-version)"
+            checksum="$(scripts/get-libwasm-version.py --get-checksum)"
+             
             # remove all `/` or `+` characters from the docker tag and replace them with a -.
             # this ensures the docker tag is valid.
             docker_tag="$(echo $GIT_TAG | sed 's/[^a-zA-Z0-9\.]/-/g')"
-            make build-docker-wasm tag="${REGISTRY}/${ORG}/${IMAGE_NAME}:${docker_tag}"
+            docker build . -t "${REGISTRY}/${ORG}/${IMAGE_NAME}:${docker_tag}" -f modules/light-clients/08-wasm/Dockerfile --build-arg LIBWASM_VERSION=${version} --build-arg LIBWASM_CHECKSUM=${checksum}
             docker push "${REGISTRY}/${ORG}/${IMAGE_NAME}:${docker_tag}"

--- a/.github/workflows/build-wasm-simd-image-from-tag.yml
+++ b/.github/workflows/build-wasm-simd-image-from-tag.yml
@@ -34,11 +34,8 @@ jobs:
               password: ${{ secrets.GITHUB_TOKEN }}
          - name: Build image
            run: | 
-            version="$(scripts/get-libwasm-version.py --get-version)"
-            checksum="$(scripts/get-libwasm-version.py --get-checksum)"
-             
             # remove all `/` or `+` characters from the docker tag and replace them with a -.
             # this ensures the docker tag is valid.
             docker_tag="$(echo $GIT_TAG | sed 's/[^a-zA-Z0-9\.]/-/g')"
-            docker build . -t "${REGISTRY}/${ORG}/${IMAGE_NAME}:${docker_tag}" -f modules/light-clients/08-wasm/Dockerfile --build-arg LIBWASM_VERSION=${version} --build-arg LIBWASM_CHECKSUM=${checksum}
+            make build-docker-wasm tag="${REGISTRY}/${ORG}/${IMAGE_NAME}:${docker_tag}"
             docker push "${REGISTRY}/${ORG}/${IMAGE_NAME}:${docker_tag}"

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,10 @@ $(BUILD_TARGETS): go.sum $(BUILDDIR)/
 $(BUILDDIR)/:
 	mkdir -p $(BUILDDIR)/
 
+#? build-docker-wasm: Build wasm simapp with specified tag.
+build-docker-wasm:
+	./scripts/build-wasm-simapp-docker.sh $(tag)
+
 .PHONY: build build-linux
 
 #? distclean: Run `make clean`

--- a/modules/light-clients/08-wasm/testing/simapp/app.go
+++ b/modules/light-clients/08-wasm/testing/simapp/app.go
@@ -3,6 +3,7 @@ package simapp
 import (
 	"encoding/json"
 	"fmt"
+	clientkeeper "github.com/cosmos/ibc-go/v8/modules/core/02-client/keeper"
 	"io"
 	"os"
 	"path/filepath"
@@ -416,6 +417,10 @@ func NewSimApp(
 	app.IBCKeeper = ibckeeper.NewKeeper(
 		appCodec, keys[ibcexported.StoreKey], app.GetSubspace(ibcexported.ModuleName), app.StakingKeeper, app.UpgradeKeeper, scopedIBCKeeper, authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
+
+	tmClientValidator := clientkeeper.NewTendermintClientValidator(app.StakingKeeper)
+	app.IBCKeeper.ClientKeeper.SetSelfClientValidator(wasmtypes.NewWasmTMClientValidator(appCodec, tmClientValidator))
+
 	// Register the proposal types
 	// Deprecated: Avoid adding new handlers, instead use the new proposal flow
 	// by granting the governance module the right to execute the message.

--- a/modules/light-clients/08-wasm/testing/simapp/app.go
+++ b/modules/light-clients/08-wasm/testing/simapp/app.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	clientkeeper "github.com/cosmos/ibc-go/v8/modules/core/02-client/keeper"
-
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/spf13/cast"

--- a/modules/light-clients/08-wasm/testing/simapp/app.go
+++ b/modules/light-clients/08-wasm/testing/simapp/app.go
@@ -3,10 +3,11 @@ package simapp
 import (
 	"encoding/json"
 	"fmt"
-	clientkeeper "github.com/cosmos/ibc-go/v8/modules/core/02-client/keeper"
 	"io"
 	"os"
 	"path/filepath"
+
+	clientkeeper "github.com/cosmos/ibc-go/v8/modules/core/02-client/keeper"
 
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/gogoproto/proto"
@@ -129,6 +130,7 @@ import (
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	ibc "github.com/cosmos/ibc-go/v8/modules/core"
 	ibcclient "github.com/cosmos/ibc-go/v8/modules/core/02-client"
+	clientkeeper "github.com/cosmos/ibc-go/v8/modules/core/02-client/keeper"
 	ibcclienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	ibcconnectiontypes "github.com/cosmos/ibc-go/v8/modules/core/03-connection/types"
 	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types"

--- a/modules/light-clients/08-wasm/types/client_validator.go
+++ b/modules/light-clients/08-wasm/types/client_validator.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 

--- a/modules/light-clients/08-wasm/types/client_validator.go
+++ b/modules/light-clients/08-wasm/types/client_validator.go
@@ -1,0 +1,61 @@
+package types
+
+import (
+	errorsmod "cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	clientkeeper "github.com/cosmos/ibc-go/v8/modules/core/02-client/keeper"
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	"github.com/cosmos/ibc-go/v8/modules/core/exported"
+	ibctm "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
+)
+
+type WasmTMClientValidator struct {
+	cdc codec.BinaryCodec
+	tm  clientkeeper.TendermintClientValidator
+}
+
+var _ clienttypes.SelfClientValidator = (*WasmTMClientValidator)(nil)
+
+// NewWasmTMClientValidator creates and returns a new SelfClientValidator for wasm tendermint consensus.
+func NewWasmTMClientValidator(cdc codec.BinaryCodec, tm clientkeeper.TendermintClientValidator) *WasmTMClientValidator {
+	return &WasmTMClientValidator{
+		cdc: cdc,
+		tm:  tm,
+	}
+}
+
+func (w WasmTMClientValidator) GetSelfConsensusState(ctx sdk.Context, height exported.Height) (exported.ConsensusState, error) {
+	consensusState, err := w.tm.GetSelfConsensusState(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+
+	// encode consensusState to wasm.ConsensusState.Data
+	bz, err := w.cdc.Marshal(consensusState)
+	if err != nil {
+		return nil, err
+	}
+
+	wasmConsensusState := &ConsensusState{
+		Data: bz,
+	}
+
+	return wasmConsensusState, nil
+}
+
+func (w WasmTMClientValidator) ValidateSelfClient(ctx sdk.Context, clientState exported.ClientState) error {
+	wasmClientState, ok := clientState.(*ClientState)
+	if !ok {
+		return errorsmod.Wrapf(clienttypes.ErrInvalidClient, "client must be a wasm client, expected: %T, got: %T", ClientState{}, wasmClientState)
+	}
+
+	// unmarshal the wasmClientState bytes into tendermint client and call self validation
+	var tmClientState *ibctm.ClientState
+	if err := w.cdc.Unmarshal(wasmClientState.Data, tmClientState); err != nil {
+		return err
+	}
+
+	return w.tm.ValidateSelfClient(ctx, tmClientState)
+}

--- a/modules/light-clients/08-wasm/types/client_validator.go
+++ b/modules/light-clients/08-wasm/types/client_validator.go
@@ -13,13 +13,13 @@ import (
 
 type WasmTMClientValidator struct {
 	cdc codec.BinaryCodec
-	tm  clientkeeper.TendermintClientValidator
+	tm  *clientkeeper.TendermintClientValidator
 }
 
 var _ clienttypes.SelfClientValidator = (*WasmTMClientValidator)(nil)
 
 // NewWasmTMClientValidator creates and returns a new SelfClientValidator for wasm tendermint consensus.
-func NewWasmTMClientValidator(cdc codec.BinaryCodec, tm clientkeeper.TendermintClientValidator) *WasmTMClientValidator {
+func NewWasmTMClientValidator(cdc codec.BinaryCodec, tm *clientkeeper.TendermintClientValidator) *WasmTMClientValidator {
 	return &WasmTMClientValidator{
 		cdc: cdc,
 		tm:  tm,

--- a/scripts/build-wasm-simapp-docker.sh
+++ b/scripts/build-wasm-simapp-docker.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eou pipefail
+
+# build_wasm_image extracts the correct libwasm version and checksum
+# based on the go.mod and builds a docker image with the provided tag.
+function build_wasm_image(){
+  local version="$(scripts/get-libwasm-version.py --get-version)"
+  local checksum="$(scripts/get-libwasm-version.py --get-checksum)"
+  docker build . -t "${1}" -f modules/light-clients/08-wasm/Dockerfile --build-arg LIBWASM_VERSION=${version} --build-arg LIBWASM_CHECKSUM=${checksum}
+}
+
+# default to latest if no tag is specified.
+TAG="${1:-ibc-go-wasm-simd:latest}"
+
+build_wasm_image "${TAG}"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #5863


### Commit Message / Changelog Entry

```text
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
