### PR TITLE
docs: fix the warning syntax error across docs

### DIFF
--- a/docs/docs/01-ibc/03-apps/01-apps.md
+++ b/docs/docs/01-ibc/03-apps/01-apps.md
@@ -314,7 +314,7 @@ sequence, err := IBCChannelKeeper.SendPacket(
 )
 ```
 
-::: warning
+:::warning
 In order to prevent modules from sending packets on channels they do not own, IBC expects
 modules to pass in the correct channel capability for the packet's source channel.
 :::

--- a/docs/docs/01-ibc/06-channel-upgrades.md
+++ b/docs/docs/01-ibc/06-channel-upgrades.md
@@ -70,7 +70,7 @@ As part of the handling of the `MsgChannelUpgradeInit` message, the application'
 
 After this message is handled successfully, the channel's upgrade sequence will be incremented. This upgrade sequence will serve as a nonce for the upgrade process to provide replay protection.
 
-::: warning
+:::warning
 Initiating an upgrade in the same block as opening a channel may potentially prevent the counterparty channel from also opening. 
 :::
 

--- a/docs/docs/02-apps/01-transfer/07-params.md
+++ b/docs/docs/02-apps/01-transfer/07-params.md
@@ -26,7 +26,7 @@ To prevent a single token from being transferred from the chain, set the `SendEn
 - For Cosmos SDK v0.46.x or earlier, set the bank module's [`SendEnabled` parameter](https://github.com/cosmos/cosmos-sdk/blob/release/v0.46.x/x/bank/spec/05_params.md#sendenabled) for the denomination to `false`.
 - For Cosmos SDK versions above v0.46.x, set the bank module's `SendEnabled` entry for the denomination to `false` using `MsgSetSendEnabled` as a governance proposal.
 
-::: warning
+:::warning
 Doing so will prevent the token from being transferred between any accounts in the blockchain.
 :::
 
@@ -39,7 +39,7 @@ To prevent a single token from being transferred to the chain, set the `ReceiveE
 - For Cosmos SDK v0.46.x or earlier, set the bank module's [`SendEnabled` parameter](https://github.com/cosmos/cosmos-sdk/blob/release/v0.46.x/x/bank/spec/05_params.md#sendenabled) for the denomination to `false`.
 - For Cosmos SDK versions above v0.46.x, set the bank module's `SendEnabled` entry for the denomination to `false` using `MsgSetSendEnabled` as a governance proposal.
 
-::: warning
+:::warning
 Doing so will prevent the token from being transferred between any accounts in the blockchain.
 :::
 

--- a/docs/docs/04-middleware/02-callbacks/02-integration.md
+++ b/docs/docs/04-middleware/02-callbacks/02-integration.md
@@ -74,7 +74,7 @@ app.TransferKeeper.WithICS4Wrapper(transferICS4Wrapper)
 ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack)
 ```
 
-::: warning
+:::warning
 The usage of `WithICS4Wrapper` after `transferStack`'s configuration is critical! It allows the callbacks middleware to do `SendPacket` callbacks and asynchronous `ReceivePacket` callbacks. You must do this regardless of whether you are using the `29-fee` middleware or not.
 :::
 
