### PR TITLE
Make keep containers configurable

### DIFF
--- a/e2e/sample.config.yaml
+++ b/e2e/sample.config.yaml
@@ -24,7 +24,7 @@ activeRelayer: hermes # override with RELAYER_ID
 relayers:
   - id: hermes
     image: ghcr.io/informalsystems/hermes
-    tag: "v1.7.0"
+    tag: "1.10.0"
   - id: rly
     image: ghcr.io/cosmos/relayer
     tag: "latest"
@@ -38,6 +38,8 @@ cometbft:
 debug:
   # setting this value to true will force log collection even if the test passes.
   dumpLogs: false
+  # settings this value to true will keep the containers running after the test finishes.
+  keepContainers: true
 
 # Required only for upgrade tests.
 # Chain A will be upgraded the specified tag.

--- a/e2e/testsuite/testconfig.go
+++ b/e2e/testsuite/testconfig.go
@@ -52,6 +52,10 @@ const (
 	ChainUpgradePlanEnv = "CHAIN_UPGRADE_PLAN"
 	// E2EConfigFilePathEnv allows you to specify a custom path for the config file to be used.
 	E2EConfigFilePathEnv = "E2E_CONFIG_PATH"
+	// KeepContainersEnv instructs interchaintest to not delete the containers after a test has run.
+	// this ensures that chain containers are not deleted after a test suite is run if other tests
+	// depend on those chains.
+	KeepContainersEnv = "KEEP_CONTAINERS"
 
 	// defaultBinary is the default binary that will be used by the chains.
 	defaultBinary = "simd"
@@ -297,6 +301,11 @@ type DebugConfig struct {
 
 	// GenesisDebug contains debug information specific to Genesis.
 	GenesisDebug GenesisDebugConfig `yaml:"genesis"`
+
+	// KeepContainers specifies if the containers should be kept after the test suite is done.
+	// NOTE: when running a full test suite, this value should be set to true in order to preserve
+	// shared resources.
+	KeepContainers bool `yaml:"keepContainers"`
 }
 
 // LoadConfig attempts to load a atest configuration from the default file path.
@@ -370,6 +379,10 @@ func applyEnvironmentVariableOverrides(fromFile TestConfig) TestConfig {
 
 	if os.Getenv(ChainUpgradeTagEnv) != "" {
 		fromFile.UpgradeConfig.Tag = envTc.UpgradeConfig.Tag
+	}
+
+	if isEnvTrue(KeepContainersEnv) {
+		fromFile.DebugConfig.KeepContainers = true
 	}
 
 	return fromFile
@@ -513,12 +526,16 @@ func GetChainBTag() string {
 // if the tests are running locally.
 // Note: github actions passes a CI env value of true by default to all runners.
 func IsCI() bool {
-	return strings.ToLower(os.Getenv("CI")) == "true"
+	return isEnvTrue("CI")
 }
 
 // IsFork returns true if the tests are running in fork mode, false is returned otherwise.
 func IsFork() bool {
-	return strings.ToLower(os.Getenv("FORK")) == "true"
+	return isEnvTrue("FORK")
+}
+
+func isEnvTrue(env string) bool {
+	return strings.ToLower(os.Getenv(env)) == "true"
 }
 
 // ChainOptions stores chain configurations for the chains that will be

--- a/e2e/testsuite/testsuite.go
+++ b/e2e/testsuite/testsuite.go
@@ -166,7 +166,9 @@ func (s *E2ETestSuite) initalizeRelayerPool(n int) []ibc.Relayer {
 func (s *E2ETestSuite) SetupChains(ctx context.Context, channelOptionsModifier ChainOptionModifier, chainSpecOpts ...ChainOptionConfiguration) {
 	s.T().Logf("Setting up chains: %s", s.T().Name())
 
-	s.Require().NoError(os.Setenv("KEEP_CONTAINERS", "true"))
+	if LoadConfig().DebugConfig.KeepContainers {
+		s.Require().NoError(os.Setenv(KeepContainersEnv, "true"))
+	}
 
 	s.initState()
 	s.configureGenesisDebugExport()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

When running a full test suite, we need to keep the containers around after a test finishes so as to not interfere with other tests. For local development it can be handy to still clean up containers after a single test.

This PR adds a config value to enable this.

closes: #XXXX

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
