### PR TITLE
test: add more multi-denom test cases

### DIFF
--- a/modules/apps/29-fee/transfer_test.go
+++ b/modules/apps/29-fee/transfer_test.go
@@ -11,62 +11,81 @@ import (
 
 // Integration test to ensure ics29 works with ics20
 func (suite *FeeTestSuite) TestFeeTransfer() {
-	path := ibctesting.NewPath(suite.chainA, suite.chainB)
-	feeTransferVersion := string(types.ModuleCdc.MustMarshalJSON(&types.Metadata{FeeVersion: types.Version, AppVersion: transfertypes.V2}))
-	path.EndpointA.ChannelConfig.Version = feeTransferVersion
-	path.EndpointB.ChannelConfig.Version = feeTransferVersion
-	path.EndpointA.ChannelConfig.PortID = transfertypes.PortID
-	path.EndpointB.ChannelConfig.PortID = transfertypes.PortID
-
-	path.Setup()
-
-	// set up coin & ics20 packet
-	coin := ibctesting.TestCoin
-	fee := types.Fee{
-		RecvFee:    defaultRecvFee,
-		AckFee:     defaultAckFee,
-		TimeoutFee: defaultTimeoutFee,
+	testCases := []struct {
+		name            string
+		coinsToTransfer sdk.Coins
+	}{
+		{
+			"transfer single denom",
+			sdk.NewCoins(ibctesting.TestCoin),
+		},
+		{
+			"transfer multiple denoms",
+			sdk.NewCoins(ibctesting.TestCoin, ibctesting.SecondaryTestCoin),
+		},
 	}
 
-	msgs := []sdk.Msg{
-		types.NewMsgPayPacketFee(fee, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, suite.chainA.SenderAccount.GetAddress().String(), nil),
-		transfertypes.NewMsgTransfer(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, sdk.NewCoins(coin), suite.chainA.SenderAccount.GetAddress().String(), suite.chainB.SenderAccount.GetAddress().String(), clienttypes.NewHeight(1, 100), 0, ""),
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest() // reset
+
+			path := ibctesting.NewPath(suite.chainA, suite.chainB)
+			feeTransferVersion := string(types.ModuleCdc.MustMarshalJSON(&types.Metadata{FeeVersion: types.Version, AppVersion: transfertypes.V2}))
+			path.EndpointA.ChannelConfig.Version = feeTransferVersion
+			path.EndpointB.ChannelConfig.Version = feeTransferVersion
+			path.EndpointA.ChannelConfig.PortID = transfertypes.PortID
+			path.EndpointB.ChannelConfig.PortID = transfertypes.PortID
+
+			path.Setup()
+
+			fee := types.Fee{
+				RecvFee:    defaultRecvFee,
+				AckFee:     defaultAckFee,
+				TimeoutFee: defaultTimeoutFee,
+			}
+
+			msgs := []sdk.Msg{
+				types.NewMsgPayPacketFee(fee, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, suite.chainA.SenderAccount.GetAddress().String(), nil),
+				transfertypes.NewMsgTransfer(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, tc.coinsToTransfer, suite.chainA.SenderAccount.GetAddress().String(), suite.chainB.SenderAccount.GetAddress().String(), clienttypes.NewHeight(1, 100), 0, ""),
+			}
+
+			res, err := suite.chainA.SendMsgs(msgs...)
+			suite.Require().NoError(err) // message committed
+
+			// after incentivizing the packets
+			originalChainASenderAccountBalance := sdk.NewCoins(suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainA.SenderAccount.GetAddress(), ibctesting.TestCoin.Denom))
+
+			packet, err := ibctesting.ParsePacketFromEvents(res.Events)
+			suite.Require().NoError(err)
+
+			// register counterparty address on chainB
+			// relayerAddress is address of sender account on chainB, but we will use it on chainA
+			// to differentiate from the chainA.SenderAccount for checking successful relay payouts
+			relayerAddress := suite.chainB.SenderAccount.GetAddress()
+
+			msgRegister := types.NewMsgRegisterCounterpartyPayee(path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, suite.chainB.SenderAccount.GetAddress().String(), relayerAddress.String())
+			_, err = suite.chainB.SendMsgs(msgRegister)
+			suite.Require().NoError(err) // message committed
+
+			// relay packet
+			err = path.RelayPacket(packet)
+			suite.Require().NoError(err) // relay committed
+
+			// ensure relayers got paid
+			// relayer for forward relay: chainB.SenderAccount
+			// relayer for reverse relay: chainA.SenderAccount
+
+			// check forward relay balance
+			suite.Require().Equal(
+				fee.RecvFee,
+				sdk.NewCoins(suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainB.SenderAccount.GetAddress(), ibctesting.TestCoin.Denom)),
+			)
+
+			suite.Require().Equal(
+				fee.AckFee, // ack fee paid, no refund needed since timeout_fee = recv_fee + ack_fee
+				sdk.NewCoins(suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainA.SenderAccount.GetAddress(), ibctesting.TestCoin.Denom)).Sub(originalChainASenderAccountBalance[0]))
+		})
 	}
