### PR TITLE
imp: allow memo strings instead of keys for transfer authorizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (apps/27-interchain-accounts) [\#5533](https://github.com/cosmos/ibc-go/pull/5533) ICA host sets the host connection ID on `OnChanOpenTry`, so that ICA controller implementations are not obliged to set the value on `OnChanOpenInit` if they are not able.
 * (apps/27-interchain-accounts, apps/tranfer, apps/29-fee) [\#6253](https://github.com/cosmos/ibc-go/pull/6253) Allow channel handshake to succeed if fee middleware is wired up on one side, but not the other.
-* (apps/transfer) [\#6268](https://github.com/cosmos/ibc-go/pull/6268) Use JSON-encoded memo strings instead of JSON keys in `AllowedPacketData` of transfer authorization.
+* (apps/transfer) [\#6268](https://github.com/cosmos/ibc-go/pull/6268) Use memo strings instead of JSON keys in `AllowedPacketData` of transfer authorization.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (apps/27-interchain-accounts) [\#5533](https://github.com/cosmos/ibc-go/pull/5533) ICA host sets the host connection ID on `OnChanOpenTry`, so that ICA controller implementations are not obliged to set the value on `OnChanOpenInit` if they are not able.
 * (apps/27-interchain-accounts, apps/tranfer, apps/29-fee) [\#6253](https://github.com/cosmos/ibc-go/pull/6253) Allow channel handshake to succeed if fee middleware is wired up on one side, but not the other.
+* (apps/transfer) [\#6268](https://github.com/cosmos/ibc-go/pull/6268) Use JSON-encoded memo strings instead of JSON keys in `AllowedPacketData` of transfer authorization.
 
 ### Features
 

--- a/docs/docs/02-apps/01-transfer/08-authorizations.md
+++ b/docs/docs/02-apps/01-transfer/08-authorizations.md
@@ -22,7 +22,7 @@ It takes:
 
 - an `AllowList` list that specifies the list of addresses that are allowed to receive funds. If this list is empty, then all addresses are allowed to receive funds from the `TransferAuthorization`.
 
-- an `AllowedPacketData` list that specifies the list of memo packet data keys that are allowed to send the packet. If this list is empty, then only an empty memo is allowed (a `memo` field with non-empty content will be denied). If this list includes a single element equal to `"*"`, then any content in `memo` field will be allowed.
+- an `AllowedPacketData` list that specifies the list of (JSON-encoded) memo strings that are allowed to be included in the memo field of the packet. If this list is empty, then only an empty memo is allowed (a `memo` field with non-empty content will be denied). If this list includes a single element equal to `"*"`, then any content in `memo` field will be allowed.
 
 Setting a `TransferAuthorization` is expected to fail if:
 
@@ -51,9 +51,8 @@ type Allocation struct {
   SpendLimit sdk.Coins  
   // allow list of receivers, an empty allow list permits any receiver address
   AllowList []string 
-  // allow list of packet data keys, an empty list prohibits all packet data keys;
-  // a list only with "*" permits any packet data key
+  // allow list of (JSON-encoded) memo strings, an empty list prohibits all memo strings;
+  // a list only with "*" permits any memo string
   AllowedPacketData []string 
 }
-
 ```

--- a/docs/docs/02-apps/01-transfer/08-authorizations.md
+++ b/docs/docs/02-apps/01-transfer/08-authorizations.md
@@ -22,7 +22,7 @@ It takes:
 
 - an `AllowList` list that specifies the list of addresses that are allowed to receive funds. If this list is empty, then all addresses are allowed to receive funds from the `TransferAuthorization`.
 
-- an `AllowedPacketData` list that specifies the list of (JSON-encoded) memo strings that are allowed to be included in the memo field of the packet. If this list is empty, then only an empty memo is allowed (a `memo` field with non-empty content will be denied). If this list includes a single element equal to `"*"`, then any content in `memo` field will be allowed.
+- an `AllowedPacketData` list that specifies the list of memo strings that are allowed to be included in the memo field of the packet. If this list is empty, then only an empty memo is allowed (a `memo` field with non-empty content will be denied). If this list includes a single element equal to `"*"`, then any content in `memo` field will be allowed.
 
 Setting a `TransferAuthorization` is expected to fail if:
 
@@ -51,7 +51,7 @@ type Allocation struct {
   SpendLimit sdk.Coins  
   // allow list of receivers, an empty allow list permits any receiver address
   AllowList []string 
-  // allow list of (JSON-encoded) memo strings, an empty list prohibits all memo strings;
+  // allow list of memo strings, an empty list prohibits all memo strings;
   // a list only with "*" permits any memo string
   AllowedPacketData []string 
 }

--- a/modules/apps/transfer/types/authz.pb.go
+++ b/modules/apps/transfer/types/authz.pb.go
@@ -36,7 +36,7 @@ type Allocation struct {
 	SpendLimit github_com_cosmos_cosmos_sdk_types.Coins `protobuf:"bytes,3,rep,name=spend_limit,json=spendLimit,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.Coins" json:"spend_limit"`
 	// allow list of receivers, an empty allow list permits any receiver address
 	AllowList []string `protobuf:"bytes,4,rep,name=allow_list,json=allowList,proto3" json:"allow_list,omitempty"`
-	// allow list of (JSON-encoded) memo strings, an empty list prohibits all memo strings;
+	// allow list of memo strings, an empty list prohibits all memo strings;
 	// a list only with "*" permits any memo string
 	AllowedPacketData []string `protobuf:"bytes,5,rep,name=allowed_packet_data,json=allowedPacketData,proto3" json:"allowed_packet_data,omitempty"`
 }

--- a/modules/apps/transfer/types/authz.pb.go
+++ b/modules/apps/transfer/types/authz.pb.go
@@ -36,8 +36,8 @@ type Allocation struct {
 	SpendLimit github_com_cosmos_cosmos_sdk_types.Coins `protobuf:"bytes,3,rep,name=spend_limit,json=spendLimit,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.Coins" json:"spend_limit"`
 	// allow list of receivers, an empty allow list permits any receiver address
 	AllowList []string `protobuf:"bytes,4,rep,name=allow_list,json=allowList,proto3" json:"allow_list,omitempty"`
-	// allow list of packet data keys, an empty list prohibits all packet data keys;
-	// a list only with "*" permits any packet data key
+	// allow list of (JSON-encoded) memo strings, an empty list prohibits all memo strings;
+	// a list only with "*" permits any memo string
 	AllowedPacketData []string `protobuf:"bytes,5,rep,name=allowed_packet_data,json=allowedPacketData,proto3" json:"allowed_packet_data,omitempty"`
 }
 

--- a/modules/apps/transfer/types/keys.go
+++ b/modules/apps/transfer/types/keys.go
@@ -30,7 +30,7 @@ const (
 	// DenomPrefix is the prefix used for internal SDK coin representation.
 	DenomPrefix = "ibc"
 
-	// AllowAllPacketDataKeys holds the string key that allows all packet data keys in authz transfer messages
+	// AllowAllPacketDataKeys holds the string key that allows all memo strings in authz transfer messages
 	AllowAllPacketDataKeys = "*"
 
 	KeyTotalEscrowPrefix = "totalEscrowForDenom"

--- a/modules/apps/transfer/types/transfer_authorization.go
+++ b/modules/apps/transfer/types/transfer_authorization.go
@@ -189,14 +189,14 @@ func validateMemo(ctx sdk.Context, memo string, allowedPacketDataList []string) 
 		dst := &bytes.Buffer{}
 		err := json.Compact(dst, []byte(allowedMemo))
 		if err != nil {
-			errorsmod.Wrapf(ErrInvalidAuthorization, "failed to compact allowed memo: %s", allowedMemo)
+			return errorsmod.Wrapf(ErrInvalidAuthorization, "failed to compact allowed memo: %s", allowedMemo)
 		}
 		compactAllowedMemo := dst.String()
 
 		dst = &bytes.Buffer{}
 		err = json.Compact(dst, []byte(memo))
 		if err != nil {
-			errorsmod.Wrapf(ErrInvalidAuthorization, "failed to compact memo: %s", memo)
+			return errorsmod.Wrapf(ErrInvalidAuthorization, "failed to compact memo: %s", memo)
 		}
 		compactMemo := dst.String()
 

--- a/modules/apps/transfer/types/transfer_authorization.go
+++ b/modules/apps/transfer/types/transfer_authorization.go
@@ -187,11 +187,17 @@ func validateMemo(ctx sdk.Context, memo string, allowedPacketDataList []string) 
 		ctx.GasMeter().ConsumeGas(gasCostPerIteration, "transfer authorization")
 
 		dst := &bytes.Buffer{}
-		json.Compact(dst, []byte(allowedMemo))
+		err := json.Compact(dst, []byte(allowedMemo))
+		if err != nil {
+			errorsmod.Wrapf(ErrInvalidAuthorization, "failed to compact allowed memo: %s", allowedMemo)
+		}
 		compactAllowedMemo := dst.String()
 
 		dst = &bytes.Buffer{}
-		json.Compact(dst, []byte(memo))
+		err = json.Compact(dst, []byte(memo))
+		if err != nil {
+			errorsmod.Wrapf(ErrInvalidAuthorization, "failed to compact memo: %s", memo)
+		}
 		compactMemo := dst.String()
 
 		if compactMemo == compactAllowedMemo {

--- a/modules/apps/transfer/types/transfer_authorization.go
+++ b/modules/apps/transfer/types/transfer_authorization.go
@@ -1,9 +1,7 @@
 package types
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"math/big"
 	"strings"
 
@@ -131,16 +129,6 @@ func (a TransferAuthorization) ValidateBasic() error {
 			}
 			found[allocation.AllowList[i]] = true
 		}
-
-		if len(allocation.AllowedPacketData) > 0 && allocation.AllowedPacketData[0] != AllowAllPacketDataKeys {
-			jsonObject := make(map[string]interface{})
-			for _, elem := range allocation.AllowedPacketData {
-				err := json.Unmarshal([]byte(elem), &jsonObject)
-				if err != nil {
-					return errorsmod.Wrapf(ErrInvalidAuthorization, "allowed packet data contains a non JSON-encoded string: %s", elem)
-				}
-			}
-		}
 	}
 
 	return nil
@@ -186,21 +174,7 @@ func validateMemo(ctx sdk.Context, memo string, allowedPacketDataList []string) 
 	for _, allowedMemo := range allowedPacketDataList {
 		ctx.GasMeter().ConsumeGas(gasCostPerIteration, "transfer authorization")
 
-		dst := &bytes.Buffer{}
-		err := json.Compact(dst, []byte(allowedMemo))
-		if err != nil {
-			return errorsmod.Wrapf(ErrInvalidAuthorization, "failed to compact allowed memo: %s", allowedMemo)
-		}
-		compactAllowedMemo := dst.String()
-
-		dst = &bytes.Buffer{}
-		err = json.Compact(dst, []byte(memo))
-		if err != nil {
-			return errorsmod.Wrapf(ErrInvalidAuthorization, "failed to compact memo: %s", memo)
-		}
-		compactMemo := dst.String()
-
-		if compactMemo == compactAllowedMemo {
+		if strings.TrimSpace(memo) == strings.TrimSpace(allowedMemo) {
 			return nil
 		}
 	}

--- a/modules/apps/transfer/types/transfer_authorization.go
+++ b/modules/apps/transfer/types/transfer_authorization.go
@@ -181,11 +181,11 @@ func validateMemo(ctx sdk.Context, memo string, allowedMemos []string) error {
 		}
 	})
 
-	if isMemoAllowed {
-		return nil
-	} else {
+	if !isMemoAllowed {
 		return errorsmod.Wrapf(ErrInvalidAuthorization, "not allowed memo: %s", memo)
 	}
+	
+	return nil
 }
 
 // UnboundedSpendLimit returns the sentinel value that can be used

--- a/modules/apps/transfer/types/transfer_authorization.go
+++ b/modules/apps/transfer/types/transfer_authorization.go
@@ -174,11 +174,7 @@ func validateMemo(ctx sdk.Context, memo string, allowedMemos []string) error {
 	isMemoAllowed := slices.ContainsFunc(allowedMemos, func(allowedMemo string) bool {
 		ctx.GasMeter().ConsumeGas(gasCostPerIteration, "transfer authorization")
 
-		if strings.TrimSpace(memo) == strings.TrimSpace(allowedMemo) {
-			return true
-		} else {
-			return false
-		}
+		return strings.TrimSpace(memo) == strings.TrimSpace(allowedMemo)
 	})
 
 	if !isMemoAllowed {

--- a/modules/apps/transfer/types/transfer_authorization.go
+++ b/modules/apps/transfer/types/transfer_authorization.go
@@ -180,7 +180,7 @@ func validateMemo(ctx sdk.Context, memo string, allowedMemos []string) error {
 	if !isMemoAllowed {
 		return errorsmod.Wrapf(ErrInvalidAuthorization, "not allowed memo: %s", memo)
 	}
-	
+
 	return nil
 }
 

--- a/modules/apps/transfer/types/transfer_authorization_test.go
+++ b/modules/apps/transfer/types/transfer_authorization_test.go
@@ -433,15 +433,7 @@ func (suite *TypesTestSuite) TestTransferAuthorizationValidateBasic() {
 		{
 			name: "non JSON-encoded allowed packet data",
 			malleate: func() {
-				allocation := types.Allocation{
-					SourcePort:        mock.PortID,
-					SourceChannel:     transferAuthz.Allocations[0].SourceChannel,
-					SpendLimit:        sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(100))),
-					AllowList:         []string{ibctesting.TestAccAddress},
-					AllowedPacketData: []string{"forward"},
-				}
-
-				transferAuthz.Allocations = append(transferAuthz.Allocations, allocation)
+				transferAuthz.Allocations[0].AllowedPacketData = []string{"forward"}
 			},
 			expPass: false,
 		},

--- a/modules/apps/transfer/types/transfer_authorization_test.go
+++ b/modules/apps/transfer/types/transfer_authorization_test.go
@@ -1,6 +1,8 @@
 package types_test
 
 import (
+	"fmt"
+
 	sdkmath "cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -170,7 +172,7 @@ func (suite *TypesTestSuite) TestTransferAuthorizationAccept() {
 			},
 			func(res authz.AcceptResponse, err error) {
 				suite.Require().Error(err)
-				suite.Require().ErrorContains(err, "not allowed memo: {\"forward\":{\"channel\":\"channel-11\",\"port\":\"transfer\",\"receiver\":\"stars1twfv52yxcyykx2lcvgl42svw46hsm5dd4ww6xy\",\"retries\":2,\"timeout\":1712146014542131200}}")
+				suite.Require().ErrorContains(err, fmt.Sprintf("not allowed memo: %s", testMemo2))
 			},
 		},
 		{

--- a/modules/apps/transfer/types/transfer_authorization_test.go
+++ b/modules/apps/transfer/types/transfer_authorization_test.go
@@ -38,7 +38,8 @@ const (
 
 func (suite *TypesTestSuite) TestTransferAuthorizationAccept() {
 	dst := &bytes.Buffer{}
-	json.Compact(dst, []byte(testMemo1))
+	err := json.Compact(dst, []byte(testMemo1))
+	suite.NoError(err)
 	compactTestMemo1 := dst.String()
 
 	var (

--- a/proto/ibc/applications/transfer/v1/authz.proto
+++ b/proto/ibc/applications/transfer/v1/authz.proto
@@ -19,8 +19,8 @@ message Allocation {
       [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
   // allow list of receivers, an empty allow list permits any receiver address
   repeated string allow_list = 4;
-  // allow list of packet data keys, an empty list prohibits all packet data keys;
-  // a list only with "*" permits any packet data key
+  // allow list of (JSON-encoded) memo strings, an empty list prohibits all memo strings;
+  // a list only with "*" permits any memo string
   repeated string allowed_packet_data = 5;
 }
 

--- a/proto/ibc/applications/transfer/v1/authz.proto
+++ b/proto/ibc/applications/transfer/v1/authz.proto
@@ -19,7 +19,7 @@ message Allocation {
       [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
   // allow list of receivers, an empty allow list permits any receiver address
   repeated string allow_list = 4;
-  // allow list of (JSON-encoded) memo strings, an empty list prohibits all memo strings;
+  // allow list of memo strings, an empty list prohibits all memo strings;
   // a list only with "*" permits any memo string
   repeated string allowed_packet_data = 5;
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #6095 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Updated the description of `AllowedPacketData` in the `TransferAuthorization` documentation to specify JSON-encoded memo strings.
  
- **New Features**
  - Revised the handling of memo data in authorization processes to utilize JSON-encoded memo strings instead of packet data keys.
  
- **Refactor**
  - Simplified the `validateMemo` function, enhancing memo validation efficiency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->