### PR TITLE
api!(08-wasm/v0.3.0-ibc-go-v8): update `VerifyMembershipMsg` and `VerifyNonMembershipMsg` contract api structs to support non-utf8 keys

### DIFF
--- a/modules/light-clients/08-wasm/CHANGELOG.md
+++ b/modules/light-clients/08-wasm/CHANGELOG.md
@@ -40,6 +40,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### API Breaking
 
+* [\#6644](https://github.com/cosmos/ibc-go/pull/6644) Add `v2.MerklePath` for contract api `VerifyMembershipMsg` and `VerifyNonMembershipMsg` structs. Note, this requires a migration for existing client contracts to correctly handle deserialization of `MerklePath.KeyPath` which has changed from `[]string` to `[][]bytes`. In JSON message structures this change is reflected as the `KeyPath` being a marshalled as a list of base64 encoded byte strings. This change supports proving values stored under keys which contain non-utf8 encoded symbols. See migration docs for more details.
+
 ### State Machine Breaking
 
 ### Improvements

--- a/modules/light-clients/08-wasm/internal/types/merkle_path.go
+++ b/modules/light-clients/08-wasm/internal/types/merkle_path.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	commitmenttypes "github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
+)
+
+// MerklePath is the path used to verify commitment proofs, which can be an
+// arbitrary structured object (defined by a commitment type).
+// MerklePath is represented from root-to-leaf
+// NOTE(Forward compatibility): See https://github.com/cosmos/ibc-go/issues/6496
+type MerklePath struct {
+	KeyPath [][]byte `json:"key_path,omitempty"`
+}
+
+// ToMerklePathV2 converts a 23-commitment MerklePath to a v2 MerklePath using bytes for the key path.
+// This provides the ability to prove values stored under keys which contain non-utf8 encoded symbols.
+func ToMerklePathV2(merklePath commitmenttypes.MerklePath) MerklePath {
+	var keyPath [][]byte
+	for _, key := range merklePath.KeyPath {
+		keyPath = append(keyPath, []byte(key))
+	}
+
+	return MerklePath{
+		KeyPath: keyPath,
+	}
+}

--- a/modules/light-clients/08-wasm/types/client_state.go
+++ b/modules/light-clients/08-wasm/types/client_state.go
@@ -13,6 +13,8 @@ import (
 	commitmenttypes "github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
 	ibcerrors "github.com/cosmos/ibc-go/v8/modules/core/errors"
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
+
+	internaltypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/internal/types"
 )
 
 var _ exported.ClientState = (*ClientState)(nil)
@@ -166,7 +168,7 @@ func (cs ClientState) VerifyMembership(
 			DelayTimePeriod:  delayTimePeriod,
 			DelayBlockPeriod: delayBlockPeriod,
 			Proof:            proof,
-			Path:             merklePath,
+			Path:             internaltypes.ToMerklePathV2(merklePath),
 			Value:            value,
 		},
 	}
@@ -210,7 +212,7 @@ func (cs ClientState) VerifyNonMembership(
 			DelayTimePeriod:  delayTimePeriod,
 			DelayBlockPeriod: delayBlockPeriod,
 			Proof:            proof,
-			Path:             merklePath,
+			Path:             internaltypes.ToMerklePathV2(merklePath),
 		},
 	}
 	_, err := wasmSudo[EmptyResult](ctx, cdc, clientStore, &cs, payload)

--- a/modules/light-clients/08-wasm/types/client_state_test.go
+++ b/modules/light-clients/08-wasm/types/client_state_test.go
@@ -10,6 +10,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/internal/ibcwasm"
+	internaltypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/internal/types"
 	wasmtesting "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/testing"
 	mock "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/testing/mock"
 	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