-	res, err := suite.chainA.SendMsgs(msgs...)
-	suite.Require().NoError(err) // message committed
-
-	// after incentivizing the packets
-	originalChainASenderAccountBalance := sdk.NewCoins(suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainA.SenderAccount.GetAddress(), ibctesting.TestCoin.Denom))
-
-	packet, err := ibctesting.ParsePacketFromEvents(res.Events)
-	suite.Require().NoError(err)
-
-	// register counterparty address on chainB
-	// relayerAddress is address of sender account on chainB, but we will use it on chainA
-	// to differentiate from the chainA.SenderAccount for checking successful relay payouts
-	relayerAddress := suite.chainB.SenderAccount.GetAddress()
-
-	msgRegister := types.NewMsgRegisterCounterpartyPayee(path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, suite.chainB.SenderAccount.GetAddress().String(), relayerAddress.String())
-	_, err = suite.chainB.SendMsgs(msgRegister)
-	suite.Require().NoError(err) // message committed
-
-	// relay packet
-	err = path.RelayPacket(packet)
-	suite.Require().NoError(err) // relay committed
-
-	// ensure relayers got paid
-	// relayer for forward relay: chainB.SenderAccount
-	// relayer for reverse relay: chainA.SenderAccount
-
-	// check forward relay balance
-	suite.Require().Equal(
-		fee.RecvFee,
-		sdk.NewCoins(suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainB.SenderAccount.GetAddress(), ibctesting.TestCoin.Denom)),
-	)
-
-	suite.Require().Equal(
-		fee.AckFee, // ack fee paid, no refund needed since timeout_fee = recv_fee + ack_fee
-		sdk.NewCoins(suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainA.SenderAccount.GetAddress(), ibctesting.TestCoin.Denom)).Sub(originalChainASenderAccountBalance[0]))
 }
 
 func (suite *FeeTestSuite) TestTransferFeeUpgrade() {

--- a/modules/apps/callbacks/ibc_middleware_test.go
+++ b/modules/apps/callbacks/ibc_middleware_test.go
@@ -110,16 +110,6 @@ func (s *CallbacksTestSuite) TestSendPacket() {
 			nil,
 		},
 		{
-			"success: no-op on callback data is not valid",
-			func() {
-				//nolint:goconst
-				packetData.Memo = `{"src_callback": {"address": ""}}`
-			},
-			"none", // improperly formatted callback data should result in no callback execution
-			false,
-			nil,
-		},
-		{
 			"success: multiple denoms",
 			func() {
 				packetData.Tokens = append(packetData.Tokens, transfertypes.Token{
@@ -128,6 +118,16 @@ func (s *CallbacksTestSuite) TestSendPacket() {
 				})
 			},
 			types.CallbackTypeSendPacket,
+			false,
+			nil,
+		},
+		{
+			"success: no-op on callback data is not valid",
+			func() {
+				//nolint:goconst
+				packetData.Memo = `{"src_callback": {"address": ""}}`
+			},
+			"none", // improperly formatted callback data should result in no callback execution
 			false,
 			nil,
 		},

--- a/modules/apps/callbacks/ibc_middleware_test.go
+++ b/modules/apps/callbacks/ibc_middleware_test.go
@@ -120,6 +120,18 @@ func (s *CallbacksTestSuite) TestSendPacket() {
 			nil,
 		},
 		{
+			"success: multiple denoms",
+			func() {
+				packetData.Tokens = append(packetData.Tokens, transfertypes.Token{
+					Denom:  transfertypes.NewDenom(ibctesting.SecondaryDenom),
+					Amount: ibctesting.SecondaryTestCoin.Amount.String(),
+				})
+			},
+			types.CallbackTypeSendPacket,
+			false,
+			nil,
+		},
+		{
 			"failure: ics4Wrapper SendPacket call fails",
 			func() {
 				s.path.EndpointA.ChannelID = "invalid-channel"

--- a/modules/apps/transfer/transfer_test.go
+++ b/modules/apps/transfer/transfer_test.go
@@ -37,101 +37,160 @@ func (suite *TransferTestSuite) SetupTest() {
 // 2 - from chainB to chainC
 // 3 - from chainC to chainB
 func (suite *TransferTestSuite) TestHandleMsgTransfer() {
-	// setup between chainA and chainB
-	// NOTE:
-	// pathAtoB.EndpointA = endpoint on chainA
-	// pathAtoB.EndpointB = endpoint on chainB
-	pathAtoB := ibctesting.NewTransferPath(suite.chainA, suite.chainB)
-	pathAtoB.Setup()
+	testCases := []struct {
+		name                   string
+		sourceDenomsToTransfer []string
+	}{
+		{
+			"transfer single denom",
+			[]string{sdk.DefaultBondDenom},
+		},
+		{
+			"transfer multiple denoms",
+			[]string{sdk.DefaultBondDenom, ibctesting.SecondaryDenom},
+		},
+	}
 
-	originalBalance := suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainA.SenderAccount.GetAddress(), sdk.DefaultBondDenom)
-	timeoutHeight := clienttypes.NewHeight(1, 110)
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest() // reset
 
-	amount, ok := sdkmath.NewIntFromString("9223372036854775808") // 2^63 (one above int64)
-	suite.Require().True(ok)
-	coinToSendToB := sdk.NewCoin(sdk.DefaultBondDenom, amount)
+			// setup between chainA and chainB
+			// NOTE:
+			// pathAToB.EndpointA = endpoint on chainA
+			// pathAToB.EndpointB = endpoint on chainB
+			pathAToB := ibctesting.NewTransferPath(suite.chainA, suite.chainB)
+			pathAToB.Setup()
+			traceAToB := types.NewTrace(pathAToB.EndpointB.ChannelConfig.PortID, pathAToB.EndpointB.ChannelID)
 
-	// send from chainA to chainB
-	msg := types.NewMsgTransfer(pathAtoB.EndpointA.ChannelConfig.PortID, pathAtoB.EndpointA.ChannelID, sdk.NewCoins(coinToSendToB), suite.chainA.SenderAccount.GetAddress().String(), suite.chainB.SenderAccount.GetAddress().String(), timeoutHeight, 0, "")
-	res, err := suite.chainA.SendMsgs(msg)
-	suite.Require().NoError(err) // message committed
+			originalBalances := sdk.NewCoins()
+			for _, denom := range tc.sourceDenomsToTransfer {
+				originalBalance := suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainA.SenderAccount.GetAddress(), denom)
+				originalBalances = originalBalances.Add(originalBalance)
+			}
 
-	packet, err := ibctesting.ParsePacketFromEvents(res.Events)
-	suite.Require().NoError(err)
+			timeoutHeight := clienttypes.NewHeight(1, 110)
 
-	// relay send
-	err = pathAtoB.RelayPacket(packet)
-	suite.Require().NoError(err) // relay committed
+			amount, ok := sdkmath.NewIntFromString("9223372036854775808") // 2^63 (one above int64)
+			suite.Require().True(ok)
+			originalCoins := sdk.NewCoins()
+			for _, denom := range tc.sourceDenomsToTransfer {
+				coinToSendToB := sdk.NewCoin(denom, amount)
+				originalCoins = originalCoins.Add(coinToSendToB)
+			}
 
-	// check that module account escrow address has locked the tokens
-	escrowAddress := types.GetEscrowAddress(packet.GetSourcePort(), packet.GetSourceChannel())
-	balance := suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), escrowAddress, sdk.DefaultBondDenom)
-	suite.Require().Equal(coinToSendToB, balance)
+			// send from chainA to chainB
+			msg := types.NewMsgTransfer(pathAToB.EndpointA.ChannelConfig.PortID, pathAToB.EndpointA.ChannelID, originalCoins, suite.chainA.SenderAccount.GetAddress().String(), suite.chainB.SenderAccount.GetAddress().String(), timeoutHeight, 0, "")
+			res, err := suite.chainA.SendMsgs(msg)
+			suite.Require().NoError(err) // message committed
 
-	// check that voucher exists on chain B
-	denom := types.NewDenom(sdk.DefaultBondDenom, types.NewTrace(packet.DestinationPort, packet.DestinationChannel))
-	balance = suite.chainB.GetSimApp().BankKeeper.GetBalance(suite.chainB.GetContext(), suite.chainB.SenderAccount.GetAddress(), denom.IBCDenom())
-	coinSentFromAToB := sdk.NewCoin(denom.IBCDenom(), amount)
-	suite.Require().Equal(coinSentFromAToB, balance)
+			packet, err := ibctesting.ParsePacketFromEvents(res.Events)
+			suite.Require().NoError(err)
 
-	// setup between chainB to chainC
-	// NOTE:
-	// pathBtoC.EndpointA = endpoint on chainB
-	// pathBtoC.EndpointB = endpoint on chainC
-	pathBtoC := ibctesting.NewTransferPath(suite.chainB, suite.chainC)
-	pathBtoC.Setup()
+			// relay send
+			err = pathAToB.RelayPacket(packet)
+			suite.Require().NoError(err) // relay committed
 
-	// send from chainB to chainC
-	msg = types.NewMsgTransfer(pathBtoC.EndpointA.ChannelConfig.PortID, pathBtoC.EndpointA.ChannelID, sdk.NewCoins(coinSentFromAToB), suite.chainB.SenderAccount.GetAddress().String(), suite.chainC.SenderAccount.GetAddress().String(), timeoutHeight, 0, "")
-	res, err = suite.chainB.SendMsgs(msg)
-	suite.Require().NoError(err) // message committed
+			escrowAddress := types.GetEscrowAddress(packet.GetSourcePort(), packet.GetSourceChannel())
+			coinsSentFromAToB := sdk.NewCoins()
+			for _, coin := range originalCoins {
+				// check that the balance for chainA is updated
+				chainABalance := suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainA.SenderAccount.GetAddress(), coin.Denom)
+				suite.Require().Equal(originalBalances.AmountOf(coin.Denom).Sub(amount).Int64(), chainABalance.Amount.Int64())
 
-	packet, err = ibctesting.ParsePacketFromEvents(res.Events)
-	suite.Require().NoError(err)
+				// check that module account escrow address has locked the tokens
+				chainAEscrowBalance := suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), escrowAddress, coin.Denom)
+				suite.Require().Equal(coin, chainAEscrowBalance)
 
