### PR TITLE
chore: use `NotEmpty(x)` instead `NotZero(len(x))`

### DIFF
--- a/e2e/tests/interchain_accounts/base_test.go
+++ b/e2e/tests/interchain_accounts/base_test.go
@@ -90,7 +90,7 @@ func (s *InterchainAccountsTestSuite) testMsgSendTxSuccessfulTransfer(order chan
 		var err error
 		hostAccount, err = s.QueryInterchainAccount(ctx, chainA, controllerAddress, ibctesting.FirstConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(hostAccount))
+		s.Require().NotEmpty(hostAccount)
 
 		channels, err := relayer.GetChannels(ctx, s.GetRelayerExecReporter(), chainA.Config().ChainID)
 		s.Require().NoError(err)
@@ -189,7 +189,7 @@ func (s *InterchainAccountsTestSuite) TestMsgSendTx_FailedTransfer_InsufficientF
 		var err error
 		hostAccount, err = s.QueryInterchainAccount(ctx, chainA, controllerAddress, ibctesting.FirstConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(hostAccount))
+		s.Require().NotEmpty(hostAccount)
 
 		channels, err := relayer.GetChannels(ctx, s.GetRelayerExecReporter(), chainA.Config().ChainID)
 		s.Require().NoError(err)
@@ -287,7 +287,7 @@ func (s *InterchainAccountsTestSuite) TestMsgSendTx_SuccessfulTransfer_AfterReop
 		var err error
 		hostAccount, err = s.QueryInterchainAccount(ctx, chainA, controllerAddress, ibctesting.FirstConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(hostAccount))
+		s.Require().NotEmpty(hostAccount)
 
 		_, err = s.QueryChannel(ctx, chainA, portID, initialChannelID)
 		s.Require().NoError(err)
@@ -467,7 +467,7 @@ func (s *InterchainAccountsTestSuite) testMsgSendTxSuccessfulGovProposal(order c
 		var err error
 		hostAccount, err = s.QueryInterchainAccount(ctx, chainA, controllerAddress, ibctesting.FirstConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(hostAccount))
+		s.Require().NotEmpty(hostAccount)
 
 		channels, err := relayer.GetChannels(ctx, s.GetRelayerExecReporter(), chainA.Config().ChainID)
 		s.Require().NoError(err)

--- a/e2e/tests/interchain_accounts/localhost_test.go
+++ b/e2e/tests/interchain_accounts/localhost_test.go
@@ -122,7 +122,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_Localhost(
 	t.Run("verify interchain account registration and deposit funds", func(t *testing.T) {
 		interchainAccAddress, err := s.QueryInterchainAccount(ctx, chainA, userAWallet.FormattedAddress(), exported.LocalhostConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(interchainAccAddress))
+		s.Require().NotEmpty(interchainAccAddress)
 
 		walletAmount := ibc.WalletAmount{
 			Address: interchainAccAddress,
@@ -136,7 +136,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_Localhost(
 	t.Run("send packet localhost interchain accounts", func(t *testing.T) {
 		interchainAccAddress, err := s.QueryInterchainAccount(ctx, chainA, userAWallet.FormattedAddress(), exported.LocalhostConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(interchainAccAddress))
+		s.Require().NotEmpty(interchainAccAddress)
 
 		msgSend := &banktypes.MsgSend{
 			FromAddress: interchainAccAddress,
@@ -277,7 +277,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 	t.Run("verify interchain account registration and deposit funds", func(t *testing.T) {
 		interchainAccAddress, err := s.QueryInterchainAccount(ctx, chainA, userAWallet.FormattedAddress(), exported.LocalhostConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(interchainAccAddress))
+		s.Require().NotEmpty(interchainAccAddress)
 
 		walletAmount := ibc.WalletAmount{
 			Address: interchainAccAddress,
@@ -291,7 +291,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 	t.Run("send localhost interchain accounts packet with timeout", func(t *testing.T) {
 		interchainAccAddress, err := s.QueryInterchainAccount(ctx, chainA, userAWallet.FormattedAddress(), exported.LocalhostConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(interchainAccAddress))
+		s.Require().NotEmpty(interchainAccAddress)
 
 		msgSend := &banktypes.MsgSend{
 			FromAddress: interchainAccAddress,
@@ -407,7 +407,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 	t.Run("verify interchain account and existing balance", func(t *testing.T) {
 		interchainAccAddress, err := s.QueryInterchainAccount(ctx, chainA, userAWallet.FormattedAddress(), exported.LocalhostConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(interchainAccAddress))
+		s.Require().NotEmpty(interchainAccAddress)
 
 		balance, err := s.QueryBalance(ctx, chainA, interchainAccAddress, chainADenom)
 		s.Require().NoError(err)
@@ -419,7 +419,7 @@ func (s *LocalhostInterchainAccountsTestSuite) TestInterchainAccounts_ReopenChan
 	t.Run("send packet localhost interchain accounts", func(t *testing.T) {
 		interchainAccAddress, err := s.QueryInterchainAccount(ctx, chainA, userAWallet.FormattedAddress(), exported.LocalhostConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(interchainAccAddress))
+		s.Require().NotEmpty(interchainAccAddress)
 
 		msgSend := &banktypes.MsgSend{
 			FromAddress: interchainAccAddress,

--- a/e2e/tests/interchain_accounts/params_test.go
+++ b/e2e/tests/interchain_accounts/params_test.go
@@ -155,7 +155,7 @@ func (s *InterchainAccountsParamsTestSuite) TestHostEnabledParam() {
 			var err error
 			hostAccount, err = s.QueryInterchainAccount(ctx, chainA, controllerAddress, ibctesting.FirstConnectionID)
 			s.Require().NoError(err)
-			s.Require().NotZero(len(hostAccount))
+			s.Require().NotEmpty(hostAccount)
 
 			channels, err := relayer.GetChannels(ctx, s.GetRelayerExecReporter(), chainA.Config().ChainID)
 			s.Require().NoError(err)

--- a/e2e/tests/interchain_accounts/query_test.go
+++ b/e2e/tests/interchain_accounts/query_test.go
@@ -66,7 +66,7 @@ func (s *InterchainAccountsQueryTestSuite) TestInterchainAccountsQuery() {
 		var err error
 		hostAccount, err = s.QueryInterchainAccount(ctx, chainA, controllerAddress, ibctesting.FirstConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(hostAccount))
+		s.Require().NotEmpty(hostAccount)
 
 		channels, err := relayer.GetChannels(ctx, s.GetRelayerExecReporter(), chainA.Config().ChainID)
 		s.Require().NoError(err)

--- a/e2e/tests/interchain_accounts/upgrades_test.go
+++ b/e2e/tests/interchain_accounts/upgrades_test.go
@@ -80,7 +80,7 @@ func (s *InterchainAccountsChannelUpgradesTestSuite) TestMsgSendTx_SuccessfulTra
 		var err error
 		hostAccount, err = s.QueryInterchainAccount(ctx, chainA, controllerAddress, ibctesting.FirstConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(hostAccount))
+		s.Require().NotEmpty(hostAccount)
 
 		_, err = s.QueryChannel(ctx, chainA, portID, initialChannelID)
 		s.Require().NoError(err)

--- a/e2e/tests/upgrades/genesis_test.go
+++ b/e2e/tests/upgrades/genesis_test.go
@@ -115,7 +115,7 @@ func (s *GenesisTestSuite) TestIBCGenesis() {
 		var err error
 		hostAccount, err = s.QueryInterchainAccount(ctx, chainA, controllerAddress, ibctesting.FirstConnectionID)
 		s.Require().NoError(err)
-		s.Require().NotZero(len(hostAccount))
+		s.Require().NotEmpty(hostAccount)
 
 		channels, err := relayer.GetChannels(ctx, s.GetRelayerExecReporter(), chainA.Config().ChainID)
 		s.Require().NoError(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

ref: https://github.com/cosmos/ibc-go/pull/6067#discussion_r1546403936

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test assertions for interchain account operations to improve clarity and expressiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->