### PR TITLE
fix: allow base denom with trailing slash

### DIFF
--- a/modules/apps/transfer/types/trace.go
+++ b/modules/apps/transfer/types/trace.go
@@ -199,11 +199,11 @@ func ValidatePrefixedDenom(denom string) error {
 		return nil
 	}
 
-	if strings.TrimSpace(denomSplit[len(denomSplit)-1]) == "" {
+	path, baseDenom := extractPathAndBaseFromFullDenom(denomSplit)
+	if strings.TrimSpace(baseDenom) == "" {
 		return errorsmod.Wrap(ErrInvalidDenomForTransfer, "base denomination cannot be blank")
 	}
 
-	path, _ := extractPathAndBaseFromFullDenom(denomSplit)
 	if path == "" {
 		// NOTE: base denom contains slashes, so no base denomination validation
 		return nil

--- a/modules/apps/transfer/types/trace_test.go
+++ b/modules/apps/transfer/types/trace_test.go
@@ -132,15 +132,16 @@ func TestValidatePrefixedDenom(t *testing.T) {
 		expError bool
 	}{
 		{"prefixed denom", "transfer/channel-1/uatom", false},
+		{"prefixed denom with base denom with leading slash", "transfer/channel-1/uatom/", false},
 		{"prefixed denom with '/'", "transfer/channel-1/gamm/pool/1", false},
 		{"empty prefix", "/uatom", false},
 		{"empty identifiers", "//uatom", false},
 		{"base denom", "uatom", false},
 		{"base denom with single '/'", "erc20/0x85bcBCd7e79Ec36f4fBBDc54F90C643d921151AA", false},
 		{"base denom with multiple '/'s", "gamm/pool/1", false},
+		{"single trace identifier", "transfer/", false},
 		{"invalid port ID", "(transfer)/channel-1/uatom", true},
 		{"empty denom", "", true},
-		{"single trace identifier", "transfer/", true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #6124 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
