### PR TITLE
fix: remove marshalling of anys to bytes for verify upgrade

### DIFF
--- a/modules/core/02-client/keeper/client_test.go
+++ b/modules/core/02-client/keeper/client_test.go
@@ -323,9 +323,8 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 		upgradedClient                                   *ibctm.ClientState
 		upgradedConsState                                exported.ConsensusState
 		upgradeHeight                                    exported.Height
+		upgradedClientAny, upgradedConsStateAny          *codectypes.Any
 		upgradedClientProof, upgradedConsensusStateProof []byte
-		// upgradedClientBz, upgradedConsStateBz            []byte
-		upgradedClientAny, upgradedConsStateAny *codectypes.Any
 	)
 
 	testCases := []struct {
@@ -360,101 +359,102 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 			},
 			expPass: true,
 		},
-		// {
-		// 	name: "client state not found",
-		// 	setup: func() {
-		// 		// last Height is at next block
-		// 		upgradeHeight = clienttypes.NewHeight(1, uint64(suite.chainB.GetContext().BlockHeight()+1))
+		{
+			name: "client state not found",
+			setup: func() {
+				// last Height is at next block
+				upgradeHeight = clienttypes.NewHeight(1, uint64(suite.chainB.GetContext().BlockHeight()+1))
 
-		// 		// zero custom fields and store in upgrade store
-		// 		err := suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedClient(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), upgradedClientBz)
-		// 		suite.Require().NoError(err)
-		// 		err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedConsensusState(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), upgradedConsStateBz)
-		// 		suite.Require().NoError(err)
+				// zero custom fields and store in upgrade store
+				err := suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedClient(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), suite.chainB.Codec.MustMarshal(upgradedClientAny))
+				suite.Require().NoError(err)
+				err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedConsensusState(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), suite.chainB.Codec.MustMarshal(upgradedConsStateAny))
+				suite.Require().NoError(err)
 
-		// 		// commit upgrade store changes and update clients
+				// commit upgrade store changes and update clients
 
-		// 		suite.coordinator.CommitBlock(suite.chainB)
-		// 		err = path.EndpointA.UpdateClient()
-		// 		suite.Require().NoError(err)
+				suite.coordinator.CommitBlock(suite.chainB)
+				err = path.EndpointA.UpdateClient()
+				suite.Require().NoError(err)
 
-		// 		cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
-		// 		suite.Require().True(found)
-		// 		tmCs, ok := cs.(*ibctm.ClientState)
-		// 		suite.Require().True(ok)
+				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
+				suite.Require().True(found)
+				tmCs, ok := cs.(*ibctm.ClientState)
+				suite.Require().True(ok)
 
-		// 		upgradedClientProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
-		// 		upgradedConsensusStateProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
+				upgradedClientProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
+				upgradedConsensusStateProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
 
-		// 		path.EndpointA.ClientID = "wrongclientid"
-		// 	},
-		// 	expPass: false,
-		// },
-		// {
-		// 	name: "client state is not active",
-		// 	setup: func() {
-		// 		// client is frozen
+				path.EndpointA.ClientID = "wrongclientid"
+			},
+			expPass: false,
+		},
+		{
+			name: "client state is not active",
+			setup: func() {
+				// client is frozen
 
-		// 		// last Height is at next block
-		// 		upgradeHeight = clienttypes.NewHeight(1, uint64(suite.chainB.GetContext().BlockHeight()+1))
+				// last Height is at next block
+				upgradeHeight = clienttypes.NewHeight(1, uint64(suite.chainB.GetContext().BlockHeight()+1))
 
-		// 		// zero custom fields and store in upgrade store
-		// 		err := suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedClient(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), upgradedClientBz)
-		// 		suite.Require().NoError(err)
-		// 		err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedConsensusState(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), upgradedConsStateBz)
-		// 		suite.Require().NoError(err)
+				// zero custom fields and store in upgrade store
+				err := suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedClient(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), suite.chainB.Codec.MustMarshal(upgradedClientAny))
+				suite.Require().NoError(err)
+				err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedConsensusState(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), suite.chainB.Codec.MustMarshal(upgradedConsStateAny))
+				suite.Require().NoError(err)
 
-		// 		// commit upgrade store changes and update clients
-		// 		suite.coordinator.CommitBlock(suite.chainB)
-		// 		err = path.EndpointA.UpdateClient()
-		// 		suite.Require().NoError(err)
+				// commit upgrade store changes and update clients
+				suite.coordinator.CommitBlock(suite.chainB)
+				err = path.EndpointA.UpdateClient()
+				suite.Require().NoError(err)
 