@@ -390,9 +391,12 @@ func (suite *TypesTestSuite) TestVerifyMembership() {
 					suite.Require().Nil(payload.VerifyNonMembership)
 					suite.Require().Nil(payload.VerifyUpgradeAndUpdateState)
 					suite.Require().Equal(proofHeight, payload.VerifyMembership.Height)
-					suite.Require().Equal(path, payload.VerifyMembership.Path)
 					suite.Require().Equal(proof, payload.VerifyMembership.Proof)
 					suite.Require().Equal(value, payload.VerifyMembership.Value)
+
+					mpath, ok := path.(commitmenttypes.MerklePath)
+					suite.Require().True(ok)
+					suite.Require().Equal(internaltypes.ToMerklePathV2(mpath), payload.VerifyMembership.Path)
 
 					bz, err := json.Marshal(types.EmptyResult{})
 					suite.Require().NoError(err)
@@ -418,9 +422,12 @@ func (suite *TypesTestSuite) TestVerifyMembership() {
 					suite.Require().Nil(payload.VerifyNonMembership)
 					suite.Require().Nil(payload.VerifyUpgradeAndUpdateState)
 					suite.Require().Equal(proofHeight, payload.VerifyMembership.Height)
-					suite.Require().Equal(path, payload.VerifyMembership.Path)
 					suite.Require().Equal(proof, payload.VerifyMembership.Proof)
 					suite.Require().Equal(value, payload.VerifyMembership.Value)
+
+					mpath, ok := path.(commitmenttypes.MerklePath)
+					suite.Require().True(ok)
+					suite.Require().Equal(internaltypes.ToMerklePathV2(mpath), payload.VerifyMembership.Path)
 
 					bz, err := json.Marshal(types.EmptyResult{})
 					suite.Require().NoError(err)
@@ -533,8 +540,11 @@ func (suite *TypesTestSuite) TestVerifyNonMembership() {
 					suite.Require().Nil(payload.VerifyMembership)
 					suite.Require().Nil(payload.VerifyUpgradeAndUpdateState)
 					suite.Require().Equal(proofHeight, payload.VerifyNonMembership.Height)
-					suite.Require().Equal(path, payload.VerifyNonMembership.Path)
 					suite.Require().Equal(proof, payload.VerifyNonMembership.Proof)
+
+					mpath, ok := path.(commitmenttypes.MerklePath)
+					suite.Require().True(ok)
+					suite.Require().Equal(internaltypes.ToMerklePathV2(mpath), payload.VerifyNonMembership.Path)
 
 					bz, err := json.Marshal(types.EmptyResult{})
 					suite.Require().NoError(err)
@@ -560,8 +570,11 @@ func (suite *TypesTestSuite) TestVerifyNonMembership() {
 					suite.Require().Nil(payload.VerifyMembership)
 					suite.Require().Nil(payload.VerifyUpgradeAndUpdateState)
 					suite.Require().Equal(proofHeight, payload.VerifyNonMembership.Height)
-					suite.Require().Equal(path, payload.VerifyNonMembership.Path)
 					suite.Require().Equal(proof, payload.VerifyNonMembership.Proof)
+
+					mpath, ok := path.(commitmenttypes.MerklePath)
+					suite.Require().True(ok)
+					suite.Require().Equal(internaltypes.ToMerklePathV2(mpath), payload.VerifyNonMembership.Path)
 
 					bz, err := json.Marshal(types.EmptyResult{})
 					suite.Require().NoError(err)

--- a/modules/light-clients/08-wasm/types/contract_api.go
+++ b/modules/light-clients/08-wasm/types/contract_api.go
@@ -2,7 +2,8 @@ package types
 
 import (
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
-	commitmenttypes "github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
+
+	internaltypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/internal/types"
 )
 
 // InstantiateMessage is the message that is sent to the contract's instantiate entry point.
@@ -70,21 +71,21 @@ type UpdateStateOnMisbehaviourMsg struct {
 
 // VerifyMembershipMsg is a sudoMsg sent to the contract to verify a membership proof.
 type VerifyMembershipMsg struct {
-	Height           clienttypes.Height         `json:"height"`
-	DelayTimePeriod  uint64                     `json:"delay_time_period"`
-	DelayBlockPeriod uint64                     `json:"delay_block_period"`
-	Proof            []byte                     `json:"proof"`
-	Path             commitmenttypes.MerklePath `json:"path"`
-	Value            []byte                     `json:"value"`
+	Height           clienttypes.Height       `json:"height"`
+	DelayTimePeriod  uint64                   `json:"delay_time_period"`
+	DelayBlockPeriod uint64                   `json:"delay_block_period"`
+	Proof            []byte                   `json:"proof"`
+	Path             internaltypes.MerklePath `json:"path"`
+	Value            []byte                   `json:"value"`
 }
 
 // VerifyNonMembershipMsg is a sudoMsg sent to the contract to verify a non-membership proof.
 type VerifyNonMembershipMsg struct {
-	Height           clienttypes.Height         `json:"height"`
-	DelayTimePeriod  uint64                     `json:"delay_time_period"`
-	DelayBlockPeriod uint64                     `json:"delay_block_period"`
-	Proof            []byte                     `json:"proof"`
-	Path             commitmenttypes.MerklePath `json:"path"`
+	Height           clienttypes.Height       `json:"height"`
+	DelayTimePeriod  uint64                   `json:"delay_time_period"`
+	DelayBlockPeriod uint64                   `json:"delay_block_period"`
+	Proof            []byte                   `json:"proof"`
+	Path             internaltypes.MerklePath `json:"path"`
 }
 
 // VerifyUpgradeAndUpdateStateMsg is a sudoMsg sent to the contract to verify an upgrade and update its state.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adds forwards compatibility for ibc-go/v9 commitment.v2.MerklePath.

NOTE: This PR includes a breaking change for 08-wasm client contracts. For deployed contracts this requires a migration to correctly handle deserialisation of VerifyMembershipMsg.Path.KeyPath and VerifyNonMembershipMsg.Path.KeyPath as [][]byte rather than []string.

See migration docs for more details.

ref: https://github.com/cosmos/ibc-go/issues/6496

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
