### PR TITLE
imp: reduce channel lookup in timeout flow

### DIFF
--- a/modules/core/04-channel/keeper/export_test.go
+++ b/modules/core/04-channel/keeper/export_test.go
@@ -37,6 +37,6 @@ func (k *Keeper) SetRecvStartSequence(ctx sdk.Context, portID, channelID string,
 }
 
 // TimeoutExecuted is a wrapper around timeoutExecuted to allow the function to be directly called in tests.
-func (k *Keeper) TimeoutExecuted(ctx sdk.Context, capability *capabilitytypes.Capability, packet types.Packet) error {
-	return k.timeoutExecuted(ctx, capability, packet)
+func (k *Keeper) TimeoutExecuted(ctx sdk.Context, channel types.Channel, capability *capabilitytypes.Capability, packet types.Packet) error {
+	return k.timeoutExecuted(ctx, channel, capability, packet)
 }

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -120,7 +120,7 @@ func (k *Keeper) TimeoutPacket(
 		return "", err
 	}
 
-	if err = k.timeoutExecuted(ctx, chanCap, packet); err != nil {
+	if err = k.timeoutExecuted(ctx, channel, chanCap, packet); err != nil {
 		return "", err
 	}
 
@@ -136,14 +136,10 @@ func (k *Keeper) TimeoutPacket(
 // CONTRACT: this function must be called in the IBC handler
 func (k *Keeper) timeoutExecuted(
 	ctx sdk.Context,
+	channel types.Channel,
 	chanCap *capabilitytypes.Capability,
 	packet types.Packet,
 ) error {
-	channel, found := k.GetChannel(ctx, packet.GetSourcePort(), packet.GetSourceChannel())
-	if !found {
-		return errorsmod.Wrapf(types.ErrChannelNotFound, "port ID (%s) channel ID (%s)", packet.GetSourcePort(), packet.GetSourceChannel())
-	}
-
 	capName := host.ChannelCapabilityPath(packet.GetSourcePort(), packet.GetSourceChannel())
 	if !k.scopedKeeper.AuthenticateCapability(ctx, chanCap, capName) {
 		return errorsmod.Wrapf(
@@ -302,7 +298,7 @@ func (k *Keeper) TimeoutOnClose(
 		return "", err
 	}
 
-	if err = k.timeoutExecuted(ctx, chanCap, packet); err != nil {
+	if err = k.timeoutExecuted(ctx, channel, chanCap, packet); err != nil {
 		return "", err
 	}
 

--- a/modules/core/04-channel/keeper/timeout_test.go
+++ b/modules/core/04-channel/keeper/timeout_test.go
@@ -284,22 +284,6 @@ func (suite *KeeperTestSuite) TestTimeoutExecuted() {
 			nil,
 		},
 		{
-			"channel not found",
-			func() {
-				// use wrong channel naming
-				path.Setup()
-				packet = types.NewPacket(ibctesting.MockPacketData, 1, ibctesting.InvalidID, ibctesting.InvalidID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, defaultTimeoutHeight, disabledTimeoutTimestamp)
-			},
-			func(packetCommitment []byte, err error) {
-				suite.Require().Error(err)
-				suite.Require().ErrorIs(err, types.ErrChannelNotFound)
-
-				// packet never sent.
-				suite.Require().Nil(packetCommitment)
-			},
-			nil,
-		},
-		{
 			"incorrect capability ORDERED",
 			func() {
 				path.SetChannelOrdered()
@@ -528,7 +512,7 @@ func (suite *KeeperTestSuite) TestTimeoutExecuted() {
 
 			tc.malleate()
 
-			err := suite.chainA.App.GetIBCKeeper().ChannelKeeper.TimeoutExecuted(ctx, chanCap, packet)
+			err := suite.chainA.App.GetIBCKeeper().ChannelKeeper.TimeoutExecuted(ctx, path.EndpointA.GetChannel(), chanCap, packet)
 			pc := suite.chainA.App.GetIBCKeeper().ChannelKeeper.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 			tc.expResult(pc, err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #7105

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
