### PR TITLE
chore: Rework Denoms.Sort() to sort by base denom and then trace

### DIFF
--- a/modules/apps/transfer/types/denom.go
+++ b/modules/apps/transfer/types/denom.go
@@ -122,7 +122,17 @@ var _ sort.Interface = (*Denoms)(nil)
 func (d Denoms) Len() int { return len(d) }
 
 // Less implements sort.Interface for Denoms
-func (d Denoms) Less(i, j int) bool { return d[i].Path() < d[j].Path() }
+func (d Denoms) Less(i, j int) bool {
+	if d[i].Base != d[j].Base {
+		return d[i].Base < d[j].Base
+	}
+
+	if len(d[i].Trace) != len(d[j].Base) {
+		return len(d[i].Trace) < len(d[j].Trace)
+	}
+
+	return d[i].Path() < d[j].Path()
+}
 
 // Swap implements sort.Interface for Denoms
 func (d Denoms) Swap(i, j int) { d[i], d[j] = d[j], d[i] }

--- a/modules/apps/transfer/types/denom_test.go
+++ b/modules/apps/transfer/types/denom_test.go
@@ -118,3 +118,92 @@ func (suite *TypesTestSuite) TestPath() {
 		})
 	}
 }
+
+func (suite *TypesTestSuite) TestSort() {
+	testCases := []struct {
+		name      string
+		denoms    types.Denoms
+		expDenoms types.Denoms
+	}{
+		{
+			"only base denom",
+			types.Denoms{types.Denom{Base: "uosmo"}, types.Denom{Base: "gamm"}, types.Denom{Base: "uatom"}},
+			types.Denoms{types.Denom{Base: "gamm"}, types.Denom{Base: "uatom"}, types.Denom{Base: "uosmo"}},
+		},
+		{
+			"different denom and same traces",
+			types.Denoms{
+				types.Denom{
+					Base:  "uosmo",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0")},
+				},
+				types.Denom{
+					Base:  "gamm",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0")},
+				},
+				types.Denom{
+					Base:  "uatom",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0")},
+				},
+			},
+			types.Denoms{
+				types.Denom{
+					Base:  "gamm",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0")},
+				},
+				types.Denom{
+					Base:  "uatom",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0")},
+				},
+				types.Denom{
+					Base:  "uosmo",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0")},
+				},
+			},
+		},
+		{
+			"same denom and different traces",
+			types.Denoms{
+				types.Denom{
+					Base:  "uatom",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0")},
+				},
+				types.Denom{
+					Base:  "uatom",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0"), types.NewTrace("transfer", "channel-52"), types.NewTrace("transfer", "channel-52")},
+				},
+				types.Denom{
+					Base:  "uatom",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0"), types.NewTrace("transfer", "channel-52")},
+				},
+				types.Denom{
+					Base: "uatom",
+				},
+			},
+			types.Denoms{
+				types.Denom{
+					Base: "uatom",
+				},
+				types.Denom{
+					Base:  "uatom",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0")},
+				},
+				types.Denom{
+					Base:  "uatom",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0"), types.NewTrace("transfer", "channel-52")},
+				},
+				types.Denom{
+					Base:  "uatom",
+					Trace: []types.Trace{types.NewTrace("transfer", "channel-0"), types.NewTrace("transfer", "channel-52"), types.NewTrace("transfer", "channel-52")},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.Require().Equal(tc.expDenoms, tc.denoms.Sort())
+		})
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #6451

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
