### PR TITLE
e2e: cache go module dependencies

### DIFF
--- a/.github/workflows/e2e-compatibility-workflow-call.yaml
+++ b/.github/workflows/e2e-compatibility-workflow-call.yaml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: 'e2e/go.sum'
       - name: Run e2e Test
         run: |
           cd e2e

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: 'e2e/go.sum'
       - name: Run e2e Test
         run: |
           cd e2e
@@ -104,6 +105,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: 'e2e/go.sum'
       - name: Run e2e Test
         run: |
           cd e2e

--- a/.github/workflows/e2e-test-workflow-call.yml
+++ b/.github/workflows/e2e-test-workflow-call.yml
@@ -239,6 +239,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: 'e2e/go.sum'
       - name: Run e2e Test
         id: e2e_test
         run: |

--- a/.github/workflows/e2emodule.yml
+++ b/.github/workflows/e2emodule.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: 'e2e/go.sum'
       - uses: actions/checkout@v4
       - uses: golangci/golangci-lint-action@v6.0.1
         with:
@@ -27,6 +28,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: 'e2e/go.sum'
       - name: Go Test
         run: |
           cd e2e


### PR DESCRIPTION
## Description

closes: #6534

From the issue:
The setup-go action we already use has a caching mechanism built in that we can leverage to avoid the ~2 minutes of downloading of dependencies that we do for every e2e build.

The action by default uses caching for the root-level dependencies, but needs to be told if there are go modules in sub-folder that it should be caching instead (it accepts a list). The caching mechanism is using a hash of the go.sum file as part of its key, so as long as the go.sum file is the same, we will get a cache-hit.

In other words, we can get a nice speed-up by simple adding cache-dependency-path: 'e2e/go.sum' as an argument to actions/setup-go@v5.

Documentation: https://github.com/actions/setup-go?tab=readme-ov-file#caching-dependency-files-and-build-outputs

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
