### PR TITLE
Add Wrap/Unwrap Interfaces and implement OnChanOpenInit

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/ibc_middleware.go
+++ b/modules/apps/27-interchain-accounts/controller/ibc_middleware.go
@@ -71,16 +71,6 @@ func (im IBCMiddleware) OnChanOpenInit(
 	if err != nil {
 		return "", err
 	}
-
-	// call underlying app's OnChanOpenInit callback with the passed in version
-	// the version returned is discarded as the ica-auth module does not have permission to edit the version string.
-	// ics27 will always return the version string containing the Metadata struct which is created during the `RegisterInterchainAccount` call.
-	if im.app != nil && im.keeper.IsMiddlewareEnabled(ctx, portID, connectionHops[0]) {
-		if _, err := im.app.OnChanOpenInit(ctx, order, connectionHops, portID, channelID, counterparty, version); err != nil {
-			return "", err
-		}
-	}
-
 	return version, nil
 }
 
@@ -394,4 +384,17 @@ func (im IBCMiddleware) UnmarshalPacketData(ctx sdk.Context, portID string, chan
 	}
 
 	return data, version, nil
+}
+
+// WrapVersion returns the wrapped version based on the provided version string and underlying application version.
+// TODO: decide how we want to handle the underlying app. For now I made it backwards compatible.
+func (IBCMiddleware) WrapVersion(cbVersion, underlyingAppVersion string) string {
+	// ignore underlying app version
+	return cbVersion
+}
+
+// UnwrapVersionUnsafe returns the version. Interchain accounts does not wrap versions.
+func (IBCMiddleware) UnwrapVersionUnsafe(version string) (string, string, error) {
+	// ignore underlying app version
+	return version, "", nil
 }

