### PR TITLE
refactor: replace ack interface with result type for OnRecvPacket

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/ibc_middleware.go
+++ b/modules/apps/27-interchain-accounts/controller/ibc_middleware.go
@@ -223,7 +223,7 @@ func (IBCMiddleware) OnRecvPacket(
 	ack := channeltypes.NewErrorAcknowledgement(err)
 	keeper.EmitAcknowledgementEvent(ctx, packet, ack, err)
 	return ibcexported.RecvPacketResult{
-		Status:          ibcexported.FAILURE,
+		Status:          ibcexported.Failure,
 		Acknowledgement: ack.Acknowledgement(),
 	}
 }

--- a/modules/apps/27-interchain-accounts/controller/ibc_middleware.go
+++ b/modules/apps/27-interchain-accounts/controller/ibc_middleware.go
@@ -218,11 +218,14 @@ func (IBCMiddleware) OnRecvPacket(
 	_ string,
 	packet channeltypes.Packet,
 	_ sdk.AccAddress,
-) ibcexported.Acknowledgement {
+) ibcexported.RecvPacketResult {
 	err := errorsmod.Wrapf(icatypes.ErrInvalidChannelFlow, "cannot receive packet on controller chain")
 	ack := channeltypes.NewErrorAcknowledgement(err)
 	keeper.EmitAcknowledgementEvent(ctx, packet, ack, err)
-	return ack
+	return ibcexported.RecvPacketResult{
+		Status:          ibcexported.FAILURE,
+		Acknowledgement: ack.Acknowledgement(),
+	}
 }
 
 // OnAcknowledgementPacket implements the IBCMiddleware interface