-	err = pathBtoC.RelayPacket(packet)
-	suite.Require().NoError(err) // relay committed
+				// check that voucher exists on chain B
+				chainBDenom := types.NewDenom(coin.Denom, traceAToB)
+				chainBBalance := suite.chainB.GetSimApp().BankKeeper.GetBalance(suite.chainB.GetContext(), suite.chainB.SenderAccount.GetAddress(), chainBDenom.IBCDenom())
+				coinSentFromAToB := sdk.NewCoin(chainBDenom.IBCDenom(), amount)
+				suite.Require().Equal(coinSentFromAToB, chainBBalance)
 
-	// NOTE: fungible token is prefixed with the full trace in order to verify the packet commitment
-	trace := []types.Trace{types.NewTrace(pathBtoC.EndpointB.ChannelConfig.PortID, pathBtoC.EndpointB.ChannelID)}
-	denom.Trace = append(trace, denom.Trace...)
+				coinsSentFromAToB = coinsSentFromAToB.Add(coinSentFromAToB)
+			}
 
-	// check that the balance is updated on chainC
-	coinSentFromBToC := sdk.NewCoin(denom.IBCDenom(), amount)
-	balance = suite.chainC.GetSimApp().BankKeeper.GetBalance(suite.chainC.GetContext(), suite.chainC.SenderAccount.GetAddress(), coinSentFromBToC.Denom)
-	suite.Require().Equal(coinSentFromBToC, balance)
+			// setup between chainB to chainC
+			// NOTE:
+			// pathBToC.EndpointA = endpoint on chainB
+			// pathBToC.EndpointB = endpoint on chainC
+			pathBToC := ibctesting.NewTransferPath(suite.chainB, suite.chainC)
+			pathBToC.Setup()
+			traceBToC := types.NewTrace(pathBToC.EndpointB.ChannelConfig.PortID, pathBToC.EndpointB.ChannelID)
 
