### PR TITLE
refactor: use local clock time only for transfer CLI relative timeouts

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/client/cli/tx.go
+++ b/modules/apps/27-interchain-accounts/controller/client/cli/tx.go
@@ -81,8 +81,10 @@ func newSendTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "send-tx [connection-id] [path/to/packet_msg.json]",
 		Short: "Send an interchain account tx on the provided connection.",
-		Long: strings.TrimSpace(`Submits pre-built packet data containing messages to be executed on the host chain 
-and attempts to send the packet. Packet data is provided as json, file or string. A relative timeout timestamp can be provided with flag {packet-timeout-timestamp}.
+		Long: strings.TrimSpace(`Submits pre-built packet data containing messages to be executed on the host chain and attempts to send the packet. 
+Packet data is provided as json, file or string. A timeout timestamp can be provided using the flag {packet-timeout-timestamp}. 
+By default timeout timestamps are calculated relatively, adding {packet-timeout-timestamp} to the user's local system clock time. 
+Absolute timeout timestamp values can be used by setting the {absolute-timeouts} flag to true.
 If no timeout value is set then a default relative timeout value of 10 minutes is used.`),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/modules/apps/27-interchain-accounts/controller/client/cli/tx.go
+++ b/modules/apps/27-interchain-accounts/controller/client/cli/tx.go
@@ -115,17 +115,17 @@ If no timeout value is set then a default relative timeout value of 10 minutes i
 			}
 
 			// NOTE: relative timeouts using block height are not supported.
-			if !absoluteTimeouts {
-				// use local clock time as reference time for calculating timeout timestamp.
-				if timeoutTimestamp != 0 {
-					now := time.Now().UnixNano()
-					if now > 0 {
-						timeoutTimestamp = uint64(now) + timeoutTimestamp
-					} else {
-						return errors.New("local clock time is not greater than Jan 1st, 1970 12:00 AM")
-					}
-				}
+			if !absoluteTimeouts && timeoutTimestamp == 0 {
+				return errors.New("relative timeouts must provide a non zero value timestamp")
 			}
+
+			// use local clock time as reference time for calculating timeout timestamp.
+			now := time.Now().UnixNano()
+			if now <= 0 {
+				return errors.New("local clock time is not greater than Jan 1st, 1970 12:00 AM")
+			}
+
+			timeoutTimestamp = uint64(now) + timeoutTimestamp
 
 			msg := types.NewMsgSendTx(owner, connectionID, timeoutTimestamp, icaMsgData)
 

--- a/modules/apps/27-interchain-accounts/controller/client/cli/tx.go
+++ b/modules/apps/27-interchain-accounts/controller/client/cli/tx.go
@@ -29,6 +29,12 @@ const (
 	flagAbsoluteTimeouts       = "absolute-timeouts"
 )
 
+// defaultRelativePacketTimeoutTimestamp is the default packet timeout timestamp (in nanoseconds)
+// relative to the current block timestamp of the counterparty chain provided by the client
+// state. The timeout is disabled when set to 0. The default is currently set to a 10 minute
+// timeout.
+var defaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
+
 func newRegisterInterchainAccountCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "register [connection-id]",
@@ -133,7 +139,7 @@ If no timeout value is set then a default relative timeout value of 10 minutes i
 		},
 	}
 
-	cmd.Flags().Uint64(flagPacketTimeoutTimestamp, icatypes.DefaultRelativePacketTimeoutTimestamp, "Packet timeout timestamp in nanoseconds from now. Default is 10 minutes.")
+	cmd.Flags().Uint64(flagPacketTimeoutTimestamp, defaultRelativePacketTimeoutTimestamp, "Packet timeout timestamp in nanoseconds from now. Default is 10 minutes.")
 	cmd.Flags().Bool(flagAbsoluteTimeouts, false, "Timeout flags are used as absolute timeouts.")
 	flags.AddTxFlagsToCmd(cmd)
 

--- a/modules/apps/27-interchain-accounts/controller/client/cli/tx.go
+++ b/modules/apps/27-interchain-accounts/controller/client/cli/tx.go
@@ -121,17 +121,19 @@ If no timeout value is set then a default relative timeout value of 10 minutes i
 			}
 
 			// NOTE: relative timeouts using block height are not supported.
-			if !absoluteTimeouts && timeoutTimestamp == 0 {
-				return errors.New("relative timeouts must provide a non zero value timestamp")
-			}
+			if !absoluteTimeouts {
+				if timeoutTimestamp == 0 {
+					return errors.New("relative timeouts must provide a non zero value timestamp")
+				}
 
-			// use local clock time as reference time for calculating timeout timestamp.
-			now := time.Now().UnixNano()
-			if now <= 0 {
-				return errors.New("local clock time is not greater than Jan 1st, 1970 12:00 AM")
-			}
+				// use local clock time as reference time for calculating timeout timestamp.
+				now := time.Now().UnixNano()
+				if now <= 0 {
+					return errors.New("local clock time is not greater than Jan 1st, 1970 12:00 AM")
+				}
 
-			timeoutTimestamp = uint64(now) + timeoutTimestamp
+				timeoutTimestamp = uint64(now) + timeoutTimestamp
+			}
 
 			msg := types.NewMsgSendTx(owner, connectionID, timeoutTimestamp, icaMsgData)
 

--- a/modules/apps/27-interchain-accounts/types/packet.go
+++ b/modules/apps/27-interchain-accounts/types/packet.go
@@ -3,7 +3,6 @@ package types
 import (
 	"encoding/json"
 	"strings"
-	"time"
 
 	errorsmod "cosmossdk.io/errors"
 
@@ -20,19 +19,6 @@ var (
 
 // MaxMemoCharLength defines the maximum length for the InterchainAccountPacketData memo field
 const MaxMemoCharLength = 32768
-
-var (
-	// DefaultRelativePacketTimeoutHeight is the default packet timeout height (in blocks) relative
-	// to the current block height of the counterparty chain provided by the client state. The
-	// timeout is disabled when set to 0.
-	DefaultRelativePacketTimeoutHeight = "0-1000"
-
-	// DefaultRelativePacketTimeoutTimestamp is the default packet timeout timestamp (in nanoseconds)
-	// relative to the current block timestamp of the counterparty chain provided by the client
-	// state. The timeout is disabled when set to 0. The default is currently set to a 10 minute
-	// timeout.
-	DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
-)
 
 // ValidateBasic performs basic validation of the interchain account packet data.
 // The memo may be empty.

--- a/modules/apps/transfer/client/cli/tx.go
+++ b/modules/apps/transfer/client/cli/tx.go
@@ -30,10 +30,9 @@ func NewTransferTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "transfer [src-port] [src-channel] [receiver] [amount]",
 		Short: "Transfer a fungible token through IBC",
-		Long: strings.TrimSpace(`Transfer a fungible token through IBC. Timeouts can be specified
-as absolute using the "absolute-timeouts" flag. Timeout height can be set by passing in the height string
-in the form {revision}-{height} using the "packet-timeout-height" flag. Note, relative timeout height is not supported. Relative timeout timestamp 
-is added to the value of the system user's local clock time. If no timeout value is set then a default relative timeout value of 10 minutes is used.`),
+		Long: strings.TrimSpace(`Transfer a fungible token through IBC. Timeouts can be specified as absolute using the "absolute-timeouts" flag. 
+Timeout height can be set by passing in the height string in the form {revision}-{height} using the "packet-timeout-height" flag. Note, relative timeout height is not supported. 
+Relative timeout timestamp is added to the value of the user's local system clock time using the "packet-timeout-timestamp" flag. If no timeout value is set then a default relative timeout value of 10 minutes is used.`),
 		Example: fmt.Sprintf("%s tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount]", version.AppName),
 		Args:    cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/modules/apps/transfer/client/cli/tx.go
+++ b/modules/apps/transfer/client/cli/tx.go
@@ -33,7 +33,7 @@ func NewTransferTxCmd() *cobra.Command {
 		Long: strings.TrimSpace(`Transfer a fungible token through IBC. Timeouts can be specified
 as absolute using the "absolute-timeouts" flag. Timeout height can be set by passing in the height string
 in the form {revision}-{height} using the "packet-timeout-height" flag. Note, relative timeout height is not supported. Relative timeout timestamp 
-is added to the value of the system user's local clock time. If no timeout value is set then a default relative timeout value of 10 minutes is used`),
+is added to the value of the system user's local clock time. If no timeout value is set then a default relative timeout value of 10 minutes is used.`),
 		Example: fmt.Sprintf("%s tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount]", version.AppName),
 		Args:    cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -88,10 +88,7 @@ is added to the value of the system user's local clock time. If no timeout value
 					return errors.New("relative timeouts using block height is not supported")
 				}
 
-				// use local clock time as reference time if it is later than the
-				// consensus state timestamp of the counterparty chain, otherwise
-				// still use consensus state timestamp as reference.
-				// for localhost clients local clock time is always used.
+				// use local clock time as reference time for calculating timeout timestamp.
 				if timeoutTimestamp != 0 {
 					now := time.Now().UnixNano()
 					if now > 0 {

--- a/modules/apps/transfer/client/cli/tx.go
+++ b/modules/apps/transfer/client/cli/tx.go
@@ -36,9 +36,9 @@ func NewTransferTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "transfer [src-port] [src-channel] [receiver] [amount]",
 		Short: "Transfer a fungible token through IBC",
-		Long: strings.TrimSpace(`Transfer a fungible token through IBC. Timeouts can be specified as absolute using the "absolute-timeouts" flag. 
-Timeout height can be set by passing in the height string in the form {revision}-{height} using the "packet-timeout-height" flag. Note, relative timeout height is not supported. 
-Relative timeout timestamp is added to the value of the user's local system clock time using the "packet-timeout-timestamp" flag. If no timeout value is set then a default relative timeout value of 10 minutes is used.`),
+		Long: strings.TrimSpace(`Transfer a fungible token through IBC. Timeouts can be specified as absolute using the {absolute-timeouts} flag. 
+Timeout height can be set by passing in the height string in the form {revision}-{height} using the {packet-timeout-height} flag. Note, relative timeout height is not supported. 
+Relative timeout timestamp is added to the value of the user's local system clock time using the {packet-timeout-timestamp} flag. If no timeout value is set then a default relative timeout value of 10 minutes is used.`),
 		Example: fmt.Sprintf("%s tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount]", version.AppName),
 		Args:    cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/modules/apps/transfer/client/cli/tx.go
+++ b/modules/apps/transfer/client/cli/tx.go
@@ -15,10 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 
 	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
-	clientutils "github.com/cosmos/ibc-go/v8/modules/core/02-client/client/utils"
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
-	channelutils "github.com/cosmos/ibc-go/v8/modules/core/04-channel/client/utils"
-	"github.com/cosmos/ibc-go/v8/modules/core/exported"
 )
 
 const (
@@ -34,11 +31,9 @@ func NewTransferTxCmd() *cobra.Command {
 		Use:   "transfer [src-port] [src-channel] [receiver] [amount]",
 		Short: "Transfer a fungible token through IBC",
 		Long: strings.TrimSpace(`Transfer a fungible token through IBC. Timeouts can be specified
-as absolute or relative using the "absolute-timeouts" flag. Timeout height can be set by passing in the height string
-in the form {revision}-{height} using the "packet-timeout-height" flag. Relative timeout height is added to the block
-height queried from the latest consensus state corresponding to the counterparty channel. Relative timeout timestamp 
-is added to the greater value of the local clock time and the block timestamp queried from the latest consensus state 
-corresponding to the counterparty channel. Any timeout set to 0 is disabled.`),
+as absolute using the "absolute-timeouts" flag. Timeout height can be set by passing in the height string
+in the form {revision}-{height} using the "packet-timeout-height" flag. Note, relative timeout height is not supported. Relative timeout timestamp 
+is added to the value of the system user's local clock time. If no timeout value is set then a default relative timeout value of 10 minutes is used`),
 		Example: fmt.Sprintf("%s tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount]", version.AppName),
 		Args:    cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -65,6 +60,7 @@ corresponding to the counterparty channel. Any timeout set to 0 is disabled.`),
 			if err != nil {
 				return err
 			}
+
 			timeoutHeight, err := clienttypes.ParseHeight(timeoutHeightStr)
 			if err != nil {
 				return err
@@ -85,42 +81,11 @@ corresponding to the counterparty channel. Any timeout set to 0 is disabled.`),
 				return err
 			}
 
-			// if the timeouts are not absolute, retrieve latest block height and block timestamp
-			// for the consensus state connected to the destination port/channel.
-			// localhost clients must rely solely on local clock time in order to use relative timestamps.
+			// NOTE: relative timeouts using block height are not supported.
+			// if the timeouts are not absolute, CLI users rely solely on local clock time in order to use relative timestamps.
 			if !absoluteTimeouts {
-				clientRes, err := channelutils.QueryChannelClientState(clientCtx, srcPort, srcChannel, false)
-				if err != nil {
-					return err
-				}
-
-				var clientState exported.ClientState
-				if err := clientCtx.InterfaceRegistry.UnpackAny(clientRes.IdentifiedClientState.ClientState, &clientState); err != nil {
-					return err
-				}
-
-				clientHeight, ok := clientState.GetLatestHeight().(clienttypes.Height)
-				if !ok {
-					return fmt.Errorf("invalid height type. expected type: %T, got: %T", clienttypes.Height{}, clientState.GetLatestHeight())
-				}
-
-				var consensusState exported.ConsensusState
-				if clientState.ClientType() != exported.Localhost {
-					consensusStateRes, err := clientutils.QueryConsensusState(clientCtx, clientRes.IdentifiedClientState.ClientId, clientHeight, false, true)
-					if err != nil {
-						return err
-					}
-
-					if err := clientCtx.InterfaceRegistry.UnpackAny(consensusStateRes.ConsensusState, &consensusState); err != nil {
-						return err
-					}
-				}
-
 				if !timeoutHeight.IsZero() {
-					absoluteHeight := clientHeight
-					absoluteHeight.RevisionNumber += timeoutHeight.RevisionNumber
-					absoluteHeight.RevisionHeight += timeoutHeight.RevisionHeight
-					timeoutHeight = absoluteHeight
+					return errors.New("relative timeouts using block height is not supported")
 				}
 
 				// use local clock time as reference time if it is later than the
@@ -128,19 +93,9 @@ corresponding to the counterparty channel. Any timeout set to 0 is disabled.`),
 				// still use consensus state timestamp as reference.
 				// for localhost clients local clock time is always used.
 				if timeoutTimestamp != 0 {
-					var consensusStateTimestamp uint64
-					if consensusState != nil {
-						consensusStateTimestamp = consensusState.GetTimestamp()
-					}
-
 					now := time.Now().UnixNano()
 					if now > 0 {
-						now := uint64(now)
-						if now > consensusStateTimestamp {
-							timeoutTimestamp = now + timeoutTimestamp
-						} else {
-							timeoutTimestamp = consensusStateTimestamp + timeoutTimestamp
-						}
+						timeoutTimestamp = uint64(now) + timeoutTimestamp
 					} else {
 						return errors.New("local clock time is not greater than Jan 1st, 1970 12:00 AM")
 					}
@@ -154,7 +109,7 @@ corresponding to the counterparty channel. Any timeout set to 0 is disabled.`),
 		},
 	}
 
