### PR TITLE
chore: Add gRPC validation for EscrowAddress

### DIFF
--- a/modules/apps/transfer/keeper/grpc_query.go
+++ b/modules/apps/transfer/keeper/grpc_query.go
@@ -126,8 +126,7 @@ func (k Keeper) EscrowAddress(c context.Context, req *types.QueryEscrowAddressRe
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
-	found := k.channelKeeper.HasChannel(ctx, req.PortId, req.ChannelId)
-	if !found {
+	if !k.channelKeeper.HasChannel(ctx, req.PortId, req.ChannelId) {
 		return nil, status.Error(
 			codes.NotFound,
 			errorsmod.Wrapf(channeltypes.ErrChannelNotFound, "port-id: %s, channel-id %s", req.PortId, req.ChannelId).Error(),

--- a/modules/apps/transfer/keeper/grpc_query.go
+++ b/modules/apps/transfer/keeper/grpc_query.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	errors "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
-	host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
+	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
 )
 
 var _ types.QueryServer = (*Keeper)(nil)

--- a/modules/apps/transfer/keeper/grpc_query.go
+++ b/modules/apps/transfer/keeper/grpc_query.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
-	errors "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
+	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
 )
 
@@ -130,7 +130,7 @@ func (k Keeper) EscrowAddress(c context.Context, req *types.QueryEscrowAddressRe
 	if !found {
 		return nil, status.Error(
 			codes.NotFound,
-			errorsmod.Wrapf(errors.ErrChannelNotFound, "port-id: %s, channel-id %s", req.PortId, req.ChannelId).Error(),
+			errorsmod.Wrapf(channeltypes.ErrChannelNotFound, "port-id: %s, channel-id %s", req.PortId, req.ChannelId).Error(),
 		)
 	}
 

--- a/modules/apps/transfer/keeper/grpc_query.go
+++ b/modules/apps/transfer/keeper/grpc_query.go
@@ -129,7 +129,7 @@ func (k Keeper) EscrowAddress(c context.Context, req *types.QueryEscrowAddressRe
 	if !k.channelKeeper.HasChannel(ctx, req.PortId, req.ChannelId) {
 		return nil, status.Error(
 			codes.NotFound,
-			errorsmod.Wrapf(channeltypes.ErrChannelNotFound, "port-id: %s, channel-id %s", req.PortId, req.ChannelId).Error(),
+			errorsmod.Wrapf(channeltypes.ErrChannelNotFound, "port ID (%s) channel ID (%s)", req.PortId, req.ChannelId).Error(),
 		)
 	}
 

--- a/modules/apps/transfer/keeper/grpc_query.go
+++ b/modules/apps/transfer/keeper/grpc_query.go
@@ -126,7 +126,7 @@ func (k Keeper) EscrowAddress(c context.Context, req *types.QueryEscrowAddressRe
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
-	_, found := k.channelKeeper.GetChannel(ctx, req.PortId, req.ChannelId)
+	found := k.channelKeeper.HasChannel(ctx, req.PortId, req.ChannelId)
 	if !found {
 		return nil, status.Error(
 			codes.NotFound,

--- a/modules/apps/transfer/keeper/grpc_query.go
+++ b/modules/apps/transfer/keeper/grpc_query.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	errors "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
+	host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
 )
 
 var _ types.QueryServer = (*Keeper)(nil)
@@ -113,7 +114,7 @@ func (k Keeper) DenomHash(c context.Context, req *types.QueryDenomHashRequest) (
 }
 
 // EscrowAddress implements the EscrowAddress gRPC method
-func (Keeper) EscrowAddress(c context.Context, req *types.QueryEscrowAddressRequest) (*types.QueryEscrowAddressResponse, error) {
+func (k Keeper) EscrowAddress(c context.Context, req *types.QueryEscrowAddressRequest) (*types.QueryEscrowAddressResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}

--- a/modules/apps/transfer/keeper/grpc_query.go
+++ b/modules/apps/transfer/keeper/grpc_query.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+	errors "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 )
 
 var _ types.QueryServer = (*Keeper)(nil)
@@ -118,7 +119,7 @@ func (Keeper) EscrowAddress(c context.Context, req *types.QueryEscrowAddressRequ
 	}
 
 	addr := types.GetEscrowAddress(req.PortId, req.ChannelId)
-	
+
 	if err := validategRPCRequest(req.PortId, req.ChannelId); err != nil {
 		return nil, err
 	}
@@ -128,7 +129,7 @@ func (Keeper) EscrowAddress(c context.Context, req *types.QueryEscrowAddressRequ
 	if !found {
 		return nil, status.Error(
 			codes.NotFound,
-			errorsmod.Wrapf(types.ErrChannelNotFound, "port-id: %s, channel-id %s", req.PortId, req.ChannelId).Error(),
+			errorsmod.Wrapf(errors.ErrChannelNotFound, "port-id: %s, channel-id %s", req.PortId, req.ChannelId).Error(),
 		)
 	}
 

--- a/modules/apps/transfer/keeper/grpc_query.go
+++ b/modules/apps/transfer/keeper/grpc_query.go
@@ -118,6 +118,19 @@ func (Keeper) EscrowAddress(c context.Context, req *types.QueryEscrowAddressRequ
 	}
 
 	addr := types.GetEscrowAddress(req.PortId, req.ChannelId)
+	
+	if err := validategRPCRequest(req.PortId, req.ChannelId); err != nil {
+		return nil, err
+	}
+
+	ctx := sdk.UnwrapSDKContext(c)
+	_, found := k.channelKeeper.GetChannel(ctx, req.PortId, req.ChannelId)
+	if !found {
+		return nil, status.Error(
+			codes.NotFound,
+			errorsmod.Wrapf(types.ErrChannelNotFound, "port-id: %s, channel-id %s", req.PortId, req.ChannelId).Error(),
+		)
+	}
 
 	return &types.QueryEscrowAddressResponse{
 		EscrowAddress: addr.String(),
@@ -141,4 +154,16 @@ func (k Keeper) TotalEscrowForDenom(c context.Context, req *types.QueryTotalEscr
 	return &types.QueryTotalEscrowForDenomResponse{
 		Amount: amount,
 	}, nil
+}
+
+func validategRPCRequest(portID, channelID string) error {
+	if err := host.PortIdentifierValidator(portID); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if err := host.ChannelIdentifierValidator(channelID); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	return nil
 }

--- a/modules/apps/transfer/keeper/grpc_query_test.go
+++ b/modules/apps/transfer/keeper/grpc_query_test.go
@@ -238,18 +238,9 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 		{
 			"success",
 			func() {
-
-				path := ibctesting.NewPath(suite.chainA, suite.chainB)
-				path.SetupConnections()
-				path.SetChannelOrdered()
-
-				// init channel
-				err := path.EndpointA.ChanOpenInit()
-				suite.Require().NoError(err)
-
 				req = &types.QueryEscrowAddressRequest{
-					PortId:    path.EndpointA.ChannelConfig.PortID,
-					ChannelId: path.EndpointA.ChannelID,
+					PortId:    ibctesting.TransferPort,
+					ChannelId: ibctesting.FirstChannelID,
 				}
 			},
 			true,
@@ -258,7 +249,7 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 			"failure - channel not found",
 			func() {
 				req = &types.QueryEscrowAddressRequest{
-					PortId:    ibctesting.TransferPort,
+					PortId:    ibctesting.InvalidID,
 					ChannelId: ibctesting.FirstChannelID,
 				}
 			},
@@ -270,6 +261,8 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 		tc := tc
 		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
 			suite.SetupTest() // reset
+			path := ibctesting.NewTransferPath(suite.chainA, suite.chainB)
+			path.Setup()
 
 			tc.malleate()
 			ctx := suite.chainA.GetContext()
@@ -278,7 +271,7 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 
 			if tc.expPass {
 				suite.Require().NoError(err)
-				expected := types.GetEscrowAddress(req.PortId, req.ChannelId).String()
+				expected := types.GetEscrowAddress(ibctesting.TransferPort, ibctesting.FirstChannelID).String()
 				suite.Require().Equal(expected, res.EscrowAddress)
 			} else {
 				suite.Require().Error(err)

--- a/modules/apps/transfer/keeper/grpc_query_test.go
+++ b/modules/apps/transfer/keeper/grpc_query_test.go
@@ -254,6 +254,16 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 			},
 			true,
 		},
+		{
+			"failure - channel not found",
+			func() {
+				req = &types.QueryEscrowAddressRequest{
+					PortId:    ibctesting.TransferPort,
+					ChannelId: ibctesting.FirstChannelID,
+				}
+			},
+			false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/modules/apps/transfer/keeper/grpc_query_test.go
+++ b/modules/apps/transfer/keeper/grpc_query_test.go
@@ -246,11 +246,21 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 			true,
 		},
 		{
-			"failure - channel not found",
+			"failure - channel not found due to invalid portID",
 			func() {
 				req = &types.QueryEscrowAddressRequest{
 					PortId:    ibctesting.InvalidID,
 					ChannelId: ibctesting.FirstChannelID,
+				}
+			},
+			false,
+		},		
+		{
+			"failure - channel not found due to invalid channelID",
+			func() {
+				req = &types.QueryEscrowAddressRequest{
+					PortId:    ibctesting.TransferPort,
+					ChannelId: ibctesting.InvalidID,
 				}
 			},
 			false,

--- a/modules/apps/transfer/keeper/grpc_query_test.go
+++ b/modules/apps/transfer/keeper/grpc_query_test.go
@@ -238,9 +238,18 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 		{
 			"success",
 			func() {
+
+				path := ibctesting.NewPath(suite.chainA, suite.chainB)
+				path.SetupConnections()
+				path.SetChannelOrdered()
+
+				// init channel
+				err := path.EndpointA.ChanOpenInit()
+				suite.Require().NoError(err)
+
 				req = &types.QueryEscrowAddressRequest{
-					PortId:    ibctesting.TransferPort,
-					ChannelId: ibctesting.FirstChannelID,
+					PortId:    path.EndpointA.ChannelConfig.PortID,
+					ChannelId: path.EndpointA.ChannelID,
 				}
 			},
 			true,
@@ -259,7 +268,7 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 
 			if tc.expPass {
 				suite.Require().NoError(err)
-				expected := types.GetEscrowAddress(ibctesting.TransferPort, ibctesting.FirstChannelID).String()
+				expected := types.GetEscrowAddress(req.PortId, req.ChannelId).String()
 				suite.Require().Equal(expected, res.EscrowAddress)
 			} else {
 				suite.Require().Error(err)

--- a/modules/apps/transfer/keeper/grpc_query_test.go
+++ b/modules/apps/transfer/keeper/grpc_query_test.go
@@ -254,7 +254,7 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 				}
 			},
 			false,
-		},		
+		},
 		{
 			"failure - channel not found due to invalid channelID",
 			func() {

--- a/modules/apps/transfer/keeper/grpc_query_test.go
+++ b/modules/apps/transfer/keeper/grpc_query_test.go
@@ -246,7 +246,7 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 			true,
 		},
 		{
-			"failure - channel not found due to invalid portID",
+			"failure - channel not found",
 			func() {
 				req = &types.QueryEscrowAddressRequest{
 					PortId:    ibctesting.InvalidID,
@@ -256,11 +256,21 @@ func (suite *KeeperTestSuite) TestEscrowAddress() {
 			false,
 		},
 		{
-			"failure - channel not found due to invalid channelID",
+			"failure - empty channelID",
 			func() {
 				req = &types.QueryEscrowAddressRequest{
 					PortId:    ibctesting.TransferPort,
-					ChannelId: ibctesting.InvalidID,
+					ChannelId: "",
+				}
+			},
+			false,
+		},
+		{
+			"failure - empty portID",
+			func() {
+				req = &types.QueryEscrowAddressRequest{
+					PortId:    "",
+					ChannelId: ibctesting.FirstChannelID,
 				}
 			},
 			false,

--- a/modules/apps/transfer/types/errors.go
+++ b/modules/apps/transfer/types/errors.go
@@ -16,4 +16,5 @@ var (
 	ErrMaxTransferChannels     = errorsmod.Register(ModuleName, 9, "max transfer channels")
 	ErrInvalidAuthorization    = errorsmod.Register(ModuleName, 10, "invalid transfer authorization")
 	ErrInvalidMemo             = errorsmod.Register(ModuleName, 11, "invalid memo")
+	ErrChannelNotFound         = errorsmod.Register(ModuleName, 12, "channel not found")
 )

--- a/modules/apps/transfer/types/errors.go
+++ b/modules/apps/transfer/types/errors.go
@@ -16,5 +16,4 @@ var (
 	ErrMaxTransferChannels     = errorsmod.Register(ModuleName, 9, "max transfer channels")
 	ErrInvalidAuthorization    = errorsmod.Register(ModuleName, 10, "invalid transfer authorization")
 	ErrInvalidMemo             = errorsmod.Register(ModuleName, 11, "invalid memo")
-	ErrChannelNotFound         = errorsmod.Register(ModuleName, 12, "channel not found")
 )

--- a/modules/apps/transfer/types/expected_keepers.go
+++ b/modules/apps/transfer/types/expected_keepers.go
@@ -39,6 +39,8 @@ type ChannelKeeper interface {
 	GetChannel(ctx sdk.Context, srcPort, srcChan string) (channel channeltypes.Channel, found bool)
 	GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool)
 	GetAllChannelsWithPortPrefix(ctx sdk.Context, portPrefix string) []channeltypes.IdentifiedChannel
+
+	HasChannel(ctx sdk.Context, portID, channelID string) bool
 }
 
 // ClientKeeper defines the expected IBC client keeper

--- a/modules/apps/transfer/types/expected_keepers.go
+++ b/modules/apps/transfer/types/expected_keepers.go
@@ -39,7 +39,6 @@ type ChannelKeeper interface {
 	GetChannel(ctx sdk.Context, srcPort, srcChan string) (channel channeltypes.Channel, found bool)
 	GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool)
 	GetAllChannelsWithPortPrefix(ctx sdk.Context, portPrefix string) []channeltypes.IdentifiedChannel
-
 	HasChannel(ctx sdk.Context, portID, channelID string) bool
 }
 


### PR DESCRIPTION
## Description

Added gRPC validation for EscrowAddress in apps/transfer/keeper

ref: #4140 

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved validation logic for gRPC request parameters in the transfer service.
- **Bug Fixes**
	- Enhanced error handling for non-existent channels in transfer queries.
- **Tests**
	- Added new test cases for transfer service to cover scenarios with invalid channel identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->