### PR TITLE
test: add secondary test coin to test chains

### DIFF
--- a/modules/apps/transfer/ibc_module_test.go
+++ b/modules/apps/transfer/ibc_module_test.go
@@ -278,17 +278,27 @@ func (suite *TransferTestSuite) TestOnTimeoutPacket() {
 	var packet channeltypes.Packet
 
 	testCases := []struct {
-		name     string
-		malleate func()
-		expError error
+		name           string
+		coinsToSendToB sdk.Coins
+		malleate       func()
+		expError       error
 	}{
 		{
 			"success",
+			sdk.NewCoins(ibctesting.TestCoin),
+			func() {},
+			nil,
+		},
+		{
+
+			"success with multiple coins",
+			sdk.NewCoins(ibctesting.TestCoin, ibctesting.SecondaryTestCoin),
 			func() {},
 			nil,
 		},
 		{
 			"non-existent channel",
+			sdk.NewCoins(ibctesting.TestCoin),
 			func() {
 				packet.SourceChannel = "channel-100"
 			},
@@ -296,6 +306,7 @@ func (suite *TransferTestSuite) TestOnTimeoutPacket() {
 		},
 		{
 			"invalid packet data",
+			sdk.NewCoins(ibctesting.TestCoin),
 			func() {
 				packet.Data = []byte("invalid data")
 			},
@@ -303,6 +314,7 @@ func (suite *TransferTestSuite) TestOnTimeoutPacket() {
 		},
 		{
 			"already timed-out packet",
+			sdk.NewCoins(ibctesting.TestCoin),
 			func() {
 				module, _, err := suite.chainA.App.GetIBCKeeper().PortKeeper.LookupModuleByPort(suite.chainA.GetContext(), ibctesting.TransferPort)
 				suite.Require().NoError(err)
@@ -324,12 +336,11 @@ func (suite *TransferTestSuite) TestOnTimeoutPacket() {
 			path = ibctesting.NewTransferPath(suite.chainA, suite.chainB)
 			path.Setup()
 
-			coinToSendToB := sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(42))
 			timeoutHeight := suite.chainA.GetTimeoutHeight()
 			msg := types.NewMsgTransfer(
 				path.EndpointA.ChannelConfig.PortID,
 				path.EndpointA.ChannelID,
-				sdk.NewCoins(coinToSendToB),
+				tc.coinsToSendToB,
 				suite.chainA.SenderAccount.GetAddress().String(),
 				suite.chainB.SenderAccount.GetAddress().String(),
 				timeoutHeight,

--- a/modules/apps/transfer/ibc_module_test.go
+++ b/modules/apps/transfer/ibc_module_test.go
@@ -290,7 +290,6 @@ func (suite *TransferTestSuite) TestOnTimeoutPacket() {
 			nil,
 		},
 		{
-
 			"success with multiple coins",
 			sdk.NewCoins(ibctesting.TestCoin, ibctesting.SecondaryTestCoin),
 			func() {},

--- a/testing/chain.go
+++ b/testing/chain.go
@@ -115,7 +115,10 @@ func NewTestChainWithValSet(tb testing.TB, coord *Coordinator, chainID string, v
 		// add sender account
 		balance := banktypes.Balance{
 			Address: acc.GetAddress().String(),
-			Coins:   sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, amount)),
+			Coins: sdk.NewCoins(
+				sdk.NewCoin(sdk.DefaultBondDenom, amount),
+				sdk.NewCoin(SecondaryDenom, amount),
+			),
 		}
 
 		genAccs = append(genAccs, acc)

--- a/testing/values.go
+++ b/testing/values.go
@@ -55,9 +55,11 @@ var (
 	// DefaultTrustLevel sets params variables used to create a TM client
 	DefaultTrustLevel = ibctm.DefaultTrustLevel
 
-	TestAccAddress = "cosmos17dtl0mjt3t77kpuhg2edqzjpszulwhgzuj9ljs"
-	TestCoin       = sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(100))
-	TestCoins      = sdk.NewCoins(TestCoin)
+	TestAccAddress    = "cosmos17dtl0mjt3t77kpuhg2edqzjpszulwhgzuj9ljs"
+	TestCoin          = sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(100))
+	TestCoins         = sdk.NewCoins(TestCoin)
+	SecondaryDenom    = "ufoo"
+	SecondaryTestCoin = sdk.NewCoin(SecondaryDenom, sdkmath.NewInt(100))
 
 	UpgradePath = []string{"upgrade", "upgradedIBCState"}
 


### PR DESCRIPTION
## Description

Related to #6402

This adds a secondary denom to the test chains genesis generation in the ibc-testing package.

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