-	cmd.Flags().String(flagPacketTimeoutHeight, types.DefaultRelativePacketTimeoutHeight, "Packet timeout block height. The timeout is disabled when set to 0-0.")
+	cmd.Flags().String(flagPacketTimeoutHeight, "0-0", "Packet timeout block height in the format {revision}-{height}. The timeout is disabled when set to 0-0.")
 	cmd.Flags().Uint64(flagPacketTimeoutTimestamp, types.DefaultRelativePacketTimeoutTimestamp, "Packet timeout timestamp in nanoseconds from now. Default is 10 minutes. The timeout is disabled when set to 0.")
 	cmd.Flags().Bool(flagAbsoluteTimeouts, false, "Timeout flags are used as absolute timeouts.")
 	cmd.Flags().String(flagMemo, "", "Memo to be sent along with the packet.")

--- a/modules/apps/transfer/types/packet.go
+++ b/modules/apps/transfer/types/packet.go
@@ -18,19 +18,11 @@ var (
 	_ ibcexported.PacketDataProvider = (*FungibleTokenPacketData)(nil)
 )
 
-var (
-	// DefaultRelativePacketTimeoutHeight is the default packet timeout height (in blocks) relative
-	// to the current block height of the counterparty chain provided by the client state. The
-	// timeout is disabled when set to 0.
-	// Deprecated: This value will be removed in the next major release of IBC-go.
-	DefaultRelativePacketTimeoutHeight = "0-1000"
-
-	// DefaultRelativePacketTimeoutTimestamp is the default packet timeout timestamp (in nanoseconds)
-	// relative to the current block timestamp of the counterparty chain provided by the client
-	// state. The timeout is disabled when set to 0. The default is currently set to a 10 minute
-	// timeout.
-	DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
-)
+// DefaultRelativePacketTimeoutTimestamp is the default packet timeout timestamp (in nanoseconds)
+// relative to the current block timestamp of the counterparty chain provided by the client
+// state. The timeout is disabled when set to 0. The default is currently set to a 10 minute
+// timeout.
+var DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
 
 // NewFungibleTokenPacketData constructs a new FungibleTokenPacketData instance
 func NewFungibleTokenPacketData(

--- a/modules/apps/transfer/types/packet.go
+++ b/modules/apps/transfer/types/packet.go
@@ -22,6 +22,7 @@ var (
 	// DefaultRelativePacketTimeoutHeight is the default packet timeout height (in blocks) relative
 	// to the current block height of the counterparty chain provided by the client state. The
 	// timeout is disabled when set to 0.
+	// Deprecated: This value will be removed in the next major release of IBC-go.
 	DefaultRelativePacketTimeoutHeight = "0-1000"
 
 	// DefaultRelativePacketTimeoutTimestamp is the default packet timeout timestamp (in nanoseconds)

--- a/modules/apps/transfer/types/packet.go
+++ b/modules/apps/transfer/types/packet.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
-	"time"
 
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
@@ -17,12 +16,6 @@ var (
 	_ ibcexported.PacketData         = (*FungibleTokenPacketData)(nil)
 	_ ibcexported.PacketDataProvider = (*FungibleTokenPacketData)(nil)
 )
-
-// DefaultRelativePacketTimeoutTimestamp is the default packet timeout timestamp (in nanoseconds)
-// relative to the current block timestamp of the counterparty chain provided by the client
-// state. The timeout is disabled when set to 0. The default is currently set to a 10 minute
-// timeout.
-var DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
 
 // NewFungibleTokenPacketData constructs a new FungibleTokenPacketData instance
 func NewFungibleTokenPacketData(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Refactors transfer CLI to use local clock time only for relative timeouts.
- Removes the stateful query on the node to client and consensus states.
- Disables relative timeout by block height.

closes: #3594 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to be used for the changelog entry in the PR description for review.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