-	// check that balance on chain B is empty
-	balance = suite.chainB.GetSimApp().BankKeeper.GetBalance(suite.chainB.GetContext(), suite.chainB.SenderAccount.GetAddress(), coinSentFromBToC.Denom)
-	suite.Require().Zero(balance.Amount.Int64())
+			// send from chainB to chainC
+			msg = types.NewMsgTransfer(pathBToC.EndpointA.ChannelConfig.PortID, pathBToC.EndpointA.ChannelID, coinsSentFromAToB, suite.chainB.SenderAccount.GetAddress().String(), suite.chainC.SenderAccount.GetAddress().String(), timeoutHeight, 0, "")
+			res, err = suite.chainB.SendMsgs(msg)
+			suite.Require().NoError(err) // message committed
 
-	// send from chainC back to chainB
-	msg = types.NewMsgTransfer(pathBtoC.EndpointB.ChannelConfig.PortID, pathBtoC.EndpointB.ChannelID, sdk.NewCoins(coinSentFromBToC), suite.chainC.SenderAccount.GetAddress().String(), suite.chainB.SenderAccount.GetAddress().String(), timeoutHeight, 0, "")
-	res, err = suite.chainC.SendMsgs(msg)
-	suite.Require().NoError(err) // message committed
+			packet, err = ibctesting.ParsePacketFromEvents(res.Events)
+			suite.Require().NoError(err)
 