--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -2,6 +2,7 @@ package fee
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
@@ -49,45 +50,12 @@ func (im IBCMiddleware) OnChanOpenInit(
 	counterparty channeltypes.Counterparty,
 	version string,
 ) (string, error) {
-	var versionMetadata types.Metadata
-
-	if strings.TrimSpace(version) == "" {
-		// default version
-		versionMetadata = types.Metadata{
-			FeeVersion: types.Version,
-			AppVersion: "",
-		}
-	} else {
-		metadata, err := types.MetadataFromVersion(version)
-		if err != nil {
-			// Since it is valid for fee version to not be specified, the above middleware version may be for a middleware
-			// lower down in the stack. Thus, if it is not a fee version we pass the entire version string onto the underlying
-			// application.
-			return im.app.OnChanOpenInit(ctx, order, connectionHops, portID, channelID,
-				counterparty, version)
-		}
-		versionMetadata = metadata
-	}
-
-	if versionMetadata.FeeVersion != types.Version {
-		return "", errorsmod.Wrapf(types.ErrInvalidVersion, "expected %s, got %s", types.Version, versionMetadata.FeeVersion)
-	}
-
-	appVersion, err := im.app.OnChanOpenInit(ctx, order, connectionHops, portID, channelID, counterparty, versionMetadata.AppVersion)
-	if err != nil {
-		return "", err
-	}
-
-	versionMetadata.AppVersion = appVersion
-	versionBytes, err := types.ModuleCdc.MarshalJSON(&versionMetadata)
-	if err != nil {
-		return "", err
+	if strings.TrimSpace(version) != "" && version != types.Version {
+		return "", errorsmod.Wrapf(types.ErrInvalidVersion, "expected %s, got %s", types.Version, version)
 	}
 
 	im.keeper.SetFeeEnabled(ctx, portID, channelID)
-
-	// call underlying app's OnChanOpenInit callback with the appVersion
-	return string(versionBytes), nil
+	return types.Version, nil
 }
 
 // OnChanOpenTry implements the IBCMiddleware interface
@@ -504,14 +472,14 @@ func unwrapAppVersion(channelVersion string) string {
 }
 
 // WrapVersion returns the wrapped version based on the provided version string and underlying application version.
-func (IBCMiddleware) WrapVersion(version, appVersion string) string {
-	if appVersion != types.Version {
-		return version
+func (IBCMiddleware) WrapVersion(cbVersion, underlyingAppVersion string) string {
+	if cbVersion != types.Version {
+		panic(fmt.Errorf("invalid appVersion provided. expected: %s got: %s", types.Version, cbVersion))
 	}
 
 	metadata := types.Metadata{
-		FeeVersion: types.Version,
-		AppVersion: appVersion,
+		FeeVersion: cbVersion,
+		AppVersion: underlyingAppVersion,
 	}
 
 	versionBytes := types.ModuleCdc.MustMarshal(&metadata)
@@ -519,13 +487,13 @@ func (IBCMiddleware) WrapVersion(version, appVersion string) string {
 	return string(versionBytes)
 }
 
-// UnwrapVersion returns the version. Interchain accounts does not wrap versions.
-func (IBCMiddleware) UnwrapVersion(version string) (string, string) {
+// UnwrapVersionUnsafe returns the version. Interchain accounts does not wrap versions.
+func (IBCMiddleware) UnwrapVersionUnsafe(version string) (string, string, error) {
 	metadata, err := types.MetadataFromVersion(version)
 	if err != nil {
 		// nothing to unwrap
-		return "", version
+		return "", version, err
 	}
 
-	return metadata.FeeVersion, metadata.AppVersion
+	return metadata.FeeVersion, metadata.AppVersion, nil
 }

--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -482,7 +482,7 @@ func (IBCMiddleware) WrapVersion(cbVersion, underlyingAppVersion string) string 
 		AppVersion: underlyingAppVersion,
 	}
 
-	versionBytes := types.ModuleCdc.MustMarshal(&metadata)
+	versionBytes := types.ModuleCdc.MustMarshalJSON(&metadata)
 
 	return string(versionBytes)
 }

--- a/modules/apps/callbacks/ibc_middleware.go
+++ b/modules/apps/callbacks/ibc_middleware.go
@@ -316,7 +316,7 @@ func (im IBCMiddleware) OnChanOpenInit(
 	counterparty channeltypes.Counterparty,
 	version string,
 ) (string, error) {
-	return im.app.OnChanOpenInit(ctx, channelOrdering, connectionHops, portID, channelID, counterparty, version)
+	return "", nil
 }
 
 // OnChanOpenTry defers to the underlying application

--- a/modules/apps/callbacks/ibc_middleware.go
+++ b/modules/apps/callbacks/ibc_middleware.go
@@ -307,7 +307,7 @@ func (IBCMiddleware) processCallback(
 }
 
 // OnChanOpenInit defers to the underlying application
-func (im IBCMiddleware) OnChanOpenInit(
+func (IBCMiddleware) OnChanOpenInit(
 	ctx sdk.Context,
 	channelOrdering channeltypes.Order,
 	connectionHops []string,

--- a/modules/apps/callbacks/ibc_middleware_test.go
+++ b/modules/apps/callbacks/ibc_middleware_test.go
@@ -171,7 +171,7 @@ func (s *CallbacksTestSuite) TestSendPacket() {
 
 			s.Require().Len(cbs, 1, "expected 1 legacy module")
 
-			legacyModule, ok := cbs[0].(porttypes.LegacyIBCModule)
+			legacyModule, ok := cbs[0].(*porttypes.LegacyIBCModule)
 			s.Require().True(ok, "expected there to be a single legacy ibc module")
 
 			legacyModuleCbs := legacyModule.GetCallbacks()

--- a/modules/apps/callbacks/testing/simapp/app.go
+++ b/modules/apps/callbacks/testing/simapp/app.go
@@ -526,6 +526,7 @@ func NewSimApp(
 	// initialize ICA module with mock module as the authentication module on the controller side
 	var icaControllerStack porttypes.ClassicIBCModule
 	icaControllerStack = ibcmock.NewIBCModule(&mockModule, ibcmock.NewIBCApp("", scopedICAMockKeeper))
+	ibcAppRouter.AddRoute(icacontrollertypes.SubModuleName, icaControllerStack)
 	app.ICAAuthModule, ok = icaControllerStack.(ibcmock.IBCModule)
 	if !ok {
 		panic(fmt.Errorf("cannot convert %T to %T", icaControllerStack, app.ICAAuthModule))
@@ -549,6 +550,7 @@ func NewSimApp(
 
 	var icaHostStack porttypes.ClassicIBCModule
 	icaHostStack = icahost.NewIBCModule(app.ICAHostKeeper)
+	ibcAppRouter.AddRoute(icacontrollertypes.SubModuleName, icaHostStack)
 	icaHostStack = ibcfee.NewIBCMiddleware(icaHostStack, app.IBCFeeKeeper)
 
 	// Add host, controller & ica auth modules to IBC router
@@ -561,8 +563,7 @@ func NewSimApp(
 		AddRoute(ibcmock.ModuleName+icacontrollertypes.SubModuleName, icaControllerStack) // ica with mock auth module stack route to ica (top level of middleware stack)
 
 	ibcAppRouter.
-		AddRoute(icahosttypes.SubModuleName, icaHostStack).
-		AddRoute(ibcmock.ModuleName+icacontrollertypes.SubModuleName, icaControllerStack)
+		AddRoute(icahosttypes.SubModuleName, icaHostStack)
 
 	// Create Mock IBC Fee module stack for testing
 	// SendPacket, mock module cannot send packets

--- a/modules/apps/callbacks/testing/simapp/app.go
+++ b/modules/apps/callbacks/testing/simapp/app.go
@@ -576,10 +576,13 @@ func NewSimApp(
 	// create fee wrapped mock module
 	feeMockModule := ibcmock.NewIBCModule(&mockModule, ibcmock.NewIBCApp(MockFeePort, scopedFeeMockKeeper))
 	app.FeeMockModule = feeMockModule
+	ibcAppRouter.AddRoute(MockFeePort, feeMockModule)
+
 	var feeWithMockModule porttypes.Middleware = ibcfee.NewIBCMiddleware(feeMockModule, app.IBCFeeKeeper)
+	ibcAppRouter.AddRoute(MockFeePort, feeWithMockModule)
+
 	feeWithMockModule = ibccallbacks.NewIBCMiddleware(feeWithMockModule, app.IBCFeeKeeper, app.MockContractKeeper, maxCallbackGas)
 	ibcRouter.AddRoute(MockFeePort, feeWithMockModule)
-
 	ibcAppRouter.AddRoute(MockFeePort, feeWithMockModule)
 
 	// Seal the IBC Router

--- a/modules/apps/callbacks/testing/simapp/app.go
+++ b/modules/apps/callbacks/testing/simapp/app.go
@@ -552,6 +552,7 @@ func NewSimApp(
 	icaHostStack = icahost.NewIBCModule(app.ICAHostKeeper)
 	ibcAppRouter.AddRoute(icahosttypes.SubModuleName, icaHostStack)
 	icaHostStack = ibcfee.NewIBCMiddleware(icaHostStack, app.IBCFeeKeeper)
+	ibcAppRouter.AddRoute(icahosttypes.SubModuleName, icaHostStack)
 
 	// Add host, controller & ica auth modules to IBC router
 	ibcRouter.
@@ -562,8 +563,7 @@ func NewSimApp(
 		AddRoute(icahosttypes.SubModuleName, icaHostStack).
 		AddRoute(ibcmock.ModuleName+icacontrollertypes.SubModuleName, icaControllerStack) // ica with mock auth module stack route to ica (top level of middleware stack)
 
-	ibcAppRouter.
-		AddRoute(icahosttypes.SubModuleName, icaHostStack)
+	ibcAppRouter.AddRoute(ibcmock.ModuleName+icacontrollertypes.SubModuleName, icaControllerStack)
 
 	// Create Mock IBC Fee module stack for testing
 	// SendPacket, mock module cannot send packets

--- a/modules/apps/callbacks/testing/simapp/app.go
+++ b/modules/apps/callbacks/testing/simapp/app.go
@@ -550,7 +550,7 @@ func NewSimApp(
 
 	var icaHostStack porttypes.ClassicIBCModule
 	icaHostStack = icahost.NewIBCModule(app.ICAHostKeeper)
-	ibcAppRouter.AddRoute(icacontrollertypes.SubModuleName, icaHostStack)
+	ibcAppRouter.AddRoute(icahosttypes.SubModuleName, icaHostStack)
 	icaHostStack = ibcfee.NewIBCMiddleware(icaHostStack, app.IBCFeeKeeper)
 
 	// Add host, controller & ica auth modules to IBC router

--- a/modules/core/05-port/types/ibc_legacy_module.go
+++ b/modules/core/05-port/types/ibc_legacy_module.go
@@ -40,9 +40,7 @@ func (im *LegacyIBCModule) OnChanOpenInit(
 	counterparty channeltypes.Counterparty,
 	version string,
 ) (string, error) {
-	var (
-		negotiatedVersions = make([]string, len(im.cbs))
-	)
+	negotiatedVersions := make([]string, len(im.cbs))
 
 	for i := len(im.cbs) - 1; i >= 0; i-- {
 		cbVersion := version

--- a/modules/core/05-port/types/ibc_legacy_module.go
+++ b/modules/core/05-port/types/ibc_legacy_module.go
@@ -28,7 +28,7 @@ func NewLegacyIBCModule(cbs ...ClassicIBCModule) ClassicIBCModule {
 }
 
 // OnChanOpenInit implements the IBCModule interface
-func (im *LegacyIBCModule) OnChanOpenInit(
+func (*LegacyIBCModule) OnChanOpenInit(
 	ctx sdk.Context,
 	order channeltypes.Order,
 	connectionHops []string,

--- a/modules/core/05-port/types/ibc_legacy_module.go
+++ b/modules/core/05-port/types/ibc_legacy_module.go
@@ -1,12 +1,15 @@
 package types
 
 import (
+	"strings"
+
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	clienttypes "github.com/cosmos/ibc-go/v9/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v9/modules/core/04-channel/types"
+	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
 	ibcexported "github.com/cosmos/ibc-go/v9/modules/core/exported"
 )
 
@@ -28,7 +31,7 @@ func NewLegacyIBCModule(cbs ...ClassicIBCModule) ClassicIBCModule {
 }
 
 // OnChanOpenInit implements the IBCModule interface
-func (*LegacyIBCModule) OnChanOpenInit(
+func (im *LegacyIBCModule) OnChanOpenInit(
 	ctx sdk.Context,
 	order channeltypes.Order,
 	connectionHops []string,
@@ -37,7 +40,48 @@ func (*LegacyIBCModule) OnChanOpenInit(
 	counterparty channeltypes.Counterparty,
 	version string,
 ) (string, error) {
-	return "", nil
+	var (
+		negotiatedVersions = make([]string, len(im.cbs))
+	)
+
+	for i := len(im.cbs) - 1; i >= 0; i-- {
+		cbVersion := version
+
+		// TODO: document behaviour
+		// handles default empty string + not using middleware when desired
+		if wrapper, ok := im.cbs[i].(VersionWrapper); ok {
+			appVersion, underlyingAppVersion, err := wrapper.UnwrapVersionUnsafe(version)
+			if err != nil {
+				// middleware disabled
+				negotiatedVersions[i] = ""
+				continue
+			}
+			cbVersion, version = appVersion, underlyingAppVersion
+		}
+
+		negotiatedVersion, err := im.cbs[i].OnChanOpenInit(ctx, order, connectionHops, portID, channelID, counterparty, cbVersion)
+		if err != nil {
+			return "", errorsmod.Wrapf(err, "channel open init callback failed for port ID: %s, channel ID: %s", portID, channelID)
+		}
+		negotiatedVersions[i] = negotiatedVersion
+	}
+
+	return reconstructVersion(im.cbs, negotiatedVersions)
+}
+
+// glue back proposed version for channel storage
+func reconstructVersion(cbs []ClassicIBCModule, negotiatedVersions []string) (string, error) {
+	version := negotiatedVersions[0]
+	for i := 1; i < len(cbs); i++ {
+		if strings.TrimSpace(negotiatedVersions[i]) != "" {
+			wrapper, ok := cbs[i].(VersionWrapper)
+			if !ok {
+				return "", ibcerrors.ErrInvalidVersion
+			}
+			version = wrapper.WrapVersion(negotiatedVersions[i], version)
+		}
+	}
+	return version, nil
 }
 
 // OnChanOpenTry implements the IBCModule interface.

--- a/modules/core/05-port/types/ibc_legacy_module.go
+++ b/modules/core/05-port/types/ibc_legacy_module.go
@@ -47,7 +47,7 @@ func (im *LegacyIBCModule) OnChanOpenInit(
 
 		// TODO: document behaviour
 		// handles default empty string + not using middleware when desired
-		if wrapper, ok := im.cbs[i].(VersionWrapper); ok {
+		if wrapper, ok := im.cbs[i].(VersionWrapper); ok && strings.TrimSpace(version) != "" {
 			appVersion, underlyingAppVersion, err := wrapper.UnwrapVersionUnsafe(version)
 			if err != nil {
 				// middleware disabled

--- a/modules/core/05-port/types/ibc_legacy_module.go
+++ b/modules/core/05-port/types/ibc_legacy_module.go
@@ -22,13 +22,13 @@ func (im *LegacyIBCModule) GetCallbacks() []ClassicIBCModule {
 
 // NewLegacyIBCModule creates a new IBCModule given the keeper
 func NewLegacyIBCModule(cbs ...ClassicIBCModule) ClassicIBCModule {
-	return LegacyIBCModule{
+	return &LegacyIBCModule{
 		cbs: cbs,
 	}
 }
 
 // OnChanOpenInit implements the IBCModule interface
-func (LegacyIBCModule) OnChanOpenInit(
+func (im *LegacyIBCModule) OnChanOpenInit(
 	ctx sdk.Context,
 	order channeltypes.Order,
 	connectionHops []string,

--- a/modules/core/05-port/types/module.go
+++ b/modules/core/05-port/types/module.go
@@ -129,10 +129,12 @@ type VersionWrapper interface {
 	// Applications should wrap the provided version with their application version.
 	// If they do not need to wrap, they may simply return the version provided.
 	WrapVersion(cbVersion, underlyingAppVersion string) string
-	// UnwrapVersion is required in order to remove middleware wiring and the ICS4Wrapper
+	// UnwrapVersionUnsafe is required in order to remove middleware wiring and the ICS4Wrapper
 	// while maintaining backwards compatibility. It will be removed in the future.
-	// Applications should unwrap the provided version with their application version.
-	// If they do not need to wrap, they may simply return the version provided.
+	// Applications should unwrap the provided version with into their  application version.
+	// and the underlying application version. If they are unsuccessful they should return an error.
+	// UnwrapVersionUnsafe will be used during opening handshakes and channel upgrades when the version
+	// is still being negotiated.
 	UnwrapVersionUnsafe(string) (cbVersion, underlyingAppVersion string, err error)
 	// UnwrapVersionSafe(ctx sdk.Context, portID, channelID, version string) (appVersion, version string)
 }

--- a/modules/core/05-port/types/module.go
+++ b/modules/core/05-port/types/module.go
@@ -121,6 +121,20 @@ type IBCModule interface {
 	) error
 }
 
+// TODO: docstring
+type VersionWrapper interface {
+	// WrapVersion is required in order to remove middleware wiring and the ICS4Wrapper
+	// while maintaining backwards compatibility. It will be removed in the future.
+	// Applications should wrap the provided version with their application version.
+	// If they do not need to wrap, they may simply return the version provided.
+	WrapVersion(version, appVersion string) string
+	// UnwrapVersion is required in order to remove middleware wiring and the ICS4Wrapper
+	// while maintaining backwards compatibility. It will be removed in the future.
+	// Applications should unwrap the provided version with their application version.
+	// If they do not need to wrap, they may simply return the version provided.
+	UnwrapVersion(string) (appVersion, version string)
+}
+
 // UpgradableModule defines the callbacks required to perform a channel upgrade.
 // Note: applications must ensure that state related to packet processing remains unmodified until the OnChanUpgradeOpen callback is executed.
 // This guarantees that in-flight packets are correctly flushed using the existing channel parameters.

--- a/modules/core/05-port/types/module.go
+++ b/modules/core/05-port/types/module.go
@@ -121,7 +121,8 @@ type IBCModule interface {
 	) error
 }
 
-// TODO: docstring
+// VersionWrapper is an optional interface which should be implemented by middleware which wrap the channel version
+// to ensure backwards compatibility.
 type VersionWrapper interface {
 	// WrapVersion is required in order to remove middleware wiring and the ICS4Wrapper
 	// while maintaining backwards compatibility. It will be removed in the future.

--- a/modules/core/05-port/types/module.go
+++ b/modules/core/05-port/types/module.go
@@ -128,12 +128,13 @@ type VersionWrapper interface {
 	// while maintaining backwards compatibility. It will be removed in the future.
 	// Applications should wrap the provided version with their application version.
 	// If they do not need to wrap, they may simply return the version provided.
-	WrapVersion(version, appVersion string) string
+	WrapVersion(cbVersion, underlyingAppVersion string) string
 	// UnwrapVersion is required in order to remove middleware wiring and the ICS4Wrapper
 	// while maintaining backwards compatibility. It will be removed in the future.
 	// Applications should unwrap the provided version with their application version.
 	// If they do not need to wrap, they may simply return the version provided.
-	UnwrapVersion(string) (appVersion, version string)
+	UnwrapVersionUnsafe(string) (cbVersion, underlyingAppVersion string, err error)
+	// UnwrapVersionSafe(ctx sdk.Context, portID, channelID, version string) (appVersion, version string)
 }
 
 // UpgradableModule defines the callbacks required to perform a channel upgrade.

--- a/modules/core/05-port/types/router_v2.go
+++ b/modules/core/05-port/types/router_v2.go
@@ -66,7 +66,7 @@ func (rtr *AppRouter) AddRoute(module string, cbs IBCModule) *AppRouter {
 		// in order to facilitate having a single LegacyIBCModule, but also allowing for
 		// consecutive calls to AddRoute to support existing functionality, we can re-create
 		// the legacy module with the routes as they get added.
-		if classicRoutes, ok := rtr.classicRoutes[module]; ok && len(classicRoutes) > 1 {
+		if classicRoutes, ok := rtr.classicRoutes[module]; ok {
 			rtr.legacyRoutes[module] = NewLegacyIBCModule(classicRoutes...)
 		}
 	} else {

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -194,7 +194,7 @@ func (k *Keeper) ChannelOpenInit(goCtx context.Context, msg *channeltypes.MsgCha
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	// Retrieve application callbacks from router
-	cbs, ok := k.PortKeeper.Route(msg.PortId)
+	cbs, ok := k.PortKeeper.AppRouter.HandshakeRoute(msg.PortId)
 	if !ok {
 		ctx.Logger().Error("channel open init failed", "port-id", msg.PortId, "error", errorsmod.Wrapf(porttypes.ErrInvalidRoute, "route not found to module: %s", msg.PortId))
 		return nil, errorsmod.Wrapf(porttypes.ErrInvalidRoute, "route not found to module: %s", msg.PortId)

--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -521,6 +521,8 @@ func NewSimApp(
 	// create fee wrapped mock module
 	feeMockModule := ibcmock.NewIBCModule(&mockModule, ibcmock.NewIBCApp(MockFeePort, scopedFeeMockKeeper))
 	app.FeeMockModule = feeMockModule
+	ibcAppRouter.AddRoute(MockFeePort, feeMockModule)
+
 	feeWithMockModule := ibcfee.NewIBCMiddleware(feeMockModule, app.IBCFeeKeeper)
 	ibcRouter.AddRoute(MockFeePort, feeWithMockModule)
 

--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -525,7 +525,6 @@ func NewSimApp(
 
 	feeWithMockModule := ibcfee.NewIBCMiddleware(feeMockModule, app.IBCFeeKeeper)
 	ibcRouter.AddRoute(MockFeePort, feeWithMockModule)
-
 	ibcAppRouter.AddRoute(MockFeePort, feeWithMockModule)
 
 	// Seal the IBC Router

--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -479,6 +479,7 @@ func NewSimApp(
 	// initialize ICA module with mock module as the authentication module on the controller side
 	var icaControllerStack porttypes.ClassicIBCModule
 	icaControllerStack = ibcmock.NewIBCModule(&mockModule, ibcmock.NewIBCApp("", scopedICAMockKeeper))
+	ibcAppRouter.AddRoute(icacontrollertypes.SubModuleName, icaControllerStack)
 	var ok bool
 	app.ICAAuthModule, ok = icaControllerStack.(ibcmock.IBCModule)
 	if !ok {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


This PR adds the optional VersionWrapper interface and implementation for ics29.

This PR ended up also implementing OnChanOpenInit in the LegacyIBCModule and updating all implementations to perform the new logic.

closes #7017
closes #6954 


<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