@@ -108,6 +108,6 @@ AddRoute(icacontrollertypes.SubModuleName, icaControllerStack).
 AddRoute(icahosttypes.SubModuleName, icaHostStack).
 ```
 
-::: warning
+:::warning
 The usage of `WithICS4Wrapper` here is also critical!
 :::

--- a/docs/docs/04-middleware/02-callbacks/05-end-users.md
+++ b/docs/docs/04-middleware/02-callbacks/05-end-users.md
@@ -22,7 +22,7 @@ For a given channel, the source callbacks are supported if the source chain has 
 Callbacks are always executed after the packet has been processed by the underlying IBC module.
 :::
 
-::: warning
+:::warning
 If the underlying application module is doing an asynchronous acknowledgement on packet receive (for example, if the [packet forward middleware](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware) is in the stack, and is being used by this packet), then the callbacks middleware will execute the `ReceivePacket` callback after the acknowledgement has been received.
 :::
 

--- a/docs/docs/04-middleware/02-callbacks/05-end-users.md
+++ b/docs/docs/04-middleware/02-callbacks/05-end-users.md
@@ -18,7 +18,7 @@ This section explains how to use the callbacks middleware from the perspective o
 
 For a given channel, the source callbacks are supported if the source chain has the callbacks middleware wired up in the channel's IBC stack. Similarly, the destination callbacks are supported if the destination chain has the callbacks middleware wired up in the channel's IBC stack.
 
-::: tip
+:::tip
 Callbacks are always executed after the packet has been processed by the underlying IBC module.
 :::
 
@@ -85,12 +85,12 @@ User defined gas limit was added for the following reasons:
 - To prevent callbacks from blocking packet lifecycle.
 - To prevent relayers from being able to DOS the callback execution by sending a packet with a low amount of gas.
 
-::: tip
+:::tip
 There is a chain wide parameter that sets the maximum gas limit that a user can set for a callback. This is to prevent a user from setting a gas limit that is too high for relayers. If the `"gas_limit"` is not set in the packet memo, then the maximum gas limit is used.
 :::
 
 These goals are achieved by creating a minimum gas amount required for callback execution. If the relayer provides at least the minimum gas limit for the callback execution, then the packet lifecycle will not be blocked if the callback runs out of gas during execution, and the callback cannot be retried. If the relayer does not provided the minimum amount of gas and the callback executions runs out of gas, the entire tx is reverted and it may be executed again.
 
-::: tip
+:::tip
 `SendPacket` callback is always reverted if the callback execution fails or returns an error for any reason. This is so that the packet is not sent if the callback execution fails.
 :::

--- a/docs/versioned_docs/version-v7.5.x/01-ibc/03-apps/02-ibcmodule.md
+++ b/docs/versioned_docs/version-v7.5.x/01-ibc/03-apps/02-ibcmodule.md
@@ -254,7 +254,7 @@ sequence, err := IBCChannelKeeper.SendPacket(
 )
 ```
 
-::: warning
+:::warning
 In order to prevent modules from sending packets on channels they do not own, IBC expects
 modules to pass in the correct channel capability for the packet's source channel.
 :::

--- a/docs/versioned_docs/version-v7.5.x/04-middleware/02-callbacks/02-integration.md
+++ b/docs/versioned_docs/version-v7.5.x/04-middleware/02-callbacks/02-integration.md
@@ -69,7 +69,7 @@ app.TransferKeeper.WithICS4Wrapper(transferICS4Wrapper)
 ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack)
 ```
 
-::: warning
+:::warning
 The usage of `WithICS4Wrapper` after `transferStack`'s configuration is critical! It allows the callbacks middleware to do `SendPacket` callbacks and asynchronous `ReceivePacket` callbacks. You must do this regardless of whether you are using the `29-fee` middleware or not.
 :::
 
@@ -103,6 +103,6 @@ AddRoute(icacontrollertypes.SubModuleName, icaControllerStack).
 AddRoute(icahosttypes.SubModuleName, icaHostStack).
 ```
 
-::: warning
+:::warning
 The usage of `WithICS4Wrapper` here is also critical!
 :::

--- a/docs/versioned_docs/version-v7.5.x/04-middleware/02-callbacks/05-end-users.md
+++ b/docs/versioned_docs/version-v7.5.x/04-middleware/02-callbacks/05-end-users.md
@@ -22,7 +22,7 @@ For a given channel, the source callbacks are supported if the source chain has 
 Callbacks are always executed after the packet has been processed by the underlying IBC module.
 :::
 
-::: warning
+:::warning
 If the underlying application module is doing an asynchronous acknowledgement on packet receive (for example, if the [packet forward middleware](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware) is in the stack, and is being used by this packet), then the callbacks middleware will execute the `ReceivePacket` callback after the acknowledgement has been received.
 :::
 

