### PR TITLE
feat: check client status active when verifying membership on tenderm…

### DIFF
--- a/modules/core/errors/errors.go
+++ b/modules/core/errors/errors.go
@@ -60,4 +60,7 @@ var (
 
 	// ErrNotFound defines an error when requested entity doesn't exist in the state.
 	ErrNotFound = errorsmod.Register(codespace, 16, "not found")
+
+	// ErrClientStatusNotActive defines an error when an operation expects a client to be active
+	ErrClientStatusNotActive = errorsmod.Register(codespace, 17, "client is not active")
 )

--- a/modules/light-clients/07-tendermint/client_state.go
+++ b/modules/light-clients/07-tendermint/client_state.go
@@ -219,7 +219,7 @@ func (cs ClientState) VerifyMembership(
 	path exported.Path,
 	value []byte,
 ) error {
-	if cs.Status(ctx, clientStore, cdc) == exported.Expired {
+	if cs.Status(ctx, clientStore, cdc) != exported.Active {
 		return errorsmod.Wrapf(ibcerrors.ErrClientStatusNotActive, "client status is not active")
 	}
 

--- a/modules/light-clients/07-tendermint/client_state.go
+++ b/modules/light-clients/07-tendermint/client_state.go
@@ -219,6 +219,10 @@ func (cs ClientState) VerifyMembership(
 	path exported.Path,
 	value []byte,
 ) error {
+	if cs.Status(ctx, clientStore, cdc) == exported.Expired {
+		return errorsmod.Wrapf(ibcerrors.ErrClientStatusNotActive, "client status is not active")
+	}
+
 	if cs.GetLatestHeight().LT(height) {
 		return errorsmod.Wrapf(
 			ibcerrors.ErrInvalidHeight,

--- a/modules/light-clients/07-tendermint/client_state_test.go
+++ b/modules/light-clients/07-tendermint/client_state_test.go
@@ -503,6 +503,28 @@ func (suite *TendermintTestSuite) TestVerifyMembership() {
 				proof = []byte{}
 			}, false,
 		},
+		{
+			name: "client state is frozen",
+			malleate: func() {
+				clientState := testingpath.EndpointA.GetClientState().(*ibctm.ClientState)
+				// Set the FrozenHeight to a non-zero value to indicate the client is frozen (inactive).
+				clientState.FrozenHeight = clienttypes.NewHeight(1, 1)
+				// Update the client state in the testing path to reflect the frozen state.
+				testingpath.EndpointA.SetClientState(clientState)
+			},
+			expPass: false, // Expect this test to fail since the state is not active (frozen).
+		},
+		{
+			name: "client state is expired",
+			malleate: func() {
+				clientState := testingpath.EndpointA.GetClientState().(*ibctm.ClientState)
+				// Advance the LatestHeight to simulate expiration.
+				clientState.LatestHeight = clientState.LatestHeight.Increment().(clienttypes.Height)
+				// Update the client state in the testing path to reflect the expired state.
+				testingpath.EndpointA.SetClientState(clientState)
+			},
+			expPass: false, // Expect this test to fail since the client state is expired.
+		},
 	}
 
 	for _, tc := range testCases {

--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -137,6 +137,10 @@ func (cs ClientState) VerifyMembership(
 	path exported.Path,
 	value []byte,
 ) error {
+	if cs.Status(ctx, clientStore, cdc) != exported.Active {
+		return errorsmod.Wrapf(ibcerrors.ErrClientStatusNotActive, "client status is not active")
+	}
+
 	proofHeight, ok := height.(clienttypes.Height)
 	if !ok {
 		return errorsmod.Wrapf(ibcerrors.ErrInvalidType, "expected %T, got %T", clienttypes.Height{}, height)

--- a/modules/light-clients/08-wasm/types/client_state_test.go
+++ b/modules/light-clients/08-wasm/types/client_state_test.go
@@ -448,6 +448,32 @@ func (suite *TypesTestSuite) TestVerifyMembership() {
 			},
 			ibcerrors.ErrInvalidType,
 		},
+		{
+			"client state is frozen",
+			func() {
+				// Simulate the client state being frozen by registering a query callback
+				// that returns a status indicating the client is frozen.
+				suite.mockVM.RegisterQueryCallback(types.StatusMsg{}, func(checksum wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
+					resp, err := json.Marshal(types.StatusResult{Status: exported.Frozen.String()})
+					suite.Require().NoError(err)
+					return resp, wasmtesting.DefaultGasUsed, nil
+				})
+			},
+			ibcerrors.ErrClientStatusNotActive, // Adjust based on the expected outcome when the client is frozen.
+		},
+		{
+			"client state is expired",
+			func() {
+				// Simulate the client state being expired by registering a query callback
+				// that returns a status indicating the client is expired.
+				suite.mockVM.RegisterQueryCallback(types.StatusMsg{}, func(checksum wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
+					resp, err := json.Marshal(types.StatusResult{Status: exported.Expired.String()})
+					suite.Require().NoError(err)
+					return resp, wasmtesting.DefaultGasUsed, nil
+				})
+			},
+			ibcerrors.ErrClientStatusNotActive, // This needs to be defined according to your error handling for expired clients.
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #5847 

### Commit Message / Changelog Entry

```text
type: commit message
```

see the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages. (view raw markdown for examples)


<!--
Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