-	packet, err = ibctesting.ParsePacketFromEvents(res.Events)
-	suite.Require().NoError(err)
+			err = pathBToC.RelayPacket(packet)
+			suite.Require().NoError(err) // relay committed
 
-	err = pathBtoC.RelayPacket(packet)
-	suite.Require().NoError(err) // relay committed
+			coinsSentFromBToC := sdk.NewCoins()
+			// check balances for chainB and chainC after transfer from chainB to chainC
+			for _, coin := range originalCoins {
+				// NOTE: fungible token is prefixed with the full trace in order to verify the packet commitment
+				chainCDenom := types.NewDenom(coin.Denom, traceBToC, traceAToB)
 
-	// check that balance on chain A is updated
-	balance = suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainA.SenderAccount.GetAddress(), sdk.DefaultBondDenom)
-	suite.Require().Equal(originalBalance.SubAmount(amount).Amount.Int64(), balance.Amount.Int64())
+				// check that the balance is updated on chainC
+				coinSentFromBToC := sdk.NewCoin(chainCDenom.IBCDenom(), amount)
+				chainCBalance := suite.chainC.GetSimApp().BankKeeper.GetBalance(suite.chainC.GetContext(), suite.chainC.SenderAccount.GetAddress(), coinSentFromBToC.Denom)
+				suite.Require().Equal(coinSentFromBToC, chainCBalance)
 