--- a/docs/versioned_docs/version-v7.5.x/04-middleware/02-callbacks/05-end-users.md
+++ b/docs/versioned_docs/version-v7.5.x/04-middleware/02-callbacks/05-end-users.md
@@ -18,7 +18,7 @@ This section explains how to use the callbacks middleware from the perspective o
 
 For a given channel, the source callbacks are supported if the source chain has the callbacks middleware wired up in the channel's IBC stack. Similarly, the destination callbacks are supported if the destination chain has the callbacks middleware wired up in the channel's IBC stack.
 
-::: tip
+:::tip
 Callbacks are always executed after the packet has been processed by the underlying IBC module.
 :::
 
@@ -85,12 +85,12 @@ User defined gas limit was added for the following reasons:
 - To prevent callbacks from blocking packet lifecycle.
 - To prevent relayers from being able to DOS the callback execution by sending a packet with a low amount of gas.
 
-::: tip
+:::tip
 There is a chain wide parameter that sets the maximum gas limit that a user can set for a callback. This is to prevent a user from setting a gas limit that is too high for relayers. If the `"gas_limit"` is not set in the packet memo, then the maximum gas limit is used.
 :::
 
 These goals are achieved by creating a minimum gas amount required for callback execution. If the relayer provides at least the minimum gas limit for the callback execution, then the packet lifecycle will not be blocked if the callback runs out of gas during execution, and the callback cannot be retried. If the relayer does not provided the minimum amount of gas and the callback executions runs out of gas, the entire tx is reverted and it may be executed again.
 
-::: tip
+:::tip
 `SendPacket` callback is always reverted if the callback execution fails or returns an error for any reason. This is so that the packet is not sent if the callback execution fails.
 :::

--- a/docs/versioned_docs/version-v8.3.x/01-ibc/03-apps/01-apps.md
+++ b/docs/versioned_docs/version-v8.3.x/01-ibc/03-apps/01-apps.md
@@ -314,7 +314,7 @@ sequence, err := IBCChannelKeeper.SendPacket(
 )
 ```
 
-::: warning
+:::warning
 In order to prevent modules from sending packets on channels they do not own, IBC expects
 modules to pass in the correct channel capability for the packet's source channel.
 :::

--- a/docs/versioned_docs/version-v8.3.x/01-ibc/06-channel-upgrades.md
+++ b/docs/versioned_docs/version-v8.3.x/01-ibc/06-channel-upgrades.md
@@ -70,7 +70,7 @@ As part of the handling of the `MsgChannelUpgradeInit` message, the application'
 
 After this message is handled successfully, the channel's upgrade sequence will be incremented. This upgrade sequence will serve as a nonce for the upgrade process to provide replay protection.
 
-::: warning
+:::warning
 Initiating an upgrade in the same block as opening a channel may potentially prevent the counterparty channel from also opening. 
 :::
 

--- a/docs/versioned_docs/version-v8.3.x/02-apps/01-transfer/07-params.md
+++ b/docs/versioned_docs/version-v8.3.x/02-apps/01-transfer/07-params.md
@@ -26,7 +26,7 @@ To prevent a single token from being transferred from the chain, set the `SendEn
 - For Cosmos SDK v0.46.x or earlier, set the bank module's [`SendEnabled` parameter](https://github.com/cosmos/cosmos-sdk/blob/release/v0.46.x/x/bank/spec/05_params.md#sendenabled) for the denomination to `false`.
 - For Cosmos SDK versions above v0.46.x, set the bank module's `SendEnabled` entry for the denomination to `false` using `MsgSetSendEnabled` as a governance proposal.
 
-::: warning
+:::warning
 Doing so will prevent the token from being transferred between any accounts in the blockchain.
 :::
 
@@ -39,7 +39,7 @@ To prevent a single token from being transferred to the chain, set the `ReceiveE
 - For Cosmos SDK v0.46.x or earlier, set the bank module's [`SendEnabled` parameter](https://github.com/cosmos/cosmos-sdk/blob/release/v0.46.x/x/bank/spec/05_params.md#sendenabled) for the denomination to `false`.
 - For Cosmos SDK versions above v0.46.x, set the bank module's `SendEnabled` entry for the denomination to `false` using `MsgSetSendEnabled` as a governance proposal.
 
-::: warning
+:::warning
 Doing so will prevent the token from being transferred between any accounts in the blockchain.
 :::
 

--- a/docs/versioned_docs/version-v8.3.x/04-middleware/02-callbacks/02-integration.md
+++ b/docs/versioned_docs/version-v8.3.x/04-middleware/02-callbacks/02-integration.md
@@ -69,7 +69,7 @@ app.TransferKeeper.WithICS4Wrapper(transferICS4Wrapper)
 ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack)
 ```
 