-		// 		cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
-		// 		suite.Require().True(found)
-		// 		tmCs, ok := cs.(*ibctm.ClientState)
-		// 		suite.Require().True(ok)
+				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
+				suite.Require().True(found)
+				tmCs, ok := cs.(*ibctm.ClientState)
+				suite.Require().True(ok)
 
-		// 		upgradedClientProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
-		// 		upgradedConsensusStateProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
+				upgradedClientProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
+				upgradedConsensusStateProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
 
-		// 		// set frozen client in store
-		// 		tmClient, ok := cs.(*ibctm.ClientState)
-		// 		suite.Require().True(ok)
-		// 		tmClient.FrozenHeight = clienttypes.NewHeight(1, 1)
-		// 		suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID, tmClient)
-		// 	},
-		// 	expPass: false,
-		// },
-		// {
-		// 	name: "light client module VerifyUpgradeAndUpdateState fails",
-		// 	setup: func() {
-		// 		// last Height is at next block
-		// 		upgradeHeight = clienttypes.NewHeight(1, uint64(suite.chainB.GetContext().BlockHeight()+1))
+				// set frozen client in store
+				tmClient, ok := cs.(*ibctm.ClientState)
+				suite.Require().True(ok)
+				tmClient.FrozenHeight = clienttypes.NewHeight(1, 1)
+				suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID, tmClient)
+			},
+			expPass: false,
+		},
+		{
+			name: "light client module VerifyUpgradeAndUpdateState fails",
+			setup: func() {
+				// last Height is at next block
+				upgradeHeight = clienttypes.NewHeight(1, uint64(suite.chainB.GetContext().BlockHeight()+1))
 
-		// 		// zero custom fields and store in upgrade store
-		// 		err := suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedClient(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), upgradedClientBz)
-		// 		suite.Require().NoError(err)
-		// 		err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedConsensusState(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), upgradedConsStateBz)
-		// 		suite.Require().NoError(err)
+				// zero custom fields and store in upgrade store
+				err := suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedClient(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), suite.chainB.Codec.MustMarshal(upgradedClientAny))
+				suite.Require().NoError(err)
+				err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedConsensusState(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), suite.chainB.Codec.MustMarshal(upgradedConsStateAny))
+				suite.Require().NoError(err)
 
-		// 		// change upgradedClient client-specified parameters
-		// 		upgradedClient.ChainId = "wrongchainID"
-		// 		upgradedClientBz = clienttypes.MustMarshalClientState(suite.chainA.Codec, upgradedClient)
+				// change upgradedClient client-specified parameters
+				upgradedClient.ChainId = "wrongchainID"
+				upgradedClientAny, err = codectypes.NewAnyWithValue(upgradedClient)
+				suite.Require().NoError(err)
 
-		// 		suite.coordinator.CommitBlock(suite.chainB)
-		// 		err = path.EndpointA.UpdateClient()
-		// 		suite.Require().NoError(err)
+				suite.coordinator.CommitBlock(suite.chainB)
+				err = path.EndpointA.UpdateClient()
+				suite.Require().NoError(err)
 
-		// 		cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
-		// 		suite.Require().True(found)
-		// 		tmCs, ok := cs.(*ibctm.ClientState)
-		// 		suite.Require().True(ok)
+				cs, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
+				suite.Require().True(found)
+				tmCs, ok := cs.(*ibctm.ClientState)
+				suite.Require().True(ok)
 
-		// 		upgradedClientProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
-		// 		upgradedConsensusStateProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
-		// 	},
-		// 	expPass: false,
-		// },
+				upgradedClientProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
+				upgradedConsensusStateProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(upgradeHeight.GetRevisionHeight())), tmCs.LatestHeight.GetRevisionHeight())
+			},
+			expPass: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -472,15 +472,10 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 			upgradedClient = ibctm.NewClientState(newChainID, ibctm.DefaultTrustLevel, trustingPeriod, ubdPeriod+trustingPeriod, maxClockDrift, clienttypes.NewHeight(revisionNumber+1, clientState.LatestHeight.GetRevisionHeight()+1), commitmenttypes.GetSDKSpecs(), ibctesting.UpgradePath)
 			upgradedClient = upgradedClient.ZeroCustomFields()
 
