### PR TITLE
feat(core/eureka): add timeout handler

### DIFF
--- a/modules/core/04-channel/keeper/events.go
+++ b/modules/core/04-channel/keeper/events.go
@@ -228,7 +228,7 @@ func emitAcknowledgePacketEvent(ctx sdk.Context, packet types.Packet, channel ty
 
 // emitTimeoutPacketEvent emits a timeout packet event. It will be emitted both the first time a packet
 // is timed out for a certain sequence and for all duplicate timeouts.
-func emitTimeoutPacketEvent(ctx sdk.Context, packet types.Packet, channel types.Channel) {
+func EmitTimeoutPacketEvent(ctx sdk.Context, packet types.Packet, channel types.Channel) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeTimeoutPacket,

--- a/modules/core/04-channel/keeper/keeper.go
+++ b/modules/core/04-channel/keeper/keeper.go
@@ -219,7 +219,7 @@ func (k *Keeper) SetPacketCommitment(ctx sdk.Context, portID, channelID string, 
 	store.Set(host.PacketCommitmentKey(portID, channelID, sequence), commitmentHash)
 }
 
-func (k *Keeper) deletePacketCommitment(ctx sdk.Context, portID, channelID string, sequence uint64) {
+func (k *Keeper) DeletePacketCommitment(ctx sdk.Context, portID, channelID string, sequence uint64) {
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(host.PacketCommitmentKey(portID, channelID, sequence))
 }

--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -472,7 +472,7 @@ func (k *Keeper) AcknowledgePacket(
 	}
 
 	// Delete packet commitment, since the packet has been acknowledged, the commitement is no longer necessary
-	k.deletePacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+	k.DeletePacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 	// log that a packet has been acknowledged
 	k.Logger(ctx).Info(

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -76,7 +76,7 @@ func (k *Keeper) TimeoutPacket(
 	commitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 	if len(commitment) == 0 {
-		emitTimeoutPacketEvent(ctx, packet, channel)
+		EmitTimeoutPacketEvent(ctx, packet, channel)
 		// This error indicates that the timeout has already been relayed
 		// or there is a misconfigured relayer attempting to prove a timeout
 		// for a packet never sent. Core IBC will treat this error as a no-op in order to
@@ -148,7 +148,7 @@ func (k *Keeper) TimeoutExecuted(
 		)
 	}
 
-	k.deletePacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+	k.DeletePacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 	// if an upgrade is in progress, handling packet flushing and update channel state appropriately
 	if channel.State == types.FLUSHING && channel.Ordering == types.UNORDERED {
@@ -183,7 +183,7 @@ func (k *Keeper) TimeoutExecuted(
 	)
 
 	// emit an event marking that we have processed the timeout
-	emitTimeoutPacketEvent(ctx, packet, channel)
+	EmitTimeoutPacketEvent(ctx, packet, channel)
 
 	return nil
 }
@@ -236,7 +236,7 @@ func (k *Keeper) TimeoutOnClose(
 	commitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 	if len(commitment) == 0 {
-		emitTimeoutPacketEvent(ctx, packet, channel)
+		EmitTimeoutPacketEvent(ctx, packet, channel)
 		// This error indicates that the timeout has already been relayed
 		// or there is a misconfigured relayer attempting to prove a timeout
 		// for a packet never sent. Core IBC will treat this error as a no-op in order to

--- a/modules/core/packet-server/keeper/keeper.go
+++ b/modules/core/packet-server/keeper/keeper.go
@@ -1,8 +1,18 @@
 package keeper
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec"
+	"bytes"
 
+	errorsmod "cosmossdk.io/errors"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	clienttypes "github.com/cosmos/ibc-go/v9/modules/core/02-client/types"
+	channelkeeper "github.com/cosmos/ibc-go/v9/modules/core/04-channel/keeper"
+	channeltypes "github.com/cosmos/ibc-go/v9/modules/core/04-channel/types"
+	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
+	"github.com/cosmos/ibc-go/v9/modules/core/exported"
 	"github.com/cosmos/ibc-go/v9/modules/core/packet-server/types"
 )
 
@@ -18,4 +28,77 @@ func NewKeeper(cdc codec.BinaryCodec, channelKeeper types.ChannelKeeper, clientK
 		ChannelKeeper: channelKeeper,
 		ClientKeeper:  clientKeeper,
 	}
+}
+
+func (k Keeper) TimeoutPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	proof []byte,
+	proofHeight exported.Height,
+	nextSequenceRecv uint64,
+) error {
+	// Lookup counterparty associated with our channel and ensure that it was packet was indeed
+	// sent by our counterparty.
+	counterparty, ok := k.ClientKeeper.GetCounterparty(ctx, packet.SourceChannel)
+	if !ok {
+		return channeltypes.ErrChannelNotFound
+	}
+
+	if counterparty.ClientId != packet.DestinationChannel {
+		return channeltypes.ErrInvalidChannelIdentifier
+	}
+
+	// check that timeout height or timeout timestamp has passed on the other end
+	proofTimestamp, err := k.ClientKeeper.GetClientTimestampAtHeight(ctx, packet.SourceChannel, proofHeight)
+	if err != nil {
+		return err
+	}
+
+	timeout := channeltypes.NewTimeout(packet.GetTimeoutHeight().(clienttypes.Height), packet.GetTimeoutTimestamp())
+	if !timeout.Elapsed(proofHeight.(clienttypes.Height), proofTimestamp) {
+		return errorsmod.Wrap(timeout.ErrTimeoutNotReached(proofHeight.(clienttypes.Height), proofTimestamp), "packet timeout not reached")
+	}
+
+	commitment := k.ChannelKeeper.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+
+	// create sentinel channel
+	channel := channeltypes.Channel{Ordering: channeltypes.UNORDERED, ConnectionHops: []string{packet.SourceChannel}}
+
+	if len(commitment) == 0 {
+		channelkeeper.EmitTimeoutPacketEvent(ctx, packet, channel)
+		// This error indicates that the timeout has already been relayed
+		// or there is a misconfigured relayer attempting to prove a timeout
+		// for a packet never sent. Core IBC will treat this error as a no-op in order to
+		// prevent an entire relay transaction from failing and consuming unnecessary fees.
+		return channeltypes.ErrNoOpMsg
+	}
+
+	packetCommitment := channeltypes.CommitPacket(packet)
+	// verify we sent the packet and haven't cleared it out yet
+	if !bytes.Equal(commitment, packetCommitment) {
+		return errorsmod.Wrapf(channeltypes.ErrInvalidPacket, "packet commitment bytes are not equal: got (%v), expected (%v)", commitment, packetCommitment)
+	}
+
+	// verify packet receipt absence
+	path := host.PacketReceiptKey(packet.DestinationPort, packet.DestinationChannel, packet.Sequence)
+	merklePath := types.BuildMerklePath(counterparty.MerklePathPrefix, path)
+
+	if err := k.ClientKeeper.VerifyNonMembership(
+		ctx,
+		packet.SourceChannel,
+		proofHeight,
+		0, 0,
+		proof,
+		merklePath,
+	); err != nil {
+		return err
+	}
+
+	// delete packet commitment to prevent replay
+	k.ChannelKeeper.DeletePacketCommitment(ctx, packet.SourcePort, packet.SourceChannel, packet.Sequence)
+
+	// emit timeout events
+	channelkeeper.EmitTimeoutPacketEvent(ctx, packet, channel)
+
+	return nil
 }

--- a/modules/core/packet-server/keeper/keeper.go
+++ b/modules/core/packet-server/keeper/keeper.go
@@ -100,12 +100,7 @@ func (k Keeper) SendPacket(
 	k.ChannelKeeper.SetNextSequenceSend(ctx, sourcePort, sourceChannel, sequence+1)
 	k.ChannelKeeper.SetPacketCommitment(ctx, sourcePort, sourceChannel, packet.GetSequence(), commitment)
 
-	// create sentinel channel for events
-	channel := channeltypes.Channel{
-		Ordering:       channeltypes.ORDERED,
-		ConnectionHops: []string{sourceChannel},
-	}
-	channelkeeper.EmitSendPacketEvent(ctx, packet, channel, timeoutHeight)
+	channelkeeper.EmitSendPacketEvent(ctx, packet, sentinelChannel(sourceChannel), timeoutHeight)
 
 	// return the sequence
 	return sequence, nil

--- a/modules/core/packet-server/keeper/keeper_test.go
+++ b/modules/core/packet-server/keeper/keeper_test.go
@@ -323,6 +323,7 @@ func (suite *KeeperTestSuite) TestTimeoutPacket() {
 					packet.TimeoutHeight, packet.TimeoutTimestamp, packet.AppVersion, packet.Data)
 				suite.Require().NoError(err, "send packet failed")
 
+				// set packet receipt to mock a valid past receive
 				suite.chainB.App.GetIBCKeeper().ChannelKeeper.SetPacketReceipt(suite.chainB.GetContext(), packet.DestinationPort, packet.DestinationChannel, packet.Sequence)
 			},
 			commitmenttypes.ErrInvalidProof,

--- a/modules/core/packet-server/keeper/keeper_test.go
+++ b/modules/core/packet-server/keeper/keeper_test.go
@@ -361,7 +361,7 @@ func (suite *KeeperTestSuite) TestTimeoutPacket() {
 
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
-			// intialize freezeClient to false
+			// initialize freezeClient to false
 			freezeClient = false
 
 			path = ibctesting.NewPath(suite.chainA, suite.chainB)

--- a/modules/core/packet-server/types/expected_keepers.go
+++ b/modules/core/packet-server/types/expected_keepers.go
@@ -16,7 +16,7 @@ type ChannelKeeper interface {
 	GetPacketCommitment(ctx sdk.Context, portID string, channelID string, sequence uint64) []byte
 
 	// DeletePacketCommitment deletes the packet commitment hash under the commitment path
-	// DeletePacketCommitment(ctx sdk.Context, portID string, channelID string, sequence uint64)
+	DeletePacketCommitment(ctx sdk.Context, portID string, channelID string, sequence uint64)
 
 	// SetNextSequenceSend writes the next send sequence under the sequence path
 	// This is a public path that is standardized by the IBC specification
@@ -43,4 +43,6 @@ type ClientKeeper interface {
 	// the executing chain
 	// This is a private path that is only used by the IBC lite module
 	GetCounterparty(ctx sdk.Context, clientID string) (clienttypes.Counterparty, bool)
+	// GetClientTimestampAtHeight returns the timestamp in nanoseconds of the client at the given height given the clientID.
+	GetClientTimestampAtHeight(ctx sdk.Context, clientID string, height exported.Height) (uint64, error)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #6970 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
