### PR TITLE
refactor: replaced `fmt.Sprintf` with `strconv.FormatBool` for boolean conversions

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/ibc_middleware_test.go
+++ b/modules/apps/27-interchain-accounts/controller/ibc_middleware_test.go
@@ -2,6 +2,7 @@ package controller_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	testifysuite "github.com/stretchr/testify/suite"
@@ -584,7 +585,7 @@ func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 						icatypes.EventTypePacket,
 						sdk.NewAttribute(sdk.AttributeKeyModule, icatypes.ModuleName),
 						sdk.NewAttribute(icatypes.AttributeKeyControllerChannelID, packet.GetDestChannel()),
-						sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, fmt.Sprintf("%t", false)),
+						sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, strconv.FormatBool(false)),
 						sdk.NewAttribute(icatypes.AttributeKeyAckError, "cannot receive packet on controller chain: invalid message sent to channel end"),
 					),
 				}.ToABCIEvents()

--- a/modules/apps/27-interchain-accounts/controller/keeper/events.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/events.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"fmt"
+	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -16,7 +16,7 @@ func EmitAcknowledgementEvent(ctx sdk.Context, packet channeltypes.Packet, ack e
 	attributes := []sdk.Attribute{
 		sdk.NewAttribute(sdk.AttributeKeyModule, icatypes.ModuleName),
 		sdk.NewAttribute(icatypes.AttributeKeyControllerChannelID, packet.GetDestChannel()),
-		sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, fmt.Sprintf("%t", ack.Success())),
+		sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, strconv.FormatBool(ack.Success())),
 	}
 
 	if err != nil {

--- a/modules/apps/27-interchain-accounts/host/ibc_module_test.go
+++ b/modules/apps/27-interchain-accounts/host/ibc_module_test.go
@@ -2,6 +2,7 @@ package host_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -507,7 +508,7 @@ func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 				expectedAttributes := []sdk.Attribute{
 					sdk.NewAttribute(sdk.AttributeKeyModule, icatypes.ModuleName),
 					sdk.NewAttribute(icatypes.AttributeKeyHostChannelID, packet.GetDestChannel()),
-					sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, fmt.Sprintf("%t", ack.Success())),
+					sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, strconv.FormatBool(ack.Success())),
 				}
 
 				if tc.expAckSuccess {

--- a/modules/apps/27-interchain-accounts/host/keeper/events.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/events.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"fmt"
+	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -17,7 +17,7 @@ func EmitAcknowledgementEvent(ctx sdk.Context, packet channeltypes.Packet, ack e
 	attributes := []sdk.Attribute{
 		sdk.NewAttribute(sdk.AttributeKeyModule, icatypes.ModuleName),
 		sdk.NewAttribute(icatypes.AttributeKeyHostChannelID, packet.GetDestChannel()),
-		sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, fmt.Sprintf("%t", ack.Success())),
+		sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, strconv.FormatBool(ack.Success())),
 	}
 
 	if err != nil {

--- a/modules/apps/transfer/internal/events/events.go
+++ b/modules/apps/transfer/internal/events/events.go
@@ -2,7 +2,7 @@ package events
 
 import (
 	"encoding/json"
-	"fmt"
+	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -38,7 +38,7 @@ func EmitOnRecvPacketEvent(ctx sdk.Context, packetData types.FungibleTokenPacket
 		sdk.NewAttribute(types.AttributeKeyReceiver, packetData.Receiver),
 		sdk.NewAttribute(types.AttributeKeyTokens, jsonTokens),
 		sdk.NewAttribute(types.AttributeKeyMemo, packetData.Memo),
-		sdk.NewAttribute(types.AttributeKeyAckSuccess, fmt.Sprintf("%t", ack.Success())),
+		sdk.NewAttribute(types.AttributeKeyAckSuccess, strconv.FormatBool(ack.Success())),
 	}
 
 	if ackErr != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Replaced `fmt.Sprintf` with `strconv.FormatBool` for all instances of boolean conversion.   
For reference - [#6442 (comment)](https://github.com/cosmos/ibc-go/pull/6442#discussion_r1622626311).

closes: #6449 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [X] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [X] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [X] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [X] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved boolean-to-string conversion for event attributes across multiple modules for better performance and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->