### PR TITLE
nit: use getters that guard against a nil pointer.

### DIFF
--- a/modules/apps/transfer/types/msgs.go
+++ b/modules/apps/transfer/types/msgs.go
@@ -124,10 +124,10 @@ func (msg MsgTransfer) validateForwarding() error {
 
 	if !msg.TimeoutHeight.IsZero() {
 		// when forwarding, the timeout height must not be set
-		return errorsmod.Wrapf(ErrInvalidPacketTimeout, "timeout height must be zero if forwarding path hops is not empty: %s, %s", msg.TimeoutHeight, msg.Forwarding.Hops)
+		return errorsmod.Wrapf(ErrInvalidPacketTimeout, "timeout height must be zero if forwarding path hops is not empty: %s, %s", msg.TimeoutHeight, msg.Forwarding.GetHops())
 	}
 
-	if msg.Forwarding.Unwind {
+	if msg.Forwarding.GetUnwind() {
 		if len(msg.GetCoins()) > 1 {
 			// When unwinding, we must have at most one token.
 			return errorsmod.Wrap(ibcerrors.ErrInvalidCoins, "cannot unwind more than one token")
@@ -154,7 +154,7 @@ func (msg MsgTransfer) HasForwarding() bool {
 		return false
 	}
 
-	return len(msg.Forwarding.Hops) > 0 || msg.Forwarding.Unwind
+	return len(msg.Forwarding.GetHops()) > 0 || msg.Forwarding.GetUnwind()
 }
 
 // validateIdentifiers validates the source port and channel identifiers based on the
@@ -162,7 +162,7 @@ func (msg MsgTransfer) HasForwarding() bool {
 // or unwinding isn't performed, we do normal validation, else, we assert that both
 // fields must be empty.
 func (msg MsgTransfer) validateIdentifiers() error {
-	if msg.Forwarding != nil && msg.Forwarding.Unwind {
+	if msg.Forwarding.GetUnwind() {
 		if msg.SourcePort != "" {
 			return errorsmod.Wrapf(ErrInvalidForwarding, "source port must be empty when unwind is set, got %s instead", msg.SourcePort)
 		}

--- a/modules/apps/transfer/types/transfer_authorization.go
+++ b/modules/apps/transfer/types/transfer_authorization.go
@@ -183,11 +183,11 @@ func validateForwarding(forwarding *Forwarding, allowedForwarding []AllowedForwa
 		return nil
 	}
 
-	if forwarding.Unwind {
+	if forwarding.GetUnwind() {
 		return errorsmod.Wrap(ErrInvalidForwarding, "not allowed automatic unwind")
 	}
 
-	if !isAllowedForwarding(forwarding.Hops, allowedForwarding) {
+	if !isAllowedForwarding(forwarding.GetHops(), allowedForwarding) {
 		return errorsmod.Wrapf(ErrInvalidForwarding, "not allowed hops %s", forwarding.Hops)
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

brought up during security review, this is just an additional safeguard to ensure we don't possibly act on nil pointer

closes: #XXXX

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
