### PR TITLE
test: Add tests for OnTimeoutPacket when middle chain times out packet 

### DIFF
--- a/modules/apps/transfer/keeper/relay_forwarding_test.go
+++ b/modules/apps/transfer/keeper/relay_forwarding_test.go
@@ -649,7 +649,7 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacketForwarding() {
 	amount := sdkmath.NewInt(100)
 	coin := sdk.NewCoin(sdk.DefaultBondDenom, amount)
 	sender := suite.chainA.SenderAccounts[0].SenderAccount
-	receiver := suite.chainC.SenderAccounts[0].SenderAccount // Conferm whether it's B or C
+	receiver := suite.chainC.SenderAccounts[0].SenderAccount
 
 	denomA := types.NewDenom(coin.Denom)
 	denomAB := types.NewDenom(coin.Denom, types.NewTrace(pathAtoB.EndpointB.ChannelConfig.PortID, pathAtoB.EndpointB.ChannelID))
@@ -688,6 +688,7 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacketForwarding() {
 	err = pathAtoB.EndpointB.UpdateClient()
 	suite.Require().NoError(err)
 
+	// Receive packet on B.
 	result, err = pathAtoB.EndpointB.RecvPacketWithResult(packet)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(result)
@@ -698,8 +699,9 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacketForwarding() {
 	err = pathBtoC.EndpointB.UpdateClient()
 	suite.Require().NoError(err)
 
+	// Make sure founds went from A to B's escrow account.
 	suite.assertAmountOnChain(suite.chainA, balance, originalABalance.Amount.Sub(amount), denomA.IBCDenom(), "Chain A should have less funds")
-	suite.assertAmountOnChain(suite.chainB, escrow, amount, denomAB.IBCDenom(), "Chain B's forwarding address should have coins")
+	suite.assertAmountOnChain(suite.chainB, escrow, amount, denomAB.IBCDenom(), "Chain B's escrow should have coins")
 
 	address := types.GetForwardAddress(packet.DestinationPort, packet.DestinationChannel).String()
 	data := types.NewFungibleTokenPacketDataV2(
@@ -772,5 +774,3 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacketForwarding() {
 
 	suite.assertAmountOnChain(suite.chainA, balance, originalABalance.Amount, coin.Denom, "Chain A should have their funds back")
 }
-
-//Test that fails verification if no forwarding address


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adds test for OnTimeoutPacket for the case in which the middle chain times out.

closes: #6384 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