@@ -358,7 +361,7 @@ func (im IBCMiddleware) OnChanUpgradeOpen(ctx sdk.Context, portID, channelID str
 func (IBCMiddleware) WriteAcknowledgement(
 	ctx sdk.Context,
 	packet ibcexported.PacketI,
-	ack ibcexported.Acknowledgement,
+	ack []byte,
 ) error {
 	panic(errors.New("WriteAcknowledgement not supported for ICA controller module"))
 }

--- a/modules/apps/27-interchain-accounts/controller/ibc_middleware_test.go
+++ b/modules/apps/27-interchain-accounts/controller/ibc_middleware_test.go
@@ -482,12 +482,12 @@ func (suite *InterchainAccountsTestSuite) TestOnChanCloseConfirm() {
 
 func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 	testCases := []struct {
-		name     string
-		malleate func()
-		expPass  bool
+		name      string
+		malleate  func()
+		expStatus exported.RecvPacketStatus
 	}{
 		{
-			"ICA OnRecvPacket fails with ErrInvalidChannelFlow", func() {}, false,
+			"ICA OnRecvPacket fails with ErrInvalidChannelFlow", func() {}, exported.Failure,
 		},
 	}
 
@@ -525,7 +525,7 @@ func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 
 				ctx := suite.chainA.GetContext()
 				res := cbs.OnRecvPacket(ctx, path.EndpointA.GetChannel().Version, packet, nil)
-				suite.Require().Equal(tc.expPass, res.Status == exported.Success)
+				suite.Require().Equal(tc.expStatus, res.Status, "expected %s but got %s", tc.expStatus, res.Status)
 
 				expectedEvents := sdk.Events{
 					sdk.NewEvent(

--- a/modules/apps/27-interchain-accounts/controller/ibc_middleware_test.go
+++ b/modules/apps/27-interchain-accounts/controller/ibc_middleware_test.go
@@ -525,7 +525,7 @@ func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 
 				ctx := suite.chainA.GetContext()
 				res := cbs.OnRecvPacket(ctx, path.EndpointA.GetChannel().Version, packet, nil)
-				suite.Require().Equal(tc.expPass, res.Status == exported.SUCCESS)
+				suite.Require().Equal(tc.expPass, res.Status == exported.Success)
 
 				expectedEvents := sdk.Events{
 					sdk.NewEvent(

--- a/modules/apps/27-interchain-accounts/controller/ibc_middleware_test.go
+++ b/modules/apps/27-interchain-accounts/controller/ibc_middleware_test.go
@@ -20,6 +20,7 @@ import (
 	porttypes "github.com/cosmos/ibc-go/v9/modules/core/05-port/types"
 	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
 	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
+	"github.com/cosmos/ibc-go/v9/modules/core/exported"
 	ibctesting "github.com/cosmos/ibc-go/v9/testing"
 	ibcmock "github.com/cosmos/ibc-go/v9/testing/mock"
 )
@@ -523,8 +524,8 @@ func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 				)
 
 				ctx := suite.chainA.GetContext()
-				ack := cbs.OnRecvPacket(ctx, path.EndpointA.GetChannel().Version, packet, nil)
-				suite.Require().Equal(tc.expPass, ack.Success())
+				res := cbs.OnRecvPacket(ctx, path.EndpointA.GetChannel().Version, packet, nil)
+				suite.Require().Equal(tc.expPass, res.Status == exported.SUCCESS)
 
 				expectedEvents := sdk.Events{
 					sdk.NewEvent(

--- a/modules/apps/27-interchain-accounts/controller/keeper/events.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/events.go
@@ -7,12 +7,11 @@ import (
 
 	icatypes "github.com/cosmos/ibc-go/v9/modules/apps/27-interchain-accounts/types"
 	channeltypes "github.com/cosmos/ibc-go/v9/modules/core/04-channel/types"
-	"github.com/cosmos/ibc-go/v9/modules/core/exported"
 )
 
 // EmitAcknowledgementEvent emits an event signalling a successful or failed acknowledgement and including the error
 // details if any.
-func EmitAcknowledgementEvent(ctx sdk.Context, packet channeltypes.Packet, ack exported.Acknowledgement, err error) {
+func EmitAcknowledgementEvent(ctx sdk.Context, packet channeltypes.Packet, ack channeltypes.Acknowledgement, err error) {
 	attributes := []sdk.Attribute{
 		sdk.NewAttribute(sdk.AttributeKeyModule, icatypes.ModuleName),
 		sdk.NewAttribute(icatypes.AttributeKeyControllerChannelID, packet.GetDestChannel()),

--- a/modules/apps/27-interchain-accounts/host/ibc_module.go
+++ b/modules/apps/27-interchain-accounts/host/ibc_module.go
@@ -133,7 +133,7 @@ func (im IBCModule) OnRecvPacket(
 		im.keeper.Logger(ctx).Info("host submodule is disabled")
 		keeper.EmitHostDisabledEvent(ctx, packet)
 		return ibcexported.RecvPacketResult{
-			Status:          ibcexported.FAILURE,
+			Status:          ibcexported.Failure,
 			Acknowledgement: channeltypes.NewErrorAcknowledgement(types.ErrHostSubModuleDisabled).Acknowledgement(),
 		}
 	}
@@ -147,7 +147,7 @@ func (im IBCModule) OnRecvPacket(
 		im.keeper.Logger(ctx).Error(fmt.Sprintf("%s sequence %d", err.Error(), packet.Sequence))
 
 		return ibcexported.RecvPacketResult{
-			Status:          ibcexported.FAILURE,
+			Status:          ibcexported.Failure,
 			Acknowledgement: ack.Acknowledgement(),
 		}
 	}
@@ -160,7 +160,7 @@ func (im IBCModule) OnRecvPacket(
 
 	// NOTE: acknowledgement will be written synchronously during IBC handler execution.
 	return ibcexported.RecvPacketResult{
-		Status:          ibcexported.SUCCESS,
+		Status:          ibcexported.Success,
 		Acknowledgement: ack.Acknowledgement(),
 	}
 }

--- a/modules/apps/27-interchain-accounts/host/ibc_module.go
+++ b/modules/apps/27-interchain-accounts/host/ibc_module.go
@@ -14,7 +14,6 @@ import (
 	channeltypes "github.com/cosmos/ibc-go/v9/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/v9/modules/core/05-port/types"
 	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
-	"github.com/cosmos/ibc-go/v9/modules/core/exported"
 	ibcexported "github.com/cosmos/ibc-go/v9/modules/core/exported"
 )
 
@@ -147,7 +146,7 @@ func (im IBCModule) OnRecvPacket(
 		keeper.EmitAcknowledgementEvent(ctx, packet, ack, err)
 		im.keeper.Logger(ctx).Error(fmt.Sprintf("%s sequence %d", err.Error(), packet.Sequence))
 
-		return exported.RecvPacketResult{
+		return ibcexported.RecvPacketResult{
 			Status:          ibcexported.FAILURE,
 			Acknowledgement: ack.Acknowledgement(),
 		}
@@ -161,7 +160,7 @@ func (im IBCModule) OnRecvPacket(
 
 	// NOTE: acknowledgement will be written synchronously during IBC handler execution.
 	return ibcexported.RecvPacketResult{
-		Status:          exported.SUCCESS,
+		Status:          ibcexported.SUCCESS,
 		Acknowledgement: ack.Acknowledgement(),
 	}
 }

--- a/modules/apps/27-interchain-accounts/host/ibc_module_test.go
+++ b/modules/apps/27-interchain-accounts/host/ibc_module_test.go
@@ -420,7 +420,7 @@ func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 					ctx sdk.Context, channelVersion string, packet channeltypes.Packet, relayer sdk.AccAddress,
 				) exported.RecvPacketResult {
 					return exported.RecvPacketResult{
-						Status:          exported.FAILURE,
+						Status:          exported.Failure,
 						Acknowledgement: channeltypes.NewErrorAcknowledgement(fmt.Errorf("failed OnRecvPacket mock callback")).Acknowledgement(),
 					}
 				}
@@ -504,11 +504,11 @@ func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 				expectedAttributes := []sdk.Attribute{
 					sdk.NewAttribute(sdk.AttributeKeyModule, icatypes.ModuleName),
 					sdk.NewAttribute(icatypes.AttributeKeyHostChannelID, packet.GetDestChannel()),
-					sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, strconv.FormatBool(res.Status == exported.SUCCESS)),
+					sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, strconv.FormatBool(res.Status == exported.Success)),
 				}
 
 				if tc.expAckSuccess {
-					suite.Require().Equal(exported.SUCCESS, res.Status)
+					suite.Require().Equal(exported.Success, res.Status)
 					suite.Require().Equal(expectedAck.Acknowledgement(), res.Acknowledgement)
 
 					expectedEvents := sdk.Events{
@@ -522,7 +522,7 @@ func (suite *InterchainAccountsTestSuite) TestOnRecvPacket() {
 					ibctesting.AssertEvents(&suite.Suite, expectedEvents, ctx.EventManager().Events().ToABCIEvents())
 
 				} else {
-					suite.Require().Equal(exported.FAILURE, res.Status)
+					suite.Require().Equal(exported.Failure, res.Status)
 
 					expectedAttributes = append(expectedAttributes, sdk.NewAttribute(icatypes.AttributeKeyAckError, tc.eventErrorMsg))
 					expectedEvents := sdk.Events{

--- a/modules/apps/27-interchain-accounts/host/keeper/events.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/events.go
@@ -8,12 +8,11 @@ import (
 	"github.com/cosmos/ibc-go/v9/modules/apps/27-interchain-accounts/host/types"
 	icatypes "github.com/cosmos/ibc-go/v9/modules/apps/27-interchain-accounts/types"
 	channeltypes "github.com/cosmos/ibc-go/v9/modules/core/04-channel/types"
-	"github.com/cosmos/ibc-go/v9/modules/core/exported"
 )
 
 // EmitAcknowledgementEvent emits an event signalling a successful or failed acknowledgement and including the error
 // details if any.
-func EmitAcknowledgementEvent(ctx sdk.Context, packet channeltypes.Packet, ack exported.Acknowledgement, err error) {
+func EmitAcknowledgementEvent(ctx sdk.Context, packet channeltypes.Packet, ack channeltypes.Acknowledgement, err error) {
 	attributes := []sdk.Attribute{
 		sdk.NewAttribute(sdk.AttributeKeyModule, icatypes.ModuleName),
 		sdk.NewAttribute(icatypes.AttributeKeyHostChannelID, packet.GetDestChannel()),

--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -179,24 +179,27 @@ func (im IBCMiddleware) OnRecvPacket(
 	channelVersion string,
 	packet channeltypes.Packet,
 	relayer sdk.AccAddress,
-) exported.Acknowledgement {
+) exported.RecvPacketResult {
 	if !im.keeper.IsFeeEnabled(ctx, packet.DestinationPort, packet.DestinationChannel) {
 		return im.app.OnRecvPacket(ctx, channelVersion, packet, relayer)
 	}
 
 	appVersion := unwrapAppVersion(channelVersion)
-	ack := im.app.OnRecvPacket(ctx, appVersion, packet, relayer)
+	res := im.app.OnRecvPacket(ctx, appVersion, packet, relayer)
 
 	// in case of async acknowledgement (ack == nil) store the relayer address for use later during async WriteAcknowledgement
-	if ack == nil {
+	if res.Status == exported.ASYNC {
 		im.keeper.SetRelayerAddressForAsyncAck(ctx, channeltypes.NewPacketID(packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence()), relayer.String())
-		return nil
+		return res
 	}
 
 	// if forwardRelayer is not found we refund recv_fee
 	forwardRelayer, _ := im.keeper.GetCounterpartyPayeeAddress(ctx, relayer.String(), packet.GetDestChannel())
 
-	return types.NewIncentivizedAcknowledgement(forwardRelayer, ack.Acknowledgement(), ack.Success())
+	return exported.RecvPacketResult{
+		Status:          res.Status,
+		Acknowledgement: types.NewIncentivizedAcknowledgement(forwardRelayer, res.Acknowledgement, res.Status == exported.SUCCESS).Acknowledgement(),
+	}
 }
 
 // OnAcknowledgementPacket implements the IBCMiddleware interface
@@ -417,7 +420,7 @@ func (im IBCMiddleware) OnChanUpgradeOpen(ctx sdk.Context, portID, channelID str
 func (im IBCMiddleware) WriteAcknowledgement(
 	ctx sdk.Context,
 	packet exported.PacketI,
-	ack exported.Acknowledgement,
+	ack []byte,
 ) error {
 	return im.keeper.WriteAcknowledgement(ctx, packet, ack)
 }

--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -187,7 +187,7 @@ func (im IBCMiddleware) OnRecvPacket(
 	appVersion := unwrapAppVersion(channelVersion)
 	res := im.app.OnRecvPacket(ctx, appVersion, packet, relayer)
 
-	// in case of async acknowledgement (ack == nil) store the relayer address for use later during async WriteAcknowledgement
+	// in case of async result status store the relayer address for use later during async WriteAcknowledgement
 	if res.Status == exported.Async {
 		im.keeper.SetRelayerAddressForAsyncAck(ctx, channeltypes.NewPacketID(packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence()), relayer.String())
 		return res

--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -188,7 +188,7 @@ func (im IBCMiddleware) OnRecvPacket(
 	res := im.app.OnRecvPacket(ctx, appVersion, packet, relayer)
 
 	// in case of async acknowledgement (ack == nil) store the relayer address for use later during async WriteAcknowledgement
-	if res.Status == exported.ASYNC {
+	if res.Status == exported.Async {
 		im.keeper.SetRelayerAddressForAsyncAck(ctx, channeltypes.NewPacketID(packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence()), relayer.String())
 		return res
 	}
@@ -198,7 +198,7 @@ func (im IBCMiddleware) OnRecvPacket(
 
 	return exported.RecvPacketResult{
 		Status:          res.Status,
-		Acknowledgement: types.NewIncentivizedAcknowledgement(forwardRelayer, res.Acknowledgement, res.Status == exported.SUCCESS).Acknowledgement(),
+		Acknowledgement: types.NewIncentivizedAcknowledgement(forwardRelayer, res.Acknowledgement, res.Status == exported.Success).Acknowledgement(),
 	}
 }
 

--- a/modules/apps/29-fee/ibc_middleware_test.go
+++ b/modules/apps/29-fee/ibc_middleware_test.go
@@ -460,8 +460,10 @@ func (suite *FeeTestSuite) TestOnRecvPacket() {
 					channelVersion string,
 					packet channeltypes.Packet,
 					relayer sdk.AccAddress,
-				) exported.Acknowledgement {
-					return nil
+				) exported.RecvPacketResult {
+					return exported.RecvPacketResult{
+						Status: exported.ASYNC,
+					}
 				}
 			},
 			true,
@@ -521,13 +523,13 @@ func (suite *FeeTestSuite) TestOnRecvPacket() {
 					ForwardRelayerAddress: forwardAddr,
 					UnderlyingAppSuccess:  true,
 				}
-				suite.Require().Equal(expectedAck, result)
+				suite.Require().Equal(expectedAck.Acknowledgement(), result.Acknowledgement)
 
 			case !tc.feeEnabled:
-				suite.Require().Equal(ibcmock.MockAcknowledgement, result)
+				suite.Require().Equal(ibcmock.MockAcknowledgement.Acknowledgement(), result.Acknowledgement)
 
-			case tc.forwardRelayer && result == nil:
-				suite.Require().Equal(nil, result)
+			case tc.forwardRelayer && result.Status == exported.ASYNC:
+				suite.Require().Nil(result.Acknowledgement)
 				packetID := channeltypes.NewPacketID(packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
 
 				// retrieve the forward relayer that was stored in `onRecvPacket`
@@ -540,7 +542,7 @@ func (suite *FeeTestSuite) TestOnRecvPacket() {
 					ForwardRelayerAddress: "",
 					UnderlyingAppSuccess:  true,
 				}
-				suite.Require().Equal(expectedAck, result)
+				suite.Require().Equal(expectedAck.Acknowledgement(), result.Acknowledgement)
 			}
 		})
 	}

--- a/modules/apps/29-fee/ibc_middleware_test.go
+++ b/modules/apps/29-fee/ibc_middleware_test.go
@@ -462,7 +462,7 @@ func (suite *FeeTestSuite) TestOnRecvPacket() {
 					relayer sdk.AccAddress,
 				) exported.RecvPacketResult {
 					return exported.RecvPacketResult{
-						Status: exported.ASYNC,
+						Status: exported.Async,
 					}
 				}
 			},
@@ -528,7 +528,7 @@ func (suite *FeeTestSuite) TestOnRecvPacket() {
 			case !tc.feeEnabled:
 				suite.Require().Equal(ibcmock.MockAcknowledgement.Acknowledgement(), result.Acknowledgement)
 
-			case tc.forwardRelayer && result.Status == exported.ASYNC:
+			case tc.forwardRelayer && result.Status == exported.Async:
 				suite.Require().Nil(result.Acknowledgement)
 				packetID := channeltypes.NewPacketID(packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
 

--- a/modules/apps/29-fee/keeper/relay.go
+++ b/modules/apps/29-fee/keeper/relay.go
@@ -32,7 +32,8 @@ func (k Keeper) WriteAcknowledgement(ctx sdk.Context, packet ibcexported.PacketI
 	// if there is no registered counterparty address then write acknowledgement with empty relayer address and refund recv_fee.
 	forwardRelayer, _ := k.GetCounterpartyPayeeAddress(ctx, relayer, packet.GetDestChannel())
 
-	// TODO: this is temporarily hardcoded to true. can we remove/deprecate this bool field. NOTE: should revisit this!!
+	// TODO(https://github.com/cosmos/ibc-go/issues/7044):
+	// The underlying app success bool is temporarily hardcoded to true! This should be revisited for the issue linked above.
 	ack := types.NewIncentivizedAcknowledgement(forwardRelayer, acknowledgement, true)
 
 	k.DeleteForwardRelayerAddress(ctx, packetID)

--- a/modules/apps/29-fee/keeper/relay.go
+++ b/modules/apps/29-fee/keeper/relay.go
@@ -32,7 +32,7 @@ func (k Keeper) WriteAcknowledgement(ctx sdk.Context, packet ibcexported.PacketI
 	// if there is no registered counterparty address then write acknowledgement with empty relayer address and refund recv_fee.
 	forwardRelayer, _ := k.GetCounterpartyPayeeAddress(ctx, relayer, packet.GetDestChannel())
 
-	// TODO: temp hardcode to true
+	// TODO: this is temporarily hardcoded to true. can we remove/deprecate this bool field. NOTE: should revisit this!!
 	ack := types.NewIncentivizedAcknowledgement(forwardRelayer, acknowledgement, true)
 
 	k.DeleteForwardRelayerAddress(ctx, packetID)

--- a/modules/apps/29-fee/keeper/relay.go
+++ b/modules/apps/29-fee/keeper/relay.go
@@ -14,7 +14,7 @@ import (
 
 // WriteAcknowledgement wraps IBC ChannelKeeper's WriteAcknowledgement function
 // ICS29 WriteAcknowledgement is used for asynchronous acknowledgements
-func (k Keeper) WriteAcknowledgement(ctx sdk.Context, packet ibcexported.PacketI, acknowledgement ibcexported.Acknowledgement) error {
+func (k Keeper) WriteAcknowledgement(ctx sdk.Context, packet ibcexported.PacketI, acknowledgement []byte) error {
 	if !k.IsFeeEnabled(ctx, packet.GetDestPort(), packet.GetDestChannel()) {
 		// ics4Wrapper may be core IBC or higher-level middleware
 		return k.ics4Wrapper.WriteAcknowledgement(ctx, packet, acknowledgement)
@@ -32,12 +32,13 @@ func (k Keeper) WriteAcknowledgement(ctx sdk.Context, packet ibcexported.PacketI
 	// if there is no registered counterparty address then write acknowledgement with empty relayer address and refund recv_fee.
 	forwardRelayer, _ := k.GetCounterpartyPayeeAddress(ctx, relayer, packet.GetDestChannel())
 
-	ack := types.NewIncentivizedAcknowledgement(forwardRelayer, acknowledgement.Acknowledgement(), acknowledgement.Success())
+	// TODO: temp hardcode to true
+	ack := types.NewIncentivizedAcknowledgement(forwardRelayer, acknowledgement, true)
 
 	k.DeleteForwardRelayerAddress(ctx, packetID)
 
 	// ics4Wrapper may be core IBC or higher-level middleware
-	return k.ics4Wrapper.WriteAcknowledgement(ctx, packet, ack)
+	return k.ics4Wrapper.WriteAcknowledgement(ctx, packet, ack.Acknowledgement())
 }
 
 // GetAppVersion returns the underlying application version.

--- a/modules/apps/29-fee/keeper/relay_test.go
+++ b/modules/apps/29-fee/keeper/relay_test.go
@@ -58,7 +58,7 @@ func (suite *KeeperTestSuite) TestWriteAcknowledgementAsync() {
 			// malleate test case
 			tc.malleate()
 
-			err := suite.chainB.GetSimApp().IBCFeeKeeper.WriteAcknowledgement(suite.chainB.GetContext(), packet, ack)
+			err := suite.chainB.GetSimApp().IBCFeeKeeper.WriteAcknowledgement(suite.chainB.GetContext(), packet, ack.Acknowledgement())
 
 			if tc.expPass {
 				suite.Require().NoError(err)
@@ -95,7 +95,7 @@ func (suite *KeeperTestSuite) TestWriteAcknowledgementAsyncFeeDisabled() {
 
 	ack := channeltypes.NewResultAcknowledgement([]byte("success"))
 
-	err := suite.chainB.GetSimApp().IBCFeeKeeper.WriteAcknowledgement(suite.chainB.GetContext(), packet, ack)
+	err := suite.chainB.GetSimApp().IBCFeeKeeper.WriteAcknowledgement(suite.chainB.GetContext(), packet, ack.Acknowledgement())
 	suite.Require().NoError(err)
 
 	packetAck, _ := suite.chainB.GetSimApp().GetIBCKeeper().ChannelKeeper.GetPacketAcknowledgement(suite.chainB.GetContext(), packet.DestinationPort, packet.DestinationChannel, 1)

--- a/modules/apps/callbacks/ibc_middleware.go
+++ b/modules/apps/callbacks/ibc_middleware.go
@@ -205,8 +205,7 @@ func (im IBCMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion string, pac
 	}
 
 	callbackExecutor := func(cachedCtx sdk.Context) error {
-		acknowledgement := channeltypes.NewResultAcknowledgement(res.Acknowledgement)
-		return im.contractKeeper.IBCReceivePacketCallback(cachedCtx, packet, acknowledgement.Acknowledgement(), callbackData.CallbackAddress, callbackData.ApplicationVersion)
+		return im.contractKeeper.IBCReceivePacketCallback(cachedCtx, packet, res.Acknowledgement, callbackData.CallbackAddress, callbackData.ApplicationVersion)
 	}
 
 	// callback execution errors are not allowed to block the packet lifecycle, they are only used in event emissions

--- a/modules/apps/callbacks/ibc_middleware.go
+++ b/modules/apps/callbacks/ibc_middleware.go
@@ -188,23 +188,24 @@ func (im IBCMiddleware) OnTimeoutPacket(ctx sdk.Context, channelVersion string, 
 // It defers to the underlying application and then calls the contract callback.
 // If the contract callback runs out of gas and may be retried with a higher gas limit then the state changes are
 // reverted via a panic.
-func (im IBCMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion string, packet channeltypes.Packet, relayer sdk.AccAddress) ibcexported.Acknowledgement {
-	ack := im.app.OnRecvPacket(ctx, channelVersion, packet, relayer)
+func (im IBCMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion string, packet channeltypes.Packet, relayer sdk.AccAddress) ibcexported.RecvPacketResult {
+	res := im.app.OnRecvPacket(ctx, channelVersion, packet, relayer)
 	// if ack is nil (asynchronous acknowledgements), then the callback will be handled in WriteAcknowledgement
 	// if ack is not successful, all state changes are reverted. If a packet cannot be received, then there is
 	// no need to execute a callback on the receiving chain.
-	if ack == nil || !ack.Success() {
-		return ack
+	if res.Status != ibcexported.SUCCESS {
+		return res
 	}
 
 	// OnRecvPacket is not blocked if the packet does not opt-in to callbacks
 	callbackData, err := types.GetDestCallbackData(ctx, im.app, packet, im.maxCallbackGas)
 	if err != nil {
-		return ack
+		return res
 	}
 
 	callbackExecutor := func(cachedCtx sdk.Context) error {
-		return im.contractKeeper.IBCReceivePacketCallback(cachedCtx, packet, ack, callbackData.CallbackAddress, callbackData.ApplicationVersion)
+		acknowledgement := channeltypes.NewResultAcknowledgement(res.Acknowledgement)
+		return im.contractKeeper.IBCReceivePacketCallback(cachedCtx, packet, acknowledgement.Acknowledgement(), callbackData.CallbackAddress, callbackData.ApplicationVersion)
 	}
 
 	// callback execution errors are not allowed to block the packet lifecycle, they are only used in event emissions
@@ -214,7 +215,7 @@ func (im IBCMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion string, pac
 		types.CallbackTypeReceivePacket, callbackData, err,
 	)
 
-	return ack
+	return res
 }
 
 // WriteAcknowledgement implements the ReceivePacket destination callbacks for the ibc-callbacks middleware
@@ -225,7 +226,7 @@ func (im IBCMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion string, pac
 func (im IBCMiddleware) WriteAcknowledgement(
 	ctx sdk.Context,
 	packet ibcexported.PacketI,
-	ack ibcexported.Acknowledgement,
+	ack []byte,
 ) error {
 	err := im.ics4Wrapper.WriteAcknowledgement(ctx, packet, ack)
 	if err != nil {

--- a/modules/apps/callbacks/ibc_middleware.go
+++ b/modules/apps/callbacks/ibc_middleware.go
@@ -194,7 +194,7 @@ func (im IBCMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion string, pac
 	// if result status is failed, then all state changes are reverted.
 	// if a packet cannot be received, then there is no need to execute a callback on the receiving chain,
 	// thus we only proceed with the contract keeper callback if the result status is successful.
-	if res.Status != ibcexported.SUCCESS {
+	if res.Status != ibcexported.Success {
 		return res
 	}
 

--- a/modules/apps/callbacks/ibc_middleware.go
+++ b/modules/apps/callbacks/ibc_middleware.go
@@ -190,9 +190,10 @@ func (im IBCMiddleware) OnTimeoutPacket(ctx sdk.Context, channelVersion string, 
 // reverted via a panic.
 func (im IBCMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion string, packet channeltypes.Packet, relayer sdk.AccAddress) ibcexported.RecvPacketResult {
 	res := im.app.OnRecvPacket(ctx, channelVersion, packet, relayer)
-	// if ack is nil (asynchronous acknowledgements), then the callback will be handled in WriteAcknowledgement
-	// if ack is not successful, all state changes are reverted. If a packet cannot be received, then there is
-	// no need to execute a callback on the receiving chain.
+	// if result status is asynchronous, then the callback will be handled in WriteAcknowledgement
+	// if result status is failed, then all state changes are reverted.
+	// if a packet cannot be received, then there is no need to execute a callback on the receiving chain,
+	// thus we only proceed with the contract keeper callback if the result status is successful.
 	if res.Status != ibcexported.SUCCESS {
 		return res
 	}

--- a/modules/apps/callbacks/ibc_middleware_test.go
+++ b/modules/apps/callbacks/ibc_middleware_test.go
@@ -687,7 +687,7 @@ func (s *CallbacksTestSuite) TestOnRecvPacket() {
 			switch tc.expAck {
 			case successAck:
 				res := onRecvPacket()
-				s.Require().Equal(ibcexported.SUCCESS, res.Status)
+				s.Require().Equal(ibcexported.Success, res.Status)
 				s.Require().NotNil(res.Acknowledgement)
 
 			case panicAck:
@@ -1128,7 +1128,7 @@ func (s *CallbacksTestSuite) TestOnRecvPacketAsyncAck() {
 	)
 
 	res := mockFeeCallbackStack.OnRecvPacket(s.chainA.GetContext(), ibcmock.MockFeeVersion, packet, s.chainA.SenderAccount.GetAddress())
-	s.Require().Equal(ibcexported.ASYNC, res.Status)
+	s.Require().Equal(ibcexported.Async, res.Status)
 	s.Require().Nil(res.Acknowledgement)
 	s.AssertHasExecutedExpectedCallback("none", true)
 }

--- a/modules/apps/callbacks/ibc_middleware_test.go
+++ b/modules/apps/callbacks/ibc_middleware_test.go
@@ -561,176 +561,175 @@ func (s *CallbacksTestSuite) TestOnTimeoutPacket() {
 	}
 }
 
-// TODO: refactor this test to get rid of exported.Acknowledgement
-// func (s *CallbacksTestSuite) TestOnRecvPacket() {
-// 	type expResult uint8
-// 	const (
-// 		noExecution expResult = iota
-// 		callbackFailed
-// 		callbackSuccess
-// 	)
+func (s *CallbacksTestSuite) TestOnRecvPacket() {
+	type expResult uint8
+	const (
+		noExecution expResult = iota
+		callbackFailed
+		callbackSuccess
+	)
 
-// 	var (
-// 		packetData   transfertypes.FungibleTokenPacketDataV2
-// 		packet       channeltypes.Packet
-// 		ctx          sdk.Context
-// 		userGasLimit uint64
-// 	)
+	var (
+		packetData   transfertypes.FungibleTokenPacketDataV2
+		packet       channeltypes.Packet
+		ctx          sdk.Context
+		userGasLimit uint64
+	)
 
-// 	successAck := channeltypes.NewResultAcknowledgement([]byte{byte(1)})
-// 	panicAck := channeltypes.NewErrorAcknowledgement(fmt.Errorf("panic"))
+	successAck := channeltypes.NewResultAcknowledgement([]byte{byte(1)})
+	panicAck := channeltypes.NewErrorAcknowledgement(fmt.Errorf("panic"))
 
-// 	testCases := []struct {
-// 		name      string
-// 		malleate  func()
-// 		expResult expResult
-// 		expAck    ibcexported.Acknowledgement // TODO: refactor to remove ack interface
-// 	}{
-// 		{
-// 			"success",
-// 			func() {},
-// 			callbackSuccess,
-// 			successAck,
-// 		},
-// 		{
-// 			"failure: underlying app OnRecvPacket fails",
-// 			func() {
-// 				packet.Data = []byte("invalid packet data")
-// 			},
-// 			noExecution,
-// 			channeltypes.NewErrorAcknowledgement(ibcerrors.ErrInvalidType),
-// 		},
-// 		{
-// 			"success: no-op on callback data is not valid",
-// 			func() {
-// 				//nolint:goconst
-// 				packetData.Memo = `{"dest_callback": {"address": ""}}`
-// 				packet.Data = packetData.GetBytes()
-// 			},
-// 			noExecution,
-// 			successAck,
-// 		},
-// 		{
-// 			"failure: callback execution reach out of gas, but sufficient gas provided by relayer",
-// 			func() {
-// 				packetData.Memo = fmt.Sprintf(`{"dest_callback": {"address":"%s", "gas_limit":"%d"}}`, simapp.OogPanicContract, userGasLimit)
-// 				packet.Data = packetData.GetBytes()
-// 			},
-// 			callbackFailed,
-// 			successAck,
-// 		},
-// 		{
-// 			"failure: callback execution panics on insufficient gas provided by relayer",
-// 			func() {
-// 				packetData.Memo = fmt.Sprintf(`{"dest_callback": {"address":"%s", "gas_limit":"%d"}}`, simapp.OogPanicContract, userGasLimit)
-// 				packet.Data = packetData.GetBytes()
+	testCases := []struct {
+		name      string
+		malleate  func()
+		expResult expResult
+		expAck    channeltypes.Acknowledgement
+	}{
+		{
+			"success",
+			func() {},
+			callbackSuccess,
+			successAck,
+		},
+		{
+			"failure: underlying app OnRecvPacket fails",
+			func() {
+				packet.Data = []byte("invalid packet data")
+			},
+			noExecution,
+			channeltypes.NewErrorAcknowledgement(ibcerrors.ErrInvalidType),
+		},
+		{
+			"success: no-op on callback data is not valid",
+			func() {
+				//nolint:goconst
+				packetData.Memo = `{"dest_callback": {"address": ""}}`
+				packet.Data = packetData.GetBytes()
+			},
+			noExecution,
+			successAck,
+		},
+		{
+			"failure: callback execution reach out of gas, but sufficient gas provided by relayer",
+			func() {
+				packetData.Memo = fmt.Sprintf(`{"dest_callback": {"address":"%s", "gas_limit":"%d"}}`, simapp.OogPanicContract, userGasLimit)
+				packet.Data = packetData.GetBytes()
+			},
+			callbackFailed,
+			successAck,
+		},
+		{
+			"failure: callback execution panics on insufficient gas provided by relayer",
+			func() {
+				packetData.Memo = fmt.Sprintf(`{"dest_callback": {"address":"%s", "gas_limit":"%d"}}`, simapp.OogPanicContract, userGasLimit)
+				packet.Data = packetData.GetBytes()
 
-// 				ctx = ctx.WithGasMeter(storetypes.NewGasMeter(300_000))
-// 			},
-// 			callbackFailed,
-// 			panicAck,
-// 		},
-// 		{
-// 			"failure: callback execution fails",
-// 			func() {
-// 				packetData.Memo = fmt.Sprintf(`{"dest_callback": {"address":"%s"}}`, simapp.ErrorContract)
-// 				packet.Data = packetData.GetBytes()
-// 			},
-// 			callbackFailed,
-// 			successAck,
-// 		},
-// 	}
+				ctx = ctx.WithGasMeter(storetypes.NewGasMeter(300_000))
+			},
+			callbackFailed,
+			panicAck,
+		},
+		{
+			"failure: callback execution fails",
+			func() {
+				packetData.Memo = fmt.Sprintf(`{"dest_callback": {"address":"%s"}}`, simapp.ErrorContract)
+				packet.Data = packetData.GetBytes()
+			},
+			callbackFailed,
+			successAck,
+		},
+	}
 
-// 	for _, tc := range testCases {
-// 		tc := tc
-// 		s.Run(tc.name, func() {
-// 			s.SetupTransferTest()
+	for _, tc := range testCases {
+		tc := tc
+		s.Run(tc.name, func() {
+			s.SetupTransferTest()
 
-// 			// set user gas limit above panic level in mock contract keeper
-// 			userGasLimit = 600_000
-// 			packetData = transfertypes.NewFungibleTokenPacketDataV2(
-// 				[]transfertypes.Token{
-// 					{
-// 						Denom:  transfertypes.NewDenom(ibctesting.TestCoin.Denom),
-// 						Amount: ibctesting.TestCoin.Amount.String(),
-// 					},
-// 				},
-// 				ibctesting.TestAccAddress,
-// 				s.chainB.SenderAccount.GetAddress().String(),
-// 				fmt.Sprintf(`{"dest_callback": {"address":"%s", "gas_limit":"%d"}}`, ibctesting.TestAccAddress, userGasLimit),
-// 				ibctesting.EmptyForwardingPacketData,
-// 			)
+			// set user gas limit above panic level in mock contract keeper
+			userGasLimit = 600_000
+			packetData = transfertypes.NewFungibleTokenPacketDataV2(
+				[]transfertypes.Token{
+					{
+						Denom:  transfertypes.NewDenom(ibctesting.TestCoin.Denom),
+						Amount: ibctesting.TestCoin.Amount.String(),
+					},
+				},
+				ibctesting.TestAccAddress,
+				s.chainB.SenderAccount.GetAddress().String(),
+				fmt.Sprintf(`{"dest_callback": {"address":"%s", "gas_limit":"%d"}}`, ibctesting.TestAccAddress, userGasLimit),
+				ibctesting.EmptyForwardingPacketData,
+			)
 
-// 			packet = channeltypes.Packet{
-// 				Sequence:           1,
-// 				SourcePort:         s.path.EndpointA.ChannelConfig.PortID,
-// 				SourceChannel:      s.path.EndpointA.ChannelID,
-// 				DestinationPort:    s.path.EndpointB.ChannelConfig.PortID,
-// 				DestinationChannel: s.path.EndpointB.ChannelID,
-// 				Data:               packetData.GetBytes(),
-// 				TimeoutHeight:      s.chainB.GetTimeoutHeight(),
-// 				TimeoutTimestamp:   0,
-// 			}
+			packet = channeltypes.Packet{
+				Sequence:           1,
+				SourcePort:         s.path.EndpointA.ChannelConfig.PortID,
+				SourceChannel:      s.path.EndpointA.ChannelID,
+				DestinationPort:    s.path.EndpointB.ChannelConfig.PortID,
+				DestinationChannel: s.path.EndpointB.ChannelID,
+				Data:               packetData.GetBytes(),
+				TimeoutHeight:      s.chainB.GetTimeoutHeight(),
+				TimeoutTimestamp:   0,
+			}
 
-// 			ctx = s.chainB.GetContext()
-// 			gasLimit := ctx.GasMeter().Limit()
+			ctx = s.chainB.GetContext()
+			gasLimit := ctx.GasMeter().Limit()
 
-// 			tc.malleate()
+			tc.malleate()
 
-// 			// callbacks module is routed as top level middleware
-// 			transferStack, ok := s.chainB.App.GetIBCKeeper().PortKeeper.Route(transfertypes.ModuleName)
-// 			s.Require().True(ok)
+			// callbacks module is routed as top level middleware
+			transferStack, ok := s.chainB.App.GetIBCKeeper().PortKeeper.Route(transfertypes.ModuleName)
+			s.Require().True(ok)
 
-// 			onRecvPacket := func() ibcexported.RecvPacketResult {
-// 				return transferStack.OnRecvPacket(ctx, s.path.EndpointA.GetChannel().Version, packet, s.chainB.SenderAccount.GetAddress())
-// 			}
+			onRecvPacket := func() ibcexported.RecvPacketResult {
+				return transferStack.OnRecvPacket(ctx, s.path.EndpointA.GetChannel().Version, packet, s.chainB.SenderAccount.GetAddress())
+			}
 
-// 			switch tc.expAck {
-// 			case successAck:
-// 				res := onRecvPacket()
-// 				s.Require().Equal(ibcexported.SUCCESS, res.Status)
-// 				s.Require().NotNil(res.Acknowledgement)
+			switch tc.expAck {
+			case successAck:
+				res := onRecvPacket()
+				s.Require().Equal(ibcexported.SUCCESS, res.Status)
+				s.Require().NotNil(res.Acknowledgement)
 
-// 			case panicAck:
-// 				s.Require().PanicsWithValue(storetypes.ErrorOutOfGas{
-// 					Descriptor: fmt.Sprintf("ibc %s callback out of gas; commitGasLimit: %d", types.CallbackTypeReceivePacket, userGasLimit),
-// 				}, func() {
-// 					_ = onRecvPacket()
-// 				})
+			case panicAck:
+				s.Require().PanicsWithValue(storetypes.ErrorOutOfGas{
+					Descriptor: fmt.Sprintf("ibc %s callback out of gas; commitGasLimit: %d", types.CallbackTypeReceivePacket, userGasLimit),
+				}, func() {
+					_ = onRecvPacket()
+				})
 
-// 			default:
-// 				res := onRecvPacket()
-// 				s.Require().Equal(tc.expAck.Acknowledgement(), res.Acknowledgement)
-// 			}
+			default:
+				res := onRecvPacket()
+				s.Require().Equal(tc.expAck.Acknowledgement(), res.Acknowledgement)
+			}
 
-// 			destStatefulCounter := GetSimApp(s.chainB).MockContractKeeper.GetStateEntryCounter(s.chainB.GetContext())
-// 			destCounters := GetSimApp(s.chainB).MockContractKeeper.Counters
+			destStatefulCounter := GetSimApp(s.chainB).MockContractKeeper.GetStateEntryCounter(s.chainB.GetContext())
+			destCounters := GetSimApp(s.chainB).MockContractKeeper.Counters
 
-// 			switch tc.expResult {
-// 			case noExecution:
-// 				s.Require().Len(destCounters, 0)
-// 				s.Require().Equal(uint8(0), destStatefulCounter)
+			switch tc.expResult {
+			case noExecution:
+				s.Require().Len(destCounters, 0)
+				s.Require().Equal(uint8(0), destStatefulCounter)
 
-// 			case callbackFailed:
-// 				s.Require().Len(destCounters, 1)
-// 				s.Require().Equal(1, destCounters[types.CallbackTypeReceivePacket])
-// 				s.Require().Equal(uint8(0), destStatefulCounter)
+			case callbackFailed:
+				s.Require().Len(destCounters, 1)
+				s.Require().Equal(1, destCounters[types.CallbackTypeReceivePacket])
+				s.Require().Equal(uint8(0), destStatefulCounter)
 
-// 			case callbackSuccess:
-// 				s.Require().Len(destCounters, 1)
-// 				s.Require().Equal(1, destCounters[types.CallbackTypeReceivePacket])
-// 				s.Require().Equal(uint8(1), destStatefulCounter)
+			case callbackSuccess:
+				s.Require().Len(destCounters, 1)
+				s.Require().Equal(1, destCounters[types.CallbackTypeReceivePacket])
+				s.Require().Equal(uint8(1), destStatefulCounter)
 
-// 				expEvent, exists := GetExpectedEvent(
-// 					ctx, transferStack.(porttypes.PacketDataUnmarshaler), gasLimit, packet.Data, packet.SourcePort,
-// 					packet.DestinationPort, packet.DestinationChannel, packet.Sequence, types.CallbackTypeReceivePacket, nil,
-// 				)
-// 				s.Require().True(exists)
-// 				s.Require().Contains(ctx.EventManager().Events().ToABCIEvents(), expEvent)
-// 			}
-// 		})
-// 	}
-// }
+				expEvent, exists := GetExpectedEvent(
+					ctx, transferStack.(porttypes.PacketDataUnmarshaler), gasLimit, packet.Data, packet.SourcePort,
+					packet.DestinationPort, packet.DestinationChannel, packet.Sequence, types.CallbackTypeReceivePacket, nil,
+				)
+				s.Require().True(exists)
+				s.Require().Contains(ctx.EventManager().Events().ToABCIEvents(), expEvent)
+			}
+		})
+	}
+}
 
 func (s *CallbacksTestSuite) TestWriteAcknowledgement() {
 	var (

--- a/modules/apps/callbacks/replay_test.go
+++ b/modules/apps/callbacks/replay_test.go
@@ -264,7 +264,7 @@ func (s *CallbacksTestSuite) TestTransferRecvPacketReplayProtection() {
 			GetSimApp(s.chainB).MockContractKeeper.IBCReceivePacketCallbackFn = func(
 				cachedCtx sdk.Context,
 				packet ibcexported.PacketI,
-				_ ibcexported.Acknowledgement,
+				_ []byte,
 				_, _ string,
 			) error {
 				callbackCount++

--- a/modules/apps/callbacks/testing/simapp/contract_keeper.go
+++ b/modules/apps/callbacks/testing/simapp/contract_keeper.go
@@ -81,7 +81,7 @@ type ContractKeeper struct {
 	IBCReceivePacketCallbackFn func(
 		cachedCtx sdk.Context,
 		packet ibcexported.PacketI,
-		ack ibcexported.Acknowledgement,
+		acknowledgement []byte,
 		contractAddress string,
 		version string,
 	) error
@@ -129,7 +129,7 @@ func NewContractKeeper(key storetypes.StoreKey) *ContractKeeper {
 		return k.ProcessMockCallback(ctx, callbacktypes.CallbackTypeTimeoutPacket, contractAddress)
 	}
 
-	k.IBCReceivePacketCallbackFn = func(ctx sdk.Context, _ ibcexported.PacketI, _ ibcexported.Acknowledgement, contractAddress, _ string) error {
+	k.IBCReceivePacketCallbackFn = func(ctx sdk.Context, _ ibcexported.PacketI, _ []byte, contractAddress, _ string) error {
 		return k.ProcessMockCallback(ctx, callbacktypes.CallbackTypeReceivePacket, contractAddress)
 	}
 
@@ -204,11 +204,11 @@ func (k ContractKeeper) IBCOnTimeoutPacketCallback(
 func (k ContractKeeper) IBCReceivePacketCallback(
 	ctx sdk.Context,
 	packet ibcexported.PacketI,
-	ack ibcexported.Acknowledgement,
+	acknowledgement []byte,
 	contractAddress,
 	version string,
 ) error {
-	return k.IBCReceivePacketCallbackFn(ctx, packet, ack, contractAddress, version)
+	return k.IBCReceivePacketCallbackFn(ctx, packet, acknowledgement, contractAddress, version)
 }
 
 // ProcessMockCallback processes a mock callback.

--- a/modules/apps/callbacks/types/expected_keepers.go
+++ b/modules/apps/callbacks/types/expected_keepers.go
@@ -92,7 +92,7 @@ type ContractKeeper interface {
 	IBCReceivePacketCallback(
 		cachedCtx sdk.Context,
 		packet ibcexported.PacketI,
-		ack ibcexported.Acknowledgement,
+		acknowledgement []byte,
 		contractAddress string,
 		version string,
 	) error

--- a/modules/apps/transfer/ibc_module.go
+++ b/modules/apps/transfer/ibc_module.go
@@ -217,7 +217,7 @@ func (im IBCModule) OnRecvPacket(
 		ack = channeltypes.NewErrorAcknowledgement(ackErr)
 		im.keeper.Logger(ctx).Error(fmt.Sprintf("%s sequence %d", ackErr.Error(), packet.Sequence))
 		return ibcexported.RecvPacketResult{
-			Status:          ibcexported.FAILURE,
+			Status:          ibcexported.Failure,
 			Acknowledgement: ack.Acknowledgement(),
 		}
 	}
@@ -226,7 +226,7 @@ func (im IBCModule) OnRecvPacket(
 		ack = channeltypes.NewErrorAcknowledgement(ackErr)
 		im.keeper.Logger(ctx).Error(fmt.Sprintf("%s sequence %d", ackErr.Error(), packet.Sequence))
 		return ibcexported.RecvPacketResult{
-			Status:          ibcexported.FAILURE,
+			Status:          ibcexported.Failure,
 			Acknowledgement: ack.Acknowledgement(),
 		}
 	}
@@ -236,13 +236,13 @@ func (im IBCModule) OnRecvPacket(
 	if data.HasForwarding() {
 		// NOTE: acknowledgement will be written asynchronously
 		return ibcexported.RecvPacketResult{
-			Status: ibcexported.ASYNC,
+			Status: ibcexported.Async,
 		}
 	}
 
 	// NOTE: acknowledgement will be written synchronously during IBC handler execution.
 	return ibcexported.RecvPacketResult{
-		Status:          ibcexported.SUCCESS,
+		Status:          ibcexported.Success,
 		Acknowledgement: ack.Acknowledgement(),
 	}
 }

--- a/modules/apps/transfer/ibc_module_test.go
+++ b/modules/apps/transfer/ibc_module_test.go
@@ -17,7 +17,6 @@ import (
 	channeltypes "github.com/cosmos/ibc-go/v9/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/v9/modules/core/05-port/types"
 	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
-	"github.com/cosmos/ibc-go/v9/modules/core/exported"
 	ibctesting "github.com/cosmos/ibc-go/v9/testing"
 )
 
@@ -260,14 +259,18 @@ func (suite *TransferTestSuite) TestOnRecvPacket() {
 		expectedAttributes []sdk.Attribute
 		path               *ibctesting.Path
 	)
+
 	testCases := []struct {
 		name             string
 		malleate         func()
-		expAck           exported.Acknowledgement
+		expAck           []byte
 		expEventErrorMsg string
 	}{
 		{
-			"success", func() {}, channeltypes.NewResultAcknowledgement([]byte{byte(1)}), "",
+			"success",
+			func() {},
+			channeltypes.NewResultAcknowledgement([]byte{byte(1)}).Acknowledgement(),
+			"",
 		},
 		{
 			"success: async aknowledgment with forwarding path",
@@ -313,7 +316,7 @@ func (suite *TransferTestSuite) TestOnRecvPacket() {
 					sdk.NewAttribute(types.AttributeKeyAckError, "cannot unmarshal ICS20-V2 transfer packet data: errUnknownField \"*types.FungibleTokenPacketDataV2\": {TagNum: 13, WireType:\"fixed64\"}: invalid type"),
 				}
 			},
-			channeltypes.NewErrorAcknowledgement(ibcerrors.ErrInvalidType),
+			channeltypes.NewErrorAcknowledgement(ibcerrors.ErrInvalidType).Acknowledgement(),
 			"cannot unmarshal ICS20-V2 transfer packet data: unexpected EOF: invalid type",
 		},
 		{
@@ -321,7 +324,7 @@ func (suite *TransferTestSuite) TestOnRecvPacket() {
 			func() {
 				suite.chainB.GetSimApp().TransferKeeper.SetParams(suite.chainB.GetContext(), types.Params{ReceiveEnabled: false})
 			},
-			channeltypes.NewErrorAcknowledgement(types.ErrReceiveDisabled),
+			channeltypes.NewErrorAcknowledgement(types.ErrReceiveDisabled).Acknowledgement(),
 			"fungible token transfers to this chain are disabled",
 		},
 	}
@@ -358,13 +361,14 @@ func (suite *TransferTestSuite) TestOnRecvPacket() {
 				sdk.NewAttribute(types.AttributeKeyMemo, packetData.Memo),
 				sdk.NewAttribute(types.AttributeKeyForwardingHops, string(forwardingHopsBz)),
 			}
-			if tc.expAck == nil || tc.expAck.Success() {
-				expectedAttributes = append(expectedAttributes, sdk.NewAttribute(types.AttributeKeyAckSuccess, "true"))
-			} else {
+
+			if tc.expEventErrorMsg != "" {
 				expectedAttributes = append(expectedAttributes,
 					sdk.NewAttribute(types.AttributeKeyAckSuccess, "false"),
 					sdk.NewAttribute(types.AttributeKeyAckError, tc.expEventErrorMsg),
 				)
+			} else {
+				expectedAttributes = append(expectedAttributes, sdk.NewAttribute(types.AttributeKeyAckSuccess, "true"))
 			}
 
 			seq := uint64(1)
@@ -379,9 +383,9 @@ func (suite *TransferTestSuite) TestOnRecvPacket() {
 
 			tc.malleate() // change fields in packet
 
-			ack := cbs.OnRecvPacket(ctx, path.EndpointB.GetChannel().Version, packet, suite.chainB.SenderAccount.GetAddress())
+			res := cbs.OnRecvPacket(ctx, path.EndpointB.GetChannel().Version, packet, suite.chainB.SenderAccount.GetAddress())
 
-			suite.Require().Equal(tc.expAck, ack)
+			suite.Require().Equal(tc.expAck, res.Acknowledgement)
 
 			expectedEvents := sdk.Events{
 				sdk.NewEvent(

--- a/modules/apps/transfer/keeper/forwarding.go
+++ b/modules/apps/transfer/keeper/forwarding.go
@@ -45,7 +45,7 @@ func (k Keeper) forwardPacket(ctx sdk.Context, data types.FungibleTokenPacketDat
 
 // acknowledgeForwardedPacket writes the async acknowledgement for forwardedPacket
 func (k Keeper) acknowledgeForwardedPacket(ctx sdk.Context, forwardedPacket, packet channeltypes.Packet, ack channeltypes.Acknowledgement) error {
-	if err := k.ics4Wrapper.WriteAcknowledgement(ctx, forwardedPacket, ack); err != nil {
+	if err := k.ics4Wrapper.WriteAcknowledgement(ctx, forwardedPacket, ack.Acknowledgement()); err != nil {
 		return err
 	}
 

--- a/modules/core/03-connection/keeper/verify_test.go
+++ b/modules/core/03-connection/keeper/verify_test.go
@@ -235,7 +235,7 @@ func (suite *KeeperTestSuite) TestVerifyPacketCommitment() {
 func (suite *KeeperTestSuite) TestVerifyPacketAcknowledgement() {
 	var (
 		path            *ibctesting.Path
-		ack             exported.Acknowledgement
+		ack             []byte
 		heightDiff      uint64
 		delayTimePeriod uint64
 		timePerBlock    uint64
@@ -266,7 +266,7 @@ func (suite *KeeperTestSuite) TestVerifyPacketAcknowledgement() {
 			heightDiff = 5
 		}, false},
 		{"verification failed - changed acknowledgement", func() {
-			ack = ibcmock.MockFailAcknowledgement
+			ack = ibcmock.MockFailAcknowledgement.Acknowledgement()
 		}, false},
 		{"client status is not active - client is expired", func() {
 			clientState, ok := path.EndpointA.GetClientState().(*ibctm.ClientState)
@@ -280,8 +280,8 @@ func (suite *KeeperTestSuite) TestVerifyPacketAcknowledgement() {
 		tc := tc
 
 		suite.Run(tc.name, func() {
-			suite.SetupTest()                 // reset
-			ack = ibcmock.MockAcknowledgement // must be explicitly changed
+			suite.SetupTest()                                   // reset
+			ack = ibcmock.MockAcknowledgement.Acknowledgement() // must be explicitly changed
 
 			path = ibctesting.NewPath(suite.chainA, suite.chainB)
 			path.Setup()
@@ -317,7 +317,7 @@ func (suite *KeeperTestSuite) TestVerifyPacketAcknowledgement() {
 
 			err = suite.chainA.App.GetIBCKeeper().ConnectionKeeper.VerifyPacketAcknowledgement(
 				suite.chainA.GetContext(), connection, malleateHeight(proofHeight, heightDiff), proof,
-				packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence(), ack.Acknowledgement(),
+				packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence(), ack,
 			)
 
 			if tc.expPass {

--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -276,7 +276,7 @@ func (k *Keeper) applyReplayProtection(ctx sdk.Context, packet types.Packet, cha
 func (k *Keeper) WriteAcknowledgement(
 	ctx sdk.Context,
 	packet exported.PacketI,
-	acknowledgement exported.Acknowledgement,
+	acknowledgement []byte,
 ) error {
 	channel, found := k.GetChannel(ctx, packet.GetDestPort(), packet.GetDestChannel())
 	if !found {
@@ -304,19 +304,14 @@ func (k *Keeper) WriteAcknowledgement(
 		return types.ErrAcknowledgementExists
 	}
 
-	if acknowledgement == nil {
-		return errorsmod.Wrap(types.ErrInvalidAcknowledgement, "acknowledgement cannot be nil")
-	}
-
-	bz := acknowledgement.Acknowledgement()
-	if len(bz) == 0 {
+	if len(acknowledgement) == 0 {
 		return errorsmod.Wrap(types.ErrInvalidAcknowledgement, "acknowledgement cannot be empty")
 	}
 
 	// set the acknowledgement so that it can be verified on the other side
 	k.SetPacketAcknowledgement(
 		ctx, packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence(),
-		types.CommitAcknowledgement(bz),
+		types.CommitAcknowledgement(acknowledgement),
 	)
 
 	// log that a packet acknowledgement has been written
@@ -329,7 +324,7 @@ func (k *Keeper) WriteAcknowledgement(
 		"dst_channel", packet.GetDestChannel(),
 	)
 
-	emitWriteAcknowledgementEvent(ctx, packet.(types.Packet), channel, bz)
+	emitWriteAcknowledgementEvent(ctx, packet.(types.Packet), channel, acknowledgement)
 
 	return nil
 }

--- a/modules/core/05-port/types/ibc_legacy_module.go
+++ b/modules/core/05-port/types/ibc_legacy_module.go
@@ -201,8 +201,8 @@ func (LegacyIBCModule) OnRecvPacket(
 	channelVersion string,
 	packet channeltypes.Packet,
 	relayer sdk.AccAddress,
-) ibcexported.Acknowledgement {
-	return nil
+) ibcexported.RecvPacketResult {
+	return ibcexported.RecvPacketResult{}
 }
 
 // OnAcknowledgementPacket implements the IBCModule interface

--- a/modules/core/05-port/types/module.go
+++ b/modules/core/05-port/types/module.go
@@ -103,7 +103,7 @@ type IBCModule interface {
 		channelVersion string,
 		packet channeltypes.Packet,
 		relayer sdk.AccAddress,
-	) exported.Acknowledgement
+	) exported.RecvPacketResult
 
 	OnAcknowledgementPacket(
 		ctx sdk.Context,
@@ -196,7 +196,7 @@ type ICS4Wrapper interface {
 	WriteAcknowledgement(
 		ctx sdk.Context,
 		packet exported.PacketI,
-		ack exported.Acknowledgement,
+		ack []byte,
 	) error
 
 	GetAppVersion(

--- a/modules/core/ante/ante_test.go
+++ b/modules/core/ante/ante_test.go
@@ -351,7 +351,7 @@ func (suite *AnteTestSuite) TestAnteDecoratorCheckTx() {
 			func(suite *AnteTestSuite) []sdk.Msg {
 				suite.chainB.GetSimApp().IBCMockModule.IBCApp.OnRecvPacket = func(
 					ctx sdk.Context, channelVersion string, packet channeltypes.Packet, relayer sdk.AccAddress,
-				) exported.Acknowledgement {
+				) exported.RecvPacketResult {
 					panic(fmt.Errorf("failed OnRecvPacket mock callback"))
 				}
 
@@ -578,7 +578,7 @@ func (suite *AnteTestSuite) TestAnteDecoratorReCheckTx() {
 			func(suite *AnteTestSuite) []sdk.Msg {
 				suite.chainB.GetSimApp().IBCMockModule.IBCApp.OnRecvPacket = func(
 					ctx sdk.Context, channelVersion string, packet channeltypes.Packet, relayer sdk.AccAddress,
-				) exported.Acknowledgement {
+				) exported.RecvPacketResult {
 					panic(fmt.Errorf("failed OnRecvPacket mock callback"))
 				}
 

--- a/modules/core/exported/packet.go
+++ b/modules/core/exported/packet.go
@@ -13,12 +13,17 @@ type PacketI interface {
 	ValidateBasic() error
 }
 
-// RecvPacketStatus defines an enum type to signal the result status of a received packet.
+// RecvPacketStatus defines an enum type to signal the result status of an IBC application packet datagram and inform
+// core IBC of how to handle the application state changes held in the cache store which it was provided for OnRecvPacket callback execution.
 type RecvPacketStatus uint32
 
 const (
+	// Success instructs that the IBC application state should be persisted.
 	Success RecvPacketStatus = iota
+	// Failure instructs that the IBC application state should be discarded.
 	Failure
+	// Async instructs that the IBC application state should be persisted
+	// and acknowledgement data will be written later asynchronously.
 	Async
 )
 
@@ -28,7 +33,13 @@ func (r RecvPacketStatus) String() string {
 }
 
 // RecvPacketResult defines a result type used to encapsulate opaque application acknowledgement data, as well as
-// a status to indicate success, failure or asynchronous handling of a packet acknowledgement.
+// a status to indicate success, failure or asynchronous handling of a packet acknowledgement in the OnRecvPacket callback.
+// Status is used by core IBC to ensure partial state changes are not committed
+// when packet receives have not properly succeeded (typically resulting in an error acknowledgement being returned).
+// During OnRecvPacket callback execution, all state changes are held in a cache store and committed if
+// the result status is indicated as Async or Success.
+//
+// Note: IBC application callback events are always persisted so long as `RecvPacket` succeeds without error.
 type RecvPacketResult struct {
 	Status          RecvPacketStatus
 	Acknowledgement []byte

--- a/modules/core/exported/packet.go
+++ b/modules/core/exported/packet.go
@@ -18,6 +18,7 @@ type PacketI interface {
 // when packet receives have not properly succeeded (typically resulting in an error acknowledgement being returned).
 // The interface also allows core IBC to obtain the acknowledgement bytes whose encoding is determined by each IBC application or middleware.
 // Each custom acknowledgement type must implement this interface.
+// TODO: remove interface
 type Acknowledgement interface {
 	// Success determines if the IBC application state should be persisted when handling `RecvPacket`.
 	// During `OnRecvPacket` IBC application callback execution, all state changes are held in a cache store and committed if:
@@ -32,6 +33,21 @@ type Acknowledgement interface {
 	Success() bool
 	Acknowledgement() []byte
 }
+
+// RecvPacketResult ...
+type RecvPacketResult struct {
+	Status          RecvPacketStatus
+	Acknowledgement []byte
+}
+
+// RecvPacketStatus ...
+type RecvPacketStatus uint32
+
+const (
+	SUCCESS RecvPacketStatus = iota
+	FAILURE
+	ASYNC
+)
 
 // PacketData defines an optional interface which an application's packet data structure may implement.
 type PacketData interface {

--- a/modules/core/exported/packet.go
+++ b/modules/core/exported/packet.go
@@ -13,27 +13,6 @@ type PacketI interface {
 	ValidateBasic() error
 }
 
-// Acknowledgement defines the interface used to return acknowledgements in the OnRecvPacket callback.
-// The Acknowledgement interface is used by core IBC to ensure partial state changes are not committed
-// when packet receives have not properly succeeded (typically resulting in an error acknowledgement being returned).
-// The interface also allows core IBC to obtain the acknowledgement bytes whose encoding is determined by each IBC application or middleware.
-// Each custom acknowledgement type must implement this interface.
-// TODO: remove interface
-type Acknowledgement interface {
-	// Success determines if the IBC application state should be persisted when handling `RecvPacket`.
-	// During `OnRecvPacket` IBC application callback execution, all state changes are held in a cache store and committed if:
-	// - the acknowledgement.Success() returns true
-	// - a nil acknowledgement is returned (asynchronous acknowledgements)
-	//
-	// Note 1: IBC application callback events are always persisted so long as `RecvPacket` succeeds without error.
-	//
-	// Note 2: The return value should account for the success of the underlying IBC application or middleware. Thus the  `acknowledgement.Success` is representative of the entire IBC stack's success when receiving a packet. The individual success of each acknowledgement associated with an IBC application or middleware must be determined by obtaining the actual acknowledgement type after decoding the acknowledgement bytes.
-	//
-	// See https://github.com/cosmos/ibc-go/blob/v7.0.0/docs/ibc/apps.md for further explanations.
-	Success() bool
-	Acknowledgement() []byte
-}
-
 // RecvPacketResult ...
 type RecvPacketResult struct {
 	Status          RecvPacketStatus

--- a/modules/core/exported/packet.go
+++ b/modules/core/exported/packet.go
@@ -13,20 +13,26 @@ type PacketI interface {
 	ValidateBasic() error
 }
 
-// RecvPacketResult ...
+// RecvPacketStatus defines an enum type to signal the result status of a received packet.
+type RecvPacketStatus uint32
+
+const (
+	Success RecvPacketStatus = iota
+	Failure
+	Async
+)
+
+// String implements the fmt.Stringer interface.
+func (r RecvPacketStatus) String() string {
+	return [...]string{"Success", "Failure", "Async"}[r]
+}
+
+// RecvPacketResult defines a result type used to encapsulate opaque application acknowledgement data, as well as
+// a status to indicate success, failure or asynchronous handling of a packet acknowledgement.
 type RecvPacketResult struct {
 	Status          RecvPacketStatus
 	Acknowledgement []byte
 }
-
-// RecvPacketStatus ...
-type RecvPacketStatus uint32
-
-const (
-	SUCCESS RecvPacketStatus = iota
-	FAILURE
-	ASYNC
-)
 
 // PacketData defines an optional interface which an application's packet data structure may implement.
 type PacketData interface {

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -467,7 +467,7 @@ func (k *Keeper) RecvPacket(goCtx context.Context, msg *channeltypes.MsgRecvPack
 	// Cache context so that we may discard state changes from callback if the acknowledgement is unsuccessful.
 	cacheCtx, writeFn = ctx.CacheContext()
 	res := cbs.OnRecvPacket(cacheCtx, channelVersion, msg.Packet, relayer)
-	if res.Status == exported.SUCCESS || res.Status == exported.ASYNC {
+	if res.Status == exported.Success || res.Status == exported.Async {
 		// write application state changes for asynchronous and successful acknowledgements
 		writeFn()
 	} else {

--- a/testing/endpoint.go
+++ b/testing/endpoint.go
@@ -492,9 +492,9 @@ func (endpoint *Endpoint) RecvPacketWithResult(packet channeltypes.Packet) (*abc
 
 // WriteAcknowledgement writes an acknowledgement on the channel associated with the endpoint.
 // The counterparty client is updated.
-func (endpoint *Endpoint) WriteAcknowledgement(ack exported.Acknowledgement, packet exported.PacketI) error {
+func (endpoint *Endpoint) WriteAcknowledgement(acknowledgement []byte, packet exported.PacketI) error {
 	// no need to send message, acting as a handler
-	err := endpoint.Chain.App.GetIBCKeeper().ChannelKeeper.WriteAcknowledgement(endpoint.Chain.GetContext(), packet, ack.Acknowledgement())
+	err := endpoint.Chain.App.GetIBCKeeper().ChannelKeeper.WriteAcknowledgement(endpoint.Chain.GetContext(), packet, acknowledgement)
 	if err != nil {
 		return err
 	}

--- a/testing/endpoint.go
+++ b/testing/endpoint.go
@@ -494,7 +494,7 @@ func (endpoint *Endpoint) RecvPacketWithResult(packet channeltypes.Packet) (*abc
 // The counterparty client is updated.
 func (endpoint *Endpoint) WriteAcknowledgement(ack exported.Acknowledgement, packet exported.PacketI) error {
 	// no need to send message, acting as a handler
-	err := endpoint.Chain.App.GetIBCKeeper().ChannelKeeper.WriteAcknowledgement(endpoint.Chain.GetContext(), packet, ack)
+	err := endpoint.Chain.App.GetIBCKeeper().ChannelKeeper.WriteAcknowledgement(endpoint.Chain.GetContext(), packet, ack.Acknowledgement())
 	if err != nil {
 		return err
 	}

--- a/testing/mock/ibc_app.go
+++ b/testing/mock/ibc_app.go
@@ -78,7 +78,7 @@ type IBCApp struct {
 		channelVersion string,
 		packet channeltypes.Packet,
 		relayer sdk.AccAddress,
-	) exported.Acknowledgement
+	) exported.RecvPacketResult
 
 	OnAcknowledgementPacket func(
 		ctx sdk.Context,

--- a/testing/mock/ibc_module.go
+++ b/testing/mock/ibc_module.go
@@ -117,7 +117,7 @@ func (im IBCModule) OnSendPacket(ctx sdk.Context, portID string, channelID strin
 }
 
 // OnRecvPacket implements the IBCModule interface.
-func (im IBCModule) OnRecvPacket(ctx sdk.Context, channelVersion string, packet channeltypes.Packet, relayer sdk.AccAddress) exported.Acknowledgement {
+func (im IBCModule) OnRecvPacket(ctx sdk.Context, channelVersion string, packet channeltypes.Packet, relayer sdk.AccAddress) exported.RecvPacketResult {
 	if im.IBCApp.OnRecvPacket != nil {
 		return im.IBCApp.OnRecvPacket(ctx, channelVersion, packet, relayer)
 	}
@@ -133,12 +133,20 @@ func (im IBCModule) OnRecvPacket(ctx sdk.Context, channelVersion string, packet 
 	ctx.EventManager().EmitEvent(NewMockRecvPacketEvent())
 
 	if bytes.Equal(MockPacketData, packet.GetData()) {
-		return MockAcknowledgement
+		return exported.RecvPacketResult{
+			Status:          exported.SUCCESS,
+			Acknowledgement: MockAcknowledgement.Acknowledgement(),
+		}
 	} else if bytes.Equal(MockAsyncPacketData, packet.GetData()) {
-		return nil
+		return exported.RecvPacketResult{
+			Status: exported.ASYNC,
+		}
 	}
 
-	return MockFailAcknowledgement
+	return exported.RecvPacketResult{
+		Status:          exported.FAILURE,
+		Acknowledgement: MockFailAcknowledgement.Acknowledgement(),
+	}
 }
 
 // OnAcknowledgementPacket implements the IBCModule interface.

--- a/testing/mock/ibc_module.go
+++ b/testing/mock/ibc_module.go
@@ -134,17 +134,17 @@ func (im IBCModule) OnRecvPacket(ctx sdk.Context, channelVersion string, packet 
 
 	if bytes.Equal(MockPacketData, packet.GetData()) {
 		return exported.RecvPacketResult{
-			Status:          exported.SUCCESS,
+			Status:          exported.Success,
 			Acknowledgement: MockAcknowledgement.Acknowledgement(),
 		}
 	} else if bytes.Equal(MockAsyncPacketData, packet.GetData()) {
 		return exported.RecvPacketResult{
-			Status: exported.ASYNC,
+			Status: exported.Async,
 		}
 	}
 
 	return exported.RecvPacketResult{
-		Status:          exported.FAILURE,
+		Status:          exported.Failure,
 		Acknowledgement: MockFailAcknowledgement.Acknowledgement(),
 	}
 }

--- a/testing/mock/middleware.go
+++ b/testing/mock/middleware.go
@@ -122,17 +122,17 @@ func (im BlockUpgradeMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion st
 
 	if bytes.Equal(MockPacketData, packet.GetData()) {
 		return exported.RecvPacketResult{
-			Status:          exported.SUCCESS,
+			Status:          exported.Success,
 			Acknowledgement: MockAcknowledgement.Acknowledgement(),
 		}
 	} else if bytes.Equal(MockAsyncPacketData, packet.GetData()) {
 		return exported.RecvPacketResult{
-			Status: exported.ASYNC,
+			Status: exported.Async,
 		}
 	}
 
 	return exported.RecvPacketResult{
-		Status:          exported.FAILURE,
+		Status:          exported.Failure,
 		Acknowledgement: MockFailAcknowledgement.Acknowledgement(),
 	}
 }

--- a/testing/mock/middleware.go
+++ b/testing/mock/middleware.go
@@ -107,7 +107,7 @@ func (im BlockUpgradeMiddleware) OnSendPacket(ctx sdk.Context, portID string, ch
 }
 
 // OnRecvPacket implements the IBCModule interface.
-func (im BlockUpgradeMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion string, packet channeltypes.Packet, relayer sdk.AccAddress) exported.Acknowledgement {
+func (im BlockUpgradeMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion string, packet channeltypes.Packet, relayer sdk.AccAddress) exported.RecvPacketResult {
 	if im.IBCApp.OnRecvPacket != nil {
 		return im.IBCApp.OnRecvPacket(ctx, channelVersion, packet, relayer)
 	}
@@ -121,12 +121,20 @@ func (im BlockUpgradeMiddleware) OnRecvPacket(ctx sdk.Context, channelVersion st
 	}
 
 	if bytes.Equal(MockPacketData, packet.GetData()) {
-		return MockAcknowledgement
+		return exported.RecvPacketResult{
+			Status:          exported.SUCCESS,
+			Acknowledgement: MockAcknowledgement.Acknowledgement(),
+		}
 	} else if bytes.Equal(MockAsyncPacketData, packet.GetData()) {
-		return nil
+		return exported.RecvPacketResult{
+			Status: exported.ASYNC,
+		}
 	}
 
-	return MockFailAcknowledgement
+	return exported.RecvPacketResult{
+		Status:          exported.FAILURE,
+		Acknowledgement: MockFailAcknowledgement.Acknowledgement(),
+	}
 }
 
 // OnAcknowledgementPacket implements the IBCModule interface.
@@ -165,7 +173,7 @@ func (im BlockUpgradeMiddleware) OnTimeoutPacket(ctx sdk.Context, channelVersion
 func (BlockUpgradeMiddleware) WriteAcknowledgement(
 	ctx sdk.Context,
 	packet exported.PacketI,
-	ack exported.Acknowledgement,
+	ack []byte,
 ) error {
 	return nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Removes the `exported.Acknowledgement` interface and introduces a new concrete `RecvPacketResult` type.

closes: #7042 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