-			// upgradedClientBz, err = clienttypes.MarshalClientState(suite.chainA.App.AppCodec(), upgradedClient)
-			// suite.Require().NoError(err)
-
 			upgradedClientAny, err = codectypes.NewAnyWithValue(upgradedClient)
 			suite.Require().NoError(err)
 
 			upgradedConsState = &ibctm.ConsensusState{NextValidatorsHash: []byte("nextValsHash")}
-
-			// upgradedConsStateBz = clienttypes.MustMarshalConsensusState(suite.chainA.Codec, upgradedConsState)
 
 			upgradedConsStateAny, err = codectypes.NewAnyWithValue(upgradedConsState)
 			suite.Require().NoError(err)

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -70,19 +70,6 @@ func (k Keeper) UpdateClient(goCtx context.Context, msg *clienttypes.MsgUpdateCl
 func (k Keeper) UpgradeClient(goCtx context.Context, msg *clienttypes.MsgUpgradeClient) (*clienttypes.MsgUpgradeClientResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	// Backwards Compatibility: the light client module is expecting
-	// to unmarshal an interface so we marshal the client state Any
-	// upgradedClientState, err := k.cdc.Marshal(msg.ClientState)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// // Backwards Compatibility: the light client module is expecting
-	// // to unmarshal an interface so we marshal the consensus state Any
-	// upgradedConsensusState, err := k.cdc.Marshal(msg.ConsensusState)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	if err := k.ClientKeeper.UpgradeClient(
 		ctx, msg.ClientId,
 		msg.ClientState.Value,

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -67,6 +67,11 @@ func (k Keeper) UpdateClient(goCtx context.Context, msg *clienttypes.MsgUpdateCl
 }
 
 // UpgradeClient defines a rpc handler method for MsgUpgradeClient.
+// NOTE: The raw bytes of the conretes types encoded into protobuf.Any is passed to the client keeper.
+// The 02-client handler will route to the appropriate light client module based on client identifier and it is the responsiblity
+// of the light client module to unmarshal and interpret the proto encoded bytes.
+// Backwards compatability with older versions of ibc-go is maintained through the light client module reconstructing and encoding
+// the expected concrete type to the protobuf.Any for proof verification.
 func (k Keeper) UpgradeClient(goCtx context.Context, msg *clienttypes.MsgUpgradeClient) (*clienttypes.MsgUpgradeClientResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -72,21 +72,21 @@ func (k Keeper) UpgradeClient(goCtx context.Context, msg *clienttypes.MsgUpgrade
 
 	// Backwards Compatibility: the light client module is expecting
 	// to unmarshal an interface so we marshal the client state Any
-	upgradedClientState, err := k.cdc.Marshal(msg.ClientState)
-	if err != nil {
-		return nil, err
-	}
-	// Backwards Compatibility: the light client module is expecting
-	// to unmarshal an interface so we marshal the consensus state Any
-	upgradedConsensusState, err := k.cdc.Marshal(msg.ConsensusState)
-	if err != nil {
-		return nil, err
-	}
+	// upgradedClientState, err := k.cdc.Marshal(msg.ClientState)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// // Backwards Compatibility: the light client module is expecting
+	// // to unmarshal an interface so we marshal the consensus state Any
+	// upgradedConsensusState, err := k.cdc.Marshal(msg.ConsensusState)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	if err := k.ClientKeeper.UpgradeClient(
 		ctx, msg.ClientId,
-		upgradedClientState,
-		upgradedConsensusState,
+		msg.ClientState.Value,
+		msg.ConsensusState.Value,
 		msg.ProofUpgradeClient,
 		msg.ProofUpgradeConsensusState,
 	); err != nil {

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -68,9 +68,9 @@ func (k Keeper) UpdateClient(goCtx context.Context, msg *clienttypes.MsgUpdateCl
 
 // UpgradeClient defines a rpc handler method for MsgUpgradeClient.
 // NOTE: The raw bytes of the conretes types encoded into protobuf.Any is passed to the client keeper.
-// The 02-client handler will route to the appropriate light client module based on client identifier and it is the responsiblity
+// The 02-client handler will route to the appropriate light client module based on client identifier and it is the responsibility
 // of the light client module to unmarshal and interpret the proto encoded bytes.
-// Backwards compatability with older versions of ibc-go is maintained through the light client module reconstructing and encoding
+// Backwards compatibility with older versions of ibc-go is maintained through the light client module reconstructing and encoding
 // the expected concrete type to the protobuf.Any for proof verification.
 func (k Keeper) UpgradeClient(goCtx context.Context, msg *clienttypes.MsgUpgradeClient) (*clienttypes.MsgUpgradeClientResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/modules/light-clients/07-tendermint/light_client_module.go
+++ b/modules/light-clients/07-tendermint/light_client_module.go
@@ -277,29 +277,17 @@ func (lcm LightClientModule) VerifyUpgradeAndUpdateState(
 	upgradeClientProof,
 	upgradeConsensusStateProof []byte,
 ) error {
-	var (
-		cdc               = lcm.keeper.Codec()
-		newClientState    ClientState
-		newConsensusState ConsensusState
-	)
+	cdc := lcm.keeper.Codec()
 
+	var newClientState ClientState
 	if err := cdc.Unmarshal(newClient, &newClientState); err != nil {
-		return err
+		return errorsmod.Wrap(clienttypes.ErrInvalidClient, err.Error())
 	}
 
-	// newTmClientState, ok := newClientState.(*ClientState)
-	// if !ok {
-	// 	return errorsmod.Wrapf(clienttypes.ErrInvalidClient, "expected client state type %T, got %T", (*ClientState)(nil), newClientState)
-	// }
-
+	var newConsensusState ConsensusState
 	if err := cdc.Unmarshal(newConsState, &newConsensusState); err != nil {
-		return err
+		return errorsmod.Wrap(clienttypes.ErrInvalidConsensus, err.Error())
 	}
-
-	// newTmConsensusState, ok := newConsensusState.(*ConsensusState)
-	// if !ok {
-	// 	return errorsmod.Wrapf(clienttypes.ErrInvalidConsensus, "expected consensus state type %T, got %T", (*ConsensusState)(nil), newConsensusState)
-	// }
 
 	clientStore := lcm.storeProvider.ClientStore(ctx, clientID)
 	clientState, found := getClientState(clientStore, cdc)

--- a/modules/light-clients/07-tendermint/light_client_module_test.go
+++ b/modules/light-clients/07-tendermint/light_client_module_test.go
@@ -181,7 +181,7 @@ func (suite *TendermintTestSuite) TestVerifyUpgradeAndUpdateState() {
 		{
 			"upgraded client state height is not greater than current height",
 			func() {
-				// last Height is at next block
+				// upgrade height is at next block
 				upgradeHeight := clienttypes.NewHeight(1, uint64(suite.chainB.GetContext().BlockHeight()+1))
 
 				// zero custom fields and store in upgrade store

--- a/modules/light-clients/07-tendermint/light_client_module_test.go
+++ b/modules/light-clients/07-tendermint/light_client_module_test.go
@@ -6,12 +6,13 @@ import (
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	commitmenttypes "github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
 	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
 	ibcerrors "github.com/cosmos/ibc-go/v8/modules/core/errors"
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
-	solomachine "github.com/cosmos/ibc-go/v8/modules/light-clients/06-solomachine"
 	ibctm "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
 	ibctesting "github.com/cosmos/ibc-go/v8/testing"
 )
@@ -116,7 +117,7 @@ func (suite *TendermintTestSuite) TestVerifyUpgradeAndUpdateState() {
 		clientID                                              string
 		path                                                  *ibctesting.Path
 		upgradedClientState                                   exported.ClientState
-		upgradedClientStateBz, upgradedConsensusStateBz       []byte
+		upgradedClientStateAny, upgradedConsensusStateAny     *codectypes.Any
 		upgradedClientStateProof, upgradedConsensusStateProof []byte
 	)
 
@@ -133,10 +134,13 @@ func (suite *TendermintTestSuite) TestVerifyUpgradeAndUpdateState() {
 
 				// zero custom fields and store in upgrade store
 				zeroedUpgradedClient := upgradedClientState.(*ibctm.ClientState).ZeroCustomFields()
-				zeroedUpgradedClientBz := clienttypes.MustMarshalClientState(suite.chainA.Codec, zeroedUpgradedClient)
-				err := suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedClient(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), zeroedUpgradedClientBz)
+				zeroedUpgradedClientAny, err := codectypes.NewAnyWithValue(zeroedUpgradedClient)
 				suite.Require().NoError(err)
-				err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedConsensusState(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), upgradedConsensusStateBz)
+
+				err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedClient(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), suite.chainB.Codec.MustMarshal(zeroedUpgradedClientAny))
+				suite.Require().NoError(err)
+
+				err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedConsensusState(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), suite.chainB.Codec.MustMarshal(upgradedConsensusStateAny))
 				suite.Require().NoError(err)
 
 				// commit upgrade store changes and update clients
@@ -159,14 +163,18 @@ func (suite *TendermintTestSuite) TestVerifyUpgradeAndUpdateState() {
 		{
 			"upgraded client state is not for tendermint client state",
 			func() {
-				upgradedClientStateBz = clienttypes.MustMarshalClientState(suite.chainA.Codec, solomachine.NewClientState(0, &solomachine.ConsensusState{}))
+				upgradedClientStateAny = &codectypes.Any{
+					Value: []byte("invalid client state bytes"),
+				}
 			},
 			clienttypes.ErrInvalidClient,
 		},
 		{
 			"upgraded consensus state is not tendermint consensus state",
 			func() {
-				upgradedConsensusStateBz = clienttypes.MustMarshalConsensusState(suite.chainA.Codec, &solomachine.ConsensusState{})
+				upgradedConsensusStateAny = &codectypes.Any{
+					Value: []byte("invalid consensus state bytes"),
+				}
 			},
 			clienttypes.ErrInvalidConsensus,
 		},
@@ -174,14 +182,17 @@ func (suite *TendermintTestSuite) TestVerifyUpgradeAndUpdateState() {
 			"upgraded client state height is not greater than current height",
 			func() {
 				// last Height is at next block
-				lastHeight := clienttypes.NewHeight(1, uint64(suite.chainB.GetContext().BlockHeight()+1))
+				upgradeHeight := clienttypes.NewHeight(1, uint64(suite.chainB.GetContext().BlockHeight()+1))
 
 				// zero custom fields and store in upgrade store
 				zeroedUpgradedClient := upgradedClientState.(*ibctm.ClientState).ZeroCustomFields()
-				zeroedUpgradedClientBz := clienttypes.MustMarshalClientState(suite.chainA.Codec, zeroedUpgradedClient)
-				err := suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedClient(suite.chainB.GetContext(), int64(lastHeight.GetRevisionHeight()), zeroedUpgradedClientBz)
+				zeroedUpgradedClientAny, err := codectypes.NewAnyWithValue(zeroedUpgradedClient)
 				suite.Require().NoError(err)
-				err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedConsensusState(suite.chainB.GetContext(), int64(lastHeight.GetRevisionHeight()), upgradedConsensusStateBz)
+
+				err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedClient(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), suite.chainB.Codec.MustMarshal(zeroedUpgradedClientAny))
+				suite.Require().NoError(err)
+
+				err = suite.chainB.GetSimApp().UpgradeKeeper.SetUpgradedConsensusState(suite.chainB.GetContext(), int64(upgradeHeight.GetRevisionHeight()), suite.chainB.Codec.MustMarshal(upgradedConsensusStateAny))
 				suite.Require().NoError(err)
 
 				// change upgraded client state height to be lower than current client state height
@@ -191,15 +202,15 @@ func (suite *TendermintTestSuite) TestVerifyUpgradeAndUpdateState() {
 				suite.Require().True(ok)
 
 				tmClient.LatestHeight = newLatestheight.(clienttypes.Height)
-				upgradedClientStateBz = clienttypes.MustMarshalClientState(suite.chainA.Codec, tmClient)
+				upgradedClientStateAny, err = codectypes.NewAnyWithValue(tmClient)
 				suite.Require().NoError(err)
 
 				suite.coordinator.CommitBlock(suite.chainB)
 				err = path.EndpointA.UpdateClient()
 				suite.Require().NoError(err)
 
-				upgradedClientStateProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(lastHeight.GetRevisionHeight())), path.EndpointA.GetClientLatestHeight().GetRevisionHeight())
-				upgradedConsensusStateProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(lastHeight.GetRevisionHeight())), path.EndpointA.GetClientLatestHeight().GetRevisionHeight())
+				upgradedClientStateProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedClientKey(int64(upgradeHeight.GetRevisionHeight())), path.EndpointA.GetClientLatestHeight().GetRevisionHeight())
+				upgradedConsensusStateProof, _ = suite.chainB.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(int64(upgradeHeight.GetRevisionHeight())), path.EndpointA.GetClientLatestHeight().GetRevisionHeight())
 			},
 			ibcerrors.ErrInvalidHeight,
 		},
@@ -209,10 +220,10 @@ func (suite *TendermintTestSuite) TestVerifyUpgradeAndUpdateState() {
 		tc := tc
 		suite.Run(tc.name, func() {
 			suite.SetupTest() // reset
-			var err error
 
 			path = ibctesting.NewPath(suite.chainA, suite.chainB)
 			path.SetupClients()
+
 			clientID = path.EndpointA.ClientID
 			clientState := path.EndpointA.GetClientState().(*ibctm.ClientState)
 			revisionNumber := clienttypes.ParseChainID(clientState.ChainId)
@@ -222,23 +233,25 @@ func (suite *TendermintTestSuite) TestVerifyUpgradeAndUpdateState() {
 			suite.Require().NoError(err)
 
 			upgradedClientState = ibctm.NewClientState(newChainID, ibctm.DefaultTrustLevel, trustingPeriod, newUnbondindPeriod, maxClockDrift, clienttypes.NewHeight(revisionNumber+1, clientState.LatestHeight.GetRevisionHeight()+1), commitmenttypes.GetSDKSpecs(), upgradePath)
-			upgradedClientStateBz = clienttypes.MustMarshalClientState(suite.chainA.Codec, upgradedClientState)
+			upgradedClientStateAny, err = codectypes.NewAnyWithValue(upgradedClientState)
+			suite.Require().NoError(err)
 
 			nextValsHash := sha256.Sum256([]byte("new-nextValsHash"))
 			upgradedConsensusState := ibctm.NewConsensusState(time.Now(), commitmenttypes.NewMerkleRoot([]byte("new-hash")), nextValsHash[:])
-			upgradedConsensusStateBz = clienttypes.MustMarshalConsensusState(suite.chainA.Codec, upgradedConsensusState)
+
+			upgradedConsensusStateAny, err = codectypes.NewAnyWithValue(upgradedConsensusState)
 			suite.Require().NoError(err)
+
+			tc.malleate()
 
 			lightClientModule, found := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetRouter().GetRoute(clientID)
 			suite.Require().True(found)
 
-			tc.malleate()
-
 			err = lightClientModule.VerifyUpgradeAndUpdateState(
 				suite.chainA.GetContext(),
 				clientID,
-				upgradedClientStateBz,
-				upgradedConsensusStateBz,
+				upgradedClientStateAny.Value,
+				upgradedConsensusStateAny.Value,
 				upgradedClientStateProof,
 				upgradedConsensusStateProof,
 			)
@@ -247,8 +260,9 @@ func (suite *TendermintTestSuite) TestVerifyUpgradeAndUpdateState() {
 			if expPass {
 				suite.Require().NoError(err)
 
-				clientStateBz := clienttypes.MustMarshalClientState(suite.chainA.Codec, upgradedClientState)
-				suite.Require().Equal(upgradedClientStateBz, clientStateBz)
+				clientStateAny, err := codectypes.NewAnyWithValue(upgradedClientState)
+				suite.Require().NoError(err)
+				suite.Require().Equal(upgradedClientStateAny.Value, clientStateAny.Value)
 
 				consensusState, found := suite.chainA.GetConsensusState(clientID, path.EndpointA.GetClientLatestHeight())
 				suite.Require().True(found)

--- a/modules/light-clients/07-tendermint/upgrade.go
+++ b/modules/light-clients/07-tendermint/upgrade.go
@@ -43,6 +43,7 @@ func (cs ClientState) VerifyUpgradeAndUpdateState(
 		return errorsmod.Wrapf(clienttypes.ErrInvalidClientType, "upgraded client must be Tendermint client. expected: %T got: %T",
 			&ClientState{}, upgradedClient)
 	}
+
 	tmUpgradeConsState, ok := upgradedConsState.(*ConsensusState)
 	if !ok {
 		return errorsmod.Wrapf(clienttypes.ErrInvalidConsensus, "upgraded consensus state must be Tendermint consensus state. expected %T, got: %T",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR removes the extra marshalling step encoding the `pb.Any` of client/consensus state to bytes in core IBC.
It's possible to simply pass along the bytes of the underlying concrete type to the light client module, and it can take responsibility to remarshal the `pb.Any` for proving counterparty state. 

This PR adjusts the tests to account for this change.

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
