### PR TITLE
test: add test case for invalid timeout packet amount

### DIFF
--- a/modules/apps/transfer/keeper/relay_test.go
+++ b/modules/apps/transfer/keeper/relay_test.go
@@ -885,7 +885,7 @@ func (suite *KeeperTestSuite) TestOnAcknowledgementPacketSetsTotalEscrowAmountFo
 func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 	var (
 		path            *ibctesting.Path
-		amount          sdkmath.Int
+		amount          string
 		sender          string
 		denom           types.Denom
 		expEscrowAmount sdkmath.Int
@@ -901,7 +901,9 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 			func() {
 				escrow := types.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 				denom = types.NewDenom(sdk.DefaultBondDenom)
-				coin := sdk.NewCoin(denom.IBCDenom(), amount)
+				coinAmount, ok := sdkmath.NewIntFromString(amount)
+				suite.Require().True(ok)
+				coin := sdk.NewCoin(denom.IBCDenom(), coinAmount)
 				expEscrowAmount = sdkmath.ZeroInt()
 
 				// funds the escrow account to have balance
@@ -916,7 +918,9 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 			func() {
 				escrow := types.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 				denom = types.NewDenom(sdk.DefaultBondDenom, types.NewTrace(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID))
-				coin := sdk.NewCoin(denom.IBCDenom(), amount)
+				coinAmount, ok := sdkmath.NewIntFromString(amount)
+				suite.Require().True(ok)
+				coin := sdk.NewCoin(denom.IBCDenom(), coinAmount)
 				expEscrowAmount = sdkmath.ZeroInt()
 
 				// funds the escrow account to have balance
@@ -928,10 +932,12 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 			"failure: funds cannot be refunded because escrow account has no balance for non-native coin",
 			func() {
 				denom = types.NewDenom("bitcoin")
-				expEscrowAmount = amount
+				var ok bool
+				expEscrowAmount, ok = sdkmath.NewIntFromString(amount)
+				suite.Require().True(ok)
 
 				// set escrow amount that would have been stored after successful execution of MsgTransfer
-				suite.chainA.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainA.GetContext(), sdk.NewCoin(denom.IBCDenom(), amount))
+				suite.chainA.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainA.GetContext(), sdk.NewCoin(denom.IBCDenom(), expEscrowAmount))
 			},
 			sdkerrors.ErrInsufficientFunds,
 		},
@@ -939,10 +945,12 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 			"failure: funds cannot be refunded because escrow account has no balance for native coin",
 			func() {
 				denom = types.NewDenom(sdk.DefaultBondDenom)
-				expEscrowAmount = amount
+				var ok bool
+				expEscrowAmount, ok = sdkmath.NewIntFromString(amount)
+				suite.Require().True(ok)
 
 				// set escrow amount that would have been stored after successful execution of MsgTransfer
-				suite.chainA.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainA.GetContext(), sdk.NewCoin(denom.IBCDenom(), amount))
+				suite.chainA.GetSimApp().TransferKeeper.SetTotalEscrowForDenom(suite.chainA.GetContext(), sdk.NewCoin(denom.IBCDenom(), expEscrowAmount))
 			},
 			sdkerrors.ErrInsufficientFunds,
 		},
@@ -950,10 +958,18 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 			"failure: cannot mint because sender address is invalid",
 			func() {
 				denom = types.NewDenom(sdk.DefaultBondDenom)
-				amount = sdkmath.OneInt()
+				amount = sdkmath.OneInt().String()
 				sender = "invalid address"
 			},
 			errors.New("decoding bech32 failed"),
+		},
+		{
+			"failure: invalid amount",
+			func() {
+				denom = types.NewDenom(sdk.DefaultBondDenom)
+				amount = "invalid"
+			},
+			types.ErrInvalidAmount,
 		},
 	}
 
@@ -966,7 +982,7 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 			path = ibctesting.NewTransferPath(suite.chainA, suite.chainB)
 			path.Setup()
 
-			amount = sdkmath.NewInt(100) // must be explicitly changed
+			amount = sdkmath.NewInt(100).String() // must be explicitly changed
 			sender = suite.chainA.SenderAccount.GetAddress().String()
 			expEscrowAmount = sdkmath.ZeroInt()
 
@@ -976,7 +992,7 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 				[]types.Token{
 					{
 						Denom:  denom,
-						Amount: amount.String(),
+						Amount: amount,
 					},
 				}, sender, suite.chainB.SenderAccount.GetAddress().String(), "")
 			packet := channeltypes.NewPacket(data.GetBytes(), 1, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, clienttypes.NewHeight(1, 100), 0)
@@ -994,7 +1010,9 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 			expPass := tc.expError == nil
 			if expPass {
 				suite.Require().NoError(err)
-				suite.Require().Equal(amount.Int64(), deltaAmount.Int64(), "successful timeout did not trigger refund")
+				amountParsed, ok := sdkmath.NewIntFromString(amount)
+				suite.Require().True(ok)
+				suite.Require().Equal(amountParsed, deltaAmount, "successful timeout did not trigger refund")
 			} else {
 				suite.Require().Error(err)
 				suite.Require().ErrorContains(err, tc.expError.Error())


### PR DESCRIPTION
## Description

No related issue, was pulled out of https://github.com/cosmos/ibc-go/pull/6456

Purpose is just to cover another failure case that was discovered by coverage report to not be tested currently.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
