### PR TITLE
feat(transfer): use single byte ack for successful forward

### DIFF
--- a/modules/apps/transfer/keeper/forwarding.go
+++ b/modules/apps/transfer/keeper/forwarding.go
@@ -28,7 +28,7 @@ func (k Keeper) ackForwardPacketError(ctx sdk.Context, prevPacket channeltypes.P
 
 // ackForwardPacketSuccess writes a successful async acknowledgement for the prevPacket
 func (k Keeper) ackForwardPacketSuccess(ctx sdk.Context, prevPacket channeltypes.Packet) error {
-	forwardAck := channeltypes.NewResultAcknowledgement([]byte("forwarded packet succeeded"))
+	forwardAck := channeltypes.NewResultAcknowledgement([]byte{byte(1)})
 	return k.acknowledgeForwardedPacket(ctx, prevPacket, forwardAck)
 }
 

--- a/modules/apps/transfer/keeper/relay_forwarding_test.go
+++ b/modules/apps/transfer/keeper/relay_forwarding_test.go
@@ -263,11 +263,11 @@ func (suite *KeeperTestSuite) TestSimplifiedHappyPathForwarding() {
 	amount := sdkmath.NewInt(100)
 	/*
 		Given the following topolgy:
-		chain A (channel 0) -> (channel-0) chain B (channel-1) -> (channel-1) chain A
+		chain A (channel 0) -> (channel-0) chain B (channel-1) -> (channel-1) chain C
 		stake                  transfer/channel-0/stake           transfer/channel-1/transfer/channel-0/stake
 		We want to trigger:
-		1. A sends B over channel0.
-		2. B onRecv . 2.1(B sends A over channel1) Atomic Actions
+		1. Single transfer forwarding token from A -> B -> C
+		2. B onRecv . 2.1(B sends C over channel1) Atomic Actions
 		At this point we want to assert:
 		A: escrowA = amount,denom
 		B: escrowB = amount,transfer/channel-0/denom
@@ -276,16 +276,16 @@ func (suite *KeeperTestSuite) TestSimplifiedHappyPathForwarding() {
 	path1 := ibctesting.NewTransferPath(suite.chainA, suite.chainB)
 	path1.Setup()
 
-	path2 := ibctesting.NewTransferPath(suite.chainA, suite.chainB)
+	path2 := ibctesting.NewTransferPath(suite.chainB, suite.chainC)
 	path2.Setup()
-	coin := sdk.NewCoin(sdk.DefaultBondDenom, amount)
+	coinOnA := sdk.NewCoin(sdk.DefaultBondDenom, amount)
 	sender := suite.chainA.SenderAccounts[0].SenderAccount
-	receiver := suite.chainA.SenderAccounts[1].SenderAccount
+	receiver := suite.chainC.SenderAccounts[0].SenderAccount
 	forwarding := types.Forwarding{
 		Hops: []types.Hop{
 			{
-				PortId:    path2.EndpointB.ChannelConfig.PortID,
-				ChannelId: path2.EndpointB.ChannelID,
+				PortId:    path2.EndpointA.ChannelConfig.PortID,
+				ChannelId: path2.EndpointA.ChannelID,
 			},
 		},
 		Memo: "",
@@ -294,7 +294,7 @@ func (suite *KeeperTestSuite) TestSimplifiedHappyPathForwarding() {
 	transferMsg := types.NewMsgTransfer(
 		path1.EndpointA.ChannelConfig.PortID,
 		path1.EndpointA.ChannelID,
-		sdk.NewCoins(coin),
+		sdk.NewCoins(coinOnA),
 		sender.GetAddress().String(),
 		receiver.GetAddress().String(),
 		suite.chainA.GetTimeoutHeight(),
@@ -306,47 +306,72 @@ func (suite *KeeperTestSuite) TestSimplifiedHappyPathForwarding() {
 	suite.Require().NoError(err) // message committed
 
 	// parse the packet from result events and recv packet on chainB
-	packet, err := ibctesting.ParsePacketFromEvents(result.Events)
+	packetFromAtoB, err := ibctesting.ParsePacketFromEvents(result.Events)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(packet)
+	suite.Require().NotNil(packetFromAtoB)
 
 	err = path1.EndpointB.UpdateClient()
 	suite.Require().NoError(err)
 
-	result, err = path1.EndpointB.RecvPacketWithResult(packet)
+	result, err = path1.EndpointB.RecvPacketWithResult(packetFromAtoB)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(result)
 
 	// Check that Escrow A has amount
-	totalEscrowChainA := suite.chainA.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainA.GetContext(), coin.GetDenom())
+	totalEscrowChainA := suite.chainA.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainA.GetContext(), coinOnA.GetDenom())
 	suite.Require().Equal(sdkmath.NewInt(100), totalEscrowChainA.Amount)
 
 	// denomTrace path: transfer/channel-0
 	denomTrace := types.NewDenom(sdk.DefaultBondDenom, types.NewTrace(path1.EndpointB.ChannelConfig.PortID, path1.EndpointB.ChannelID))
 
 	// Check that Escrow B has amount
-	coin = sdk.NewCoin(denomTrace.IBCDenom(), amount)
-	totalEscrowChainB := suite.chainB.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainB.GetContext(), coin.GetDenom())
+	coinOnB := sdk.NewCoin(denomTrace.IBCDenom(), amount)
+	totalEscrowChainB := suite.chainB.GetSimApp().TransferKeeper.GetTotalEscrowForDenom(suite.chainB.GetContext(), coinOnB.GetDenom())
 	suite.Require().Equal(sdkmath.NewInt(100), totalEscrowChainB.Amount)
 
-	packet, err = ibctesting.ParsePacketFromEvents(result.Events)
+	packetFromBtoC, err := ibctesting.ParsePacketFromEvents(result.Events)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(packet)
+	suite.Require().NotNil(packetFromBtoC)
 
 	err = path2.EndpointA.UpdateClient()
 	suite.Require().NoError(err)
 
-	result, err = path2.EndpointA.RecvPacketWithResult(packet)
+	err = path2.EndpointB.UpdateClient()
+	suite.Require().NoError(err)
+
+	result, err = path2.EndpointB.RecvPacketWithResult(packetFromBtoC)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(result)
 
 	// transfer/channel-1/transfer/channel-0/denom
-	denomTraceABA := types.NewDenom(sdk.DefaultBondDenom, types.NewTrace(path2.EndpointA.ChannelConfig.PortID, path2.EndpointA.ChannelID), types.NewTrace(path1.EndpointB.ChannelConfig.PortID, path1.EndpointB.ChannelID))
+	denomTraceABC := types.NewDenom(sdk.DefaultBondDenom, types.NewTrace(path2.EndpointB.ChannelConfig.PortID, path2.EndpointB.ChannelID), types.NewTrace(path1.EndpointB.ChannelConfig.PortID, path1.EndpointB.ChannelID))
 
 	// Check that the final receiver has received the expected tokens.
-	coin = sdk.NewCoin(denomTraceABA.IBCDenom(), amount)
-	postCoinOnA := suite.chainA.GetSimApp().BankKeeper.GetBalance(suite.chainA.GetContext(), suite.chainA.SenderAccounts[1].SenderAccount.GetAddress(), coin.GetDenom())
-	suite.Require().Equal(sdkmath.NewInt(100), postCoinOnA.Amount, "final receiver balance has not increased")
+	coinOnC := sdk.NewCoin(denomTraceABC.IBCDenom(), amount)
+	balanceOnC := suite.chainC.GetSimApp().BankKeeper.GetBalance(suite.chainC.GetContext(), receiver.GetAddress(), coinOnC.GetDenom())
+	suite.Require().Equal(sdkmath.NewInt(100), balanceOnC.Amount, "final receiver balance has not increased")
+
+	successAck := channeltypes.NewResultAcknowledgement([]byte{byte(1)})
+	successAckBz := channeltypes.CommitAcknowledgement(successAck.Acknowledgement())
+	ackOnC := suite.chainC.GetAcknowledgement(packetFromBtoC)
+	suite.Require().Equal(successAckBz, ackOnC)
+
+	// Ack back to B
+	err = path2.EndpointB.UpdateClient()
+	suite.Require().NoError(err)
+
+	err = path2.EndpointA.AcknowledgePacket(packetFromBtoC, successAck.Acknowledgement())
+	suite.Require().NoError(err)
+
+	ackOnB := suite.chainB.GetAcknowledgement(packetFromAtoB)
+	suite.Require().Equal(successAckBz, ackOnB)
+
+	// Ack back to A
+	err = path1.EndpointA.UpdateClient()
+	suite.Require().NoError(err)
+
+	err = path1.EndpointA.AcknowledgePacket(packetFromAtoB, successAck.Acknowledgement())
+	suite.Require().NoError(err)
 }
 
 // This test replicates the Acknowledgement Failure Scenario 5


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

closes: #6587

Changes forward ack to `channeltypes.NewResultAcknowledgement([]byte{byte(1)})` (same as the synchronous transfer ack).

I also changed the existing `TestSimplifiedHappyPathForwarding()` test to use three chains (`A -> B -> C`) instead of two. If we want to have an `A -> B -> A` test I can put up that as well. And confirm the acks in the test, of course.

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