-::: warning
+:::warning
 The usage of `WithICS4Wrapper` after `transferStack`'s configuration is critical! It allows the callbacks middleware to do `SendPacket` callbacks and asynchronous `ReceivePacket` callbacks. You must do this regardless of whether you are using the `29-fee` middleware or not.
 :::
 
@@ -103,6 +103,6 @@ AddRoute(icacontrollertypes.SubModuleName, icaControllerStack).
 AddRoute(icahosttypes.SubModuleName, icaHostStack).
 ```
 
-::: warning
+:::warning
 The usage of `WithICS4Wrapper` here is also critical!
 :::

--- a/docs/versioned_docs/version-v8.3.x/04-middleware/02-callbacks/05-end-users.md
+++ b/docs/versioned_docs/version-v8.3.x/04-middleware/02-callbacks/05-end-users.md
@@ -22,7 +22,7 @@ For a given channel, the source callbacks are supported if the source chain has 
 Callbacks are always executed after the packet has been processed by the underlying IBC module.
 :::
 
-::: warning
+:::warning
 If the underlying application module is doing an asynchronous acknowledgement on packet receive (for example, if the [packet forward middleware](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware) is in the stack, and is being used by this packet), then the callbacks middleware will execute the `ReceivePacket` callback after the acknowledgement has been received.
 :::
 

--- a/docs/versioned_docs/version-v8.3.x/04-middleware/02-callbacks/05-end-users.md
+++ b/docs/versioned_docs/version-v8.3.x/04-middleware/02-callbacks/05-end-users.md
@@ -18,7 +18,7 @@ This section explains how to use the callbacks middleware from the perspective o
 
 For a given channel, the source callbacks are supported if the source chain has the callbacks middleware wired up in the channel's IBC stack. Similarly, the destination callbacks are supported if the destination chain has the callbacks middleware wired up in the channel's IBC stack.
 
-::: tip
+:::tip
 Callbacks are always executed after the packet has been processed by the underlying IBC module.
 :::
 
@@ -85,12 +85,12 @@ User defined gas limit was added for the following reasons:
 - To prevent callbacks from blocking packet lifecycle.
 - To prevent relayers from being able to DOS the callback execution by sending a packet with a low amount of gas.
 
-::: tip
+:::tip
 There is a chain wide parameter that sets the maximum gas limit that a user can set for a callback. This is to prevent a user from setting a gas limit that is too high for relayers. If the `"gas_limit"` is not set in the packet memo, then the maximum gas limit is used.
 :::
 
 These goals are achieved by creating a minimum gas amount required for callback execution. If the relayer provides at least the minimum gas limit for the callback execution, then the packet lifecycle will not be blocked if the callback runs out of gas during execution, and the callback cannot be retried. If the relayer does not provided the minimum amount of gas and the callback executions runs out of gas, the entire tx is reverted and it may be executed again.
 
-::: tip
+:::tip
 `SendPacket` callback is always reverted if the callback execution fails or returns an error for any reason. This is so that the packet is not sent if the callback execution fails.
 :::


### PR DESCRIPTION

## Description
some of the warning boxes on the [website](https://ibc.cosmos.network/main) are not showing properly due to an additional space in each syntax. so i removed all the additional spaces in those syntaxes to make them work.
<img width="781" alt="image" src="https://github.com/cosmos/ibc-go/assets/151764357/80f53dfc-e849-45c9-a51f-c243b8c9e4bb">


<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [x] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Review `SonarCloud Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Corrected warning block syntax in multiple documentation files for consistency and clarity.
  - Corrected tip block syntax in middleware documentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->