### PR TITLE
refactor: rename SetupPath to SetupPaths in e2e testsuite

### DIFF
--- a/e2e/tests/core/03-connection/connection_test.go
+++ b/e2e/tests/core/03-connection/connection_test.go
@@ -34,7 +34,7 @@ type ConnectionTestSuite struct {
 }
 
 func (s *ConnectionTestSuite) SetupTest() {
-	s.SetupPath(ibc.DefaultClientOpts(), s.TransferChannelOptions())
+	s.SetupPaths(ibc.DefaultClientOpts(), s.TransferChannelOptions())
 }
 
 // QueryMaxExpectedTimePerBlockParam queries the on-chain max expected time per block param for 03-connection

--- a/e2e/tests/transfer/authz_test.go
+++ b/e2e/tests/transfer/authz_test.go
@@ -33,7 +33,7 @@ type AuthzTransferTestSuite struct {
 }
 
 func (suite *AuthzTransferTestSuite) SetupTest() {
-	suite.SetupPath(ibc.DefaultClientOpts(), suite.TransferChannelOptions())
+	suite.SetupPaths(ibc.DefaultClientOpts(), suite.TransferChannelOptions())
 }
 
 // QueryGranterGrants returns all GrantAuthorizations for the given granterAddress.

--- a/e2e/tests/transfer/base_test.go
+++ b/e2e/tests/transfer/base_test.go
@@ -34,7 +34,7 @@ type TransferTestSuite struct {
 }
 
 func (s *TransferTestSuite) SetupTest() {
-	s.SetupPath(ibc.DefaultClientOpts(), s.TransferChannelOptions())
+	s.SetupPaths(ibc.DefaultClientOpts(), s.TransferChannelOptions())
 }
 
 // QueryTransferParams queries the on-chain send enabled param for the transfer module

--- a/e2e/tests/transfer/forwarding_test.go
+++ b/e2e/tests/transfer/forwarding_test.go
@@ -113,7 +113,7 @@ func (s *TransferForwardingTestSuite) TestForwarding_WithLastChainBeingICS20v1_S
 	// Creating a new path between chain B and chain C with a ICS20-v1 channel
 	opts := s.TransferChannelOptions()
 	opts.Version = transfertypes.V1
-	channelBtoC, _ := s.CreateNewPath(ctx, chainB, chainC, ibc.DefaultClientOpts(), opts)
+	channelBtoC, _ := s.CreatePath(ctx, chainB, chainC, ibc.DefaultClientOpts(), opts)
 	s.Require().Equal(transfertypes.V1, channelBtoC.Version, "the channel version is not ics20-1")
 
 	chainAWallet := s.CreateUserOnChainA(ctx, testvalues.StartingTokenAmount)

--- a/e2e/tests/transfer/incentivized_test.go
+++ b/e2e/tests/transfer/incentivized_test.go
@@ -39,7 +39,7 @@ func TestIncentivizedTransferTestSuite(t *testing.T) {
 
 // SetupTest explicitly enables fee middleware in the channel options.
 func (s *IncentivizedTransferTestSuite) SetupTest() {
-	s.SetupPath(ibc.DefaultClientOpts(), s.FeeTransferChannelOptions())
+	s.SetupPaths(ibc.DefaultClientOpts(), s.FeeTransferChannelOptions())
 }
 
 func (s *IncentivizedTransferTestSuite) TestMsgPayPacketFee_AsyncSingleSender_Succeeds() {

--- a/e2e/tests/transfer/upgradesv1_test.go
+++ b/e2e/tests/transfer/upgradesv1_test.go
@@ -33,7 +33,7 @@ type TransferChannelUpgradesV1TestSuite struct {
 func (s *TransferChannelUpgradesV1TestSuite) SetupTest() {
 	opts := s.TransferChannelOptions()
 	opts.Version = transfertypes.V1
-	s.SetupPath(ibc.DefaultClientOpts(), opts)
+	s.SetupPaths(ibc.DefaultClientOpts(), opts)
 }
 
 // TestChannelUpgrade_WithICS20v2_Succeeds tests upgrading a transfer channel to ICS20 v2.

--- a/e2e/tests/transfer/upgradesv2_test.go
+++ b/e2e/tests/transfer/upgradesv2_test.go
@@ -32,7 +32,7 @@ type TransferChannelUpgradesTestSuite struct {
 }
 
 func (s *TransferChannelUpgradesTestSuite) SetupTest() {
-	s.SetupPath(ibc.DefaultClientOpts(), s.TransferChannelOptions())
+	s.SetupPaths(ibc.DefaultClientOpts(), s.TransferChannelOptions())
 }
 
 // TestChannelUpgrade_WithFeeMiddleware_Succeeds tests upgrading a transfer channel to wire up fee middleware

--- a/e2e/tests/upgrades/upgrade_test.go
+++ b/e2e/tests/upgrades/upgrade_test.go
@@ -63,7 +63,7 @@ func (s *UpgradeTestSuite) SetupTest() {
 	if strings.HasSuffix(s.T().Name(), "TestV8ToV8_1ChainUpgrade") {
 		channelOpts = s.FeeTransferChannelOptions()
 	}
-	s.SetupPath(ibc.DefaultClientOpts(), channelOpts)
+	s.SetupPaths(ibc.DefaultClientOpts(), channelOpts)
 }
 
 // UpgradeChain upgrades a chain to a specific version using the planName provided.

--- a/e2e/testsuite/testsuite.go
+++ b/e2e/testsuite/testsuite.go
@@ -174,22 +174,23 @@ func (s *E2ETestSuite) SetupChains(ctx context.Context, channelOptionsModifier C
 // SetupTest will by default use the default channel options to create a path between the chains.
 // if non default channel options are required, the test suite must override the `SetupTest` function.
 func (s *E2ETestSuite) SetupTest() {
-	s.SetupPath(ibc.DefaultClientOpts(), defaultChannelOpts(s.GetAllChains()))
+	s.SetupPaths(ibc.DefaultClientOpts(), defaultChannelOpts(s.GetAllChains()))
 }
 
-// SetupPath creates paths between the all chains using the provided client and channel options.
-func (s *E2ETestSuite) SetupPath(clientOpts ibc.CreateClientOptions, channelOpts ibc.CreateChannelOptions) {
+// SetupPaths creates paths between the chains using the provided client and channel options.
+// The paths are created such that ChainA is connected to ChainB, ChainB is connected to ChainC etc.
+func (s *E2ETestSuite) SetupPaths(clientOpts ibc.CreateClientOptions, channelOpts ibc.CreateChannelOptions) {
 	s.T().Logf("Setting up path for: %s", s.T().Name())
 
 	ctx := context.TODO()
 	allChains := s.GetAllChains()
 	for i := 0; i < len(allChains)-1; i++ {
 		chainA, chainB := allChains[i], allChains[i+1]
-		_, _ = s.CreateNewPath(ctx, chainA, chainB, clientOpts, channelOpts)
+		_, _ = s.CreatePath(ctx, chainA, chainB, clientOpts, channelOpts)
 	}
 }
 
-func (s *E2ETestSuite) CreateNewPath(
+func (s *E2ETestSuite) CreatePath(
 	ctx context.Context,
 	chainA ibc.Chain,
 	chainB ibc.Chain,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Renames `SetupPath` in the e2e test suite to be more precise. Also renames `CreateNewPath` to `CreatePath` (because it was named `CreateNewPath` to not be too similar to the old `SetupPath`).

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