-	// check that balance on chain B has the transferred amount
-	balance = suite.chainB.GetSimApp().BankKeeper.GetBalance(suite.chainB.GetContext(), suite.chainB.SenderAccount.GetAddress(), coinSentFromAToB.Denom)
-	suite.Require().Equal(coinSentFromAToB, balance)
+				// check that balance on chain B is empty
+				chainBBalance := suite.chainB.GetSimApp().BankKeeper.GetBalance(suite.chainB.GetContext(), suite.chainB.SenderAccount.GetAddress(), coinSentFromBToC.Denom)
+				suite.Require().Zero(chainBBalance.Amount.Int64())
 
-	// check that module account escrow address is empty
-	escrowAddress = types.GetEscrowAddress(packet.GetDestPort(), packet.GetDestChannel())
-	balance = suite.chainB.GetSimApp().BankKeeper.GetBalance(suite.chainB.GetContext(), escrowAddress, coinSentFromAToB.Denom)
-	suite.Require().Zero(balance.Amount.Int64())
+				coinsSentFromBToC = coinsSentFromBToC.Add(coinSentFromBToC)
+			}
 
-	// check that balance on chain C is empty
-	balance = suite.chainC.GetSimApp().BankKeeper.GetBalance(suite.chainC.GetContext(), suite.chainC.SenderAccount.GetAddress(), denom.IBCDenom())
-	suite.Require().Zero(balance.Amount.Int64())
+			// send from chainC back to chainB
+			msg = types.NewMsgTransfer(pathBToC.EndpointB.ChannelConfig.PortID, pathBToC.EndpointB.ChannelID, coinsSentFromBToC, suite.chainC.SenderAccount.GetAddress().String(), suite.chainB.SenderAccount.GetAddress().String(), timeoutHeight, 0, "")
+			res, err = suite.chainC.SendMsgs(msg)
+			suite.Require().NoError(err) // message committed
+
+			packet, err = ibctesting.ParsePacketFromEvents(res.Events)
+			suite.Require().NoError(err)
+
+			err = pathBToC.RelayPacket(packet)
+			suite.Require().NoError(err) // relay committed
+
+			// check balances for chainC are empty after transfer from chainC to chainB
+			for _, coin := range coinsSentFromBToC {
+				// check that balance on chain C is empty
+				chainCBalance := suite.chainC.GetSimApp().BankKeeper.GetBalance(suite.chainC.GetContext(), suite.chainC.SenderAccount.GetAddress(), coin.Denom)
+				suite.Require().Zero(chainCBalance.Amount.Int64())
+			}
+
+			// check balances for chainB after transfer from chainC to chainB
+			for _, coin := range coinsSentFromAToB {
+				// check that balance on chain B has the transferred amount
+				chainBBalance := suite.chainB.GetSimApp().BankKeeper.GetBalance(suite.chainB.GetContext(), suite.chainB.SenderAccount.GetAddress(), coin.Denom)
+				suite.Require().Equal(coin, chainBBalance)
+
+				// check that module account escrow address is empty
+				escrowAddress = types.GetEscrowAddress(traceBToC.PortId, traceBToC.ChannelId)
+				chainBEscrowBalance := suite.chainB.GetSimApp().BankKeeper.GetBalance(suite.chainB.GetContext(), escrowAddress, coin.Denom)
+				suite.Require().Zero(chainBEscrowBalance.Amount.Int64())
+			}
+
+			// check balances for chainA after transfer from chainC to chainB
+			for _, coin := range originalCoins {
+				// check that the balance is unchanged
+				chainABalance := suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainA.SenderAccount.GetAddress(), coin.Denom)
+				suite.Require().Equal(originalBalances.AmountOf(coin.Denom).Sub(amount).Int64(), chainABalance.Amount.Int64())
+
+				// check that module account escrow address is unchanged
+				escrowAddress = types.GetEscrowAddress(traceAToB.PortId, traceAToB.ChannelId)
+				chainAEscrowBalance := suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), escrowAddress, coin.Denom)
+				suite.Require().Equal(coin, chainAEscrowBalance)
+			}
+		})
+	}
 }
 
 func TestTransferTestSuite(t *testing.T) {


### PR DESCRIPTION
## Description

Related to: #6402

Adds more test cases in multiple places where we currently only do a single-denom transfers.

Because I added test tables to some tests, the diff is unfortunately very ugly :/ 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
