### PR TITLE
fix(08-wasm/test): register mockVm querier callbacks against TimestampAtHeightMsg to avoid recursive loops

### DIFF
--- a/modules/light-clients/08-wasm/types/querier_test.go
+++ b/modules/light-clients/08-wasm/types/querier_test.go
@@ -290,7 +290,8 @@ func (suite *TypesTestSuite) TestStargateQuery() {
 			// NOTE: we register query callbacks against: types.TimestampAtHeightMsg{}
 			// in practise, this can against any client state msg, however registering against types.StatusMsg{} introduces recursive loops
 			// due to test case: "success: verify membership query"
-			clientState.GetTimestampAtHeight(suite.chainA.GetContext(), clientStore, suite.chainA.App.AppCodec(), clienttypes.GetSelfHeight(suite.chainA.GetContext()))
+			_, err = clientState.GetTimestampAtHeight(suite.chainA.GetContext(), clientStore, suite.chainA.App.AppCodec(), clienttypes.GetSelfHeight(suite.chainA.GetContext()))
+			suite.Require().NoError(err)
 
 			if expDiscardedState {
 				suite.Require().False(clientStore.Has(testKey))

--- a/modules/light-clients/08-wasm/types/querier_test.go
+++ b/modules/light-clients/08-wasm/types/querier_test.go
@@ -141,7 +141,7 @@ func (suite *TypesTestSuite) TestStargateQuery() {
 
 				ibcwasm.SetQueryPlugins(&querierPlugin)
 
-				suite.mockVM.RegisterQueryCallback(types.StatusMsg{}, func(_ wasmvm.Checksum, _ wasmvmtypes.Env, _ []byte, store wasmvm.KVStore, _ wasmvm.GoAPI, querier wasmvm.Querier, _ wasmvm.GasMeter, _ uint64, _ wasmvmtypes.UFraction) ([]byte, uint64, error) {
+				suite.mockVM.RegisterQueryCallback(types.TimestampAtHeightMsg{}, func(_ wasmvm.Checksum, _ wasmvmtypes.Env, _ []byte, store wasmvm.KVStore, _ wasmvm.GoAPI, querier wasmvm.Querier, _ wasmvm.GasMeter, _ uint64, _ wasmvmtypes.UFraction) ([]byte, uint64, error) {
 					queryRequest := types.QueryChecksumsRequest{}
 					bz, err := queryRequest.Marshal()
 					suite.Require().NoError(err)
@@ -194,7 +194,7 @@ func (suite *TypesTestSuite) TestStargateQuery() {
 				merklePath, err := commitmenttypes.ApplyPrefix(suite.chainA.GetPrefix(), merklePath)
 				suite.Require().NoError(err)
 
-				suite.mockVM.RegisterQueryCallback(types.StatusMsg{}, func(_ wasmvm.Checksum, _ wasmvmtypes.Env, _ []byte, _ wasmvm.KVStore, _ wasmvm.GoAPI, querier wasmvm.Querier, _ wasmvm.GasMeter, _ uint64, _ wasmvmtypes.UFraction) ([]byte, uint64, error) {
+				suite.mockVM.RegisterQueryCallback(types.TimestampAtHeightMsg{}, func(_ wasmvm.Checksum, _ wasmvmtypes.Env, _ []byte, _ wasmvm.KVStore, _ wasmvm.GoAPI, querier wasmvm.Querier, _ wasmvm.GasMeter, _ uint64, _ wasmvmtypes.UFraction) ([]byte, uint64, error) {
 					queryRequest := clienttypes.QueryVerifyMembershipRequest{
 						ClientId:    endpoint.ClientID,
 						Proof:       proof,
@@ -251,7 +251,7 @@ func (suite *TypesTestSuite) TestStargateQuery() {
 		{
 			"failure: default querier",
 			func() {
-				suite.mockVM.RegisterQueryCallback(types.StatusMsg{}, func(_ wasmvm.Checksum, _ wasmvmtypes.Env, _ []byte, store wasmvm.KVStore, _ wasmvm.GoAPI, querier wasmvm.Querier, _ wasmvm.GasMeter, _ uint64, _ wasmvmtypes.UFraction) ([]byte, uint64, error) {
+				suite.mockVM.RegisterQueryCallback(types.TimestampAtHeightMsg{}, func(_ wasmvm.Checksum, _ wasmvmtypes.Env, _ []byte, store wasmvm.KVStore, _ wasmvm.GoAPI, querier wasmvm.Querier, _ wasmvm.GasMeter, _ uint64, _ wasmvmtypes.UFraction) ([]byte, uint64, error) {
 					queryRequest := types.QueryChecksumsRequest{}
 					bz, err := queryRequest.Marshal()
 					suite.Require().NoError(err)
@@ -286,7 +286,11 @@ func (suite *TypesTestSuite) TestStargateQuery() {
 
 			clientStore := suite.chainA.App.GetIBCKeeper().ClientKeeper.ClientStore(suite.chainA.GetContext(), endpoint.ClientID)
 			clientState := endpoint.GetClientState()
-			clientState.Status(suite.chainA.GetContext(), clientStore, suite.chainA.App.AppCodec())
+
+			// NOTE: we register query callbacks against: types.TimestampAtHeightMsg{}
+			// in practise, this can against any client state msg, however registering against types.StatusMsg{} introduces recursive loops
+			// due to test case: "success: verify membership query"
+			clientState.GetTimestampAtHeight(suite.chainA.GetContext(), clientStore, suite.chainA.App.AppCodec(), clienttypes.GetSelfHeight(suite.chainA.GetContext()))
 
 			if expDiscardedState {
 				suite.Require().False(clientStore.Has(testKey))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Register querier callbacks in mockVM against `TimestampAtHeightMsg` instead of `StatusMsg`.
This avoids recursive loops introduced by yours truly in https://github.com/cosmos/ibc-go/pull/5870, adding the client status check to the rpc handler of `VerifyMembership`.

If anyone would rather a different approach to fixing this issue, we could additional create an entirely separate test func for `success: verify membership query` and only use `TimestampAtHeightMsg` for that one, but it makes no difference to me.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
