### PR TITLE
fix: delete already refunded fees from state if some fee cannot be refunded on channel closure

### DIFF
--- a/modules/apps/29-fee/keeper/escrow.go
+++ b/modules/apps/29-fee/keeper/escrow.go
@@ -206,7 +206,7 @@ func (k Keeper) RefundFeesOnChannelClosure(ctx sdk.Context, portID, channelID st
 				return nil
 			}
 
-			// pre-empitively store the unrefunded fees in case of failure
+			// preemptively store the unrefunded fees in case of failure
 			unRefundedFees = identifiedPacketFee.PacketFees[i:]
 
 			refundAddr, err := sdk.AccAddressFromBech32(packetFee.RefundAddress)

--- a/modules/apps/29-fee/keeper/escrow.go
+++ b/modules/apps/29-fee/keeper/escrow.go
@@ -190,7 +190,8 @@ func (k Keeper) RefundFeesOnChannelClosure(ctx sdk.Context, portID, channelID st
 
 	for _, identifiedPacketFee := range identifiedPacketFees {
 		var failedToSendCoins bool
-		for _, packetFee := range identifiedPacketFee.PacketFees {
+		var unRefundedFees []types.PacketFee
+		for i, packetFee := range identifiedPacketFee.PacketFees {
 
 			if !k.EscrowAccountHasBalance(cacheCtx, packetFee.Fee.Total()) {
 				// if the escrow account does not have sufficient funds then there must exist a severe bug
@@ -205,6 +206,9 @@ func (k Keeper) RefundFeesOnChannelClosure(ctx sdk.Context, portID, channelID st
 				return nil
 			}
 
+			// pre-empitively store the unrefunded fees in case of failure
+			unRefundedFees = identifiedPacketFee.PacketFees[i:]
+
 			refundAddr, err := sdk.AccAddressFromBech32(packetFee.RefundAddress)
 			if err != nil {
 				failedToSendCoins = true
@@ -218,7 +222,11 @@ func (k Keeper) RefundFeesOnChannelClosure(ctx sdk.Context, portID, channelID st
 			}
 		}
 
-		if !failedToSendCoins {
+		if failedToSendCoins {
+			// update packet fees to keep only the unrefunded fees
+			packetFees := types.NewPacketFees(unRefundedFees)
+			k.SetFeesInEscrow(cacheCtx, identifiedPacketFee.PacketId, packetFees)
+		} else {
 			k.DeleteFeesInEscrow(cacheCtx, identifiedPacketFee.PacketId)
 		}
 	}

--- a/modules/apps/29-fee/keeper/escrow_test.go
+++ b/modules/apps/29-fee/keeper/escrow_test.go
@@ -480,7 +480,6 @@ func (suite *KeeperTestSuite) TestRefundFeesOnChannelClosure() {
 		{
 			"invalid refund acc address", func() {
 				// store the fee in state & update escrow account balance
-				//expectEscrowFeesToBeDeleted = false
 				packetID := channeltypes.NewPacketID(suite.path.EndpointA.ChannelConfig.PortID, suite.path.EndpointA.ChannelID, uint64(1))
 				packetFees := types.NewPacketFees([]types.PacketFee{
 					types.NewPacketFee(fee, refundAcc.String(), nil), // this packet fee will be refunded, and will be deleted from state
@@ -501,7 +500,6 @@ func (suite *KeeperTestSuite) TestRefundFeesOnChannelClosure() {
 		},
 		{
 			"distributing to blocked address is skipped", func() {
-				//expectEscrowFeesToBeDeleted = false
 				blockedAddr := suite.chainA.GetSimApp().AccountKeeper.GetModuleAccount(suite.chainA.GetContext(), transfertypes.ModuleName).GetAddress().String()
 
 				// store the fee in state & update escrow account balance
@@ -533,7 +531,6 @@ func (suite *KeeperTestSuite) TestRefundFeesOnChannelClosure() {
 			suite.path.Setup() // setup channel
 			expIdentifiedPacketFees = []types.IdentifiedPacketFees(nil)
 			expEscrowBal = sdk.Coins{}
-			//expectEscrowFeesToBeDeleted = true
 
 			// setup
 			refundAcc = suite.chainA.SenderAccount.GetAddress()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

While refunding fees for a packet on channel closure, some fees could be refunded and some not. Those fees that are refunded should be deleted from state, so that there is no possibility of them being refunded again if the packet fee information for a packet is used somehow.

closes: #XXXX

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
