### PR TITLE
fix(08-wasm): decode checksum hex string to bytes in migrate contract CLI

### DIFF
--- a/modules/light-clients/08-wasm/client/cli/tx.go
+++ b/modules/light-clients/08-wasm/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 
@@ -97,14 +98,19 @@ func newMigrateContractCmd() *cobra.Command {
 			}
 
 			clientID := args[0]
-			checksum := args[1]
+			checksumHex := args[1]
 			migrateMsg := args[2]
+
+			checksum, err := hex.DecodeString(checksumHex)
+			if err != nil {
+				return fmt.Errorf("invalid checksum format: %w", err)
+			}
 
 			// Construct the message
 			msg := &types.MsgMigrateContract{
 				Signer:   clientCtx.GetFromAddress().String(),
 				ClientId: clientID,
-				Checksum: []byte(checksum),
+				Checksum: checksum,
 				Msg:      []byte(migrateMsg),
 			}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
The change involves updating the migrate-contract command in the tx.go file to correctly handle the checksum argument. Specifically, the checksum, which is provided as a hexadecimal string, is now decoded into bytes before being used in the MsgMigrateContract message


closes: #XXXX

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
