### PR TITLE
(chore) change tests in 27ica/controller to expect specific error

### DIFF
--- a/modules/apps/27-interchain-accounts/controller/keeper/grpc_query_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/grpc_query_test.go
@@ -12,33 +12,33 @@ func (suite *KeeperTestSuite) TestQueryInterchainAccount() {
 	testCases := []struct {
 		name     string
 		malleate func()
-		expPass  bool
+		errMsg   string
 	}{
 		{
 			"success",
 			func() {},
-			true,
+			"",
 		},
 		{
 			"empty request",
 			func() {
 				req = nil
 			},
-			false,
+			"empty request",
 		},
 		{
 			"empty owner address",
 			func() {
 				req.Owner = ""
 			},
-			false,
+			"failed to generate portID from owner address: owner address cannot be empty: invalid account address",
 		},
 		{
 			"invalid connection, account address not found",
 			func() {
 				req.ConnectionId = "invalid-connection-id"
 			},
-			false,
+			"failed to retrieve account address",
 		},
 	}
 
@@ -64,14 +64,14 @@ func (suite *KeeperTestSuite) TestQueryInterchainAccount() {
 
 				res, err := suite.chainA.GetSimApp().ICAControllerKeeper.InterchainAccount(suite.chainA.GetContext(), req)
 
-				if tc.expPass {
+				if tc.errMsg == "" {
 					expAddress, exists := suite.chainB.GetSimApp().ICAHostKeeper.GetInterchainAccountAddress(suite.chainB.GetContext(), path.EndpointB.ConnectionID, path.EndpointA.ChannelConfig.PortID)
 					suite.Require().True(exists)
 
 					suite.Require().NoError(err)
 					suite.Require().Equal(expAddress, res.Address)
 				} else {
-					suite.Require().Error(err)
+					suite.Require().ErrorContains(err, tc.errMsg)
 				}
 			})
 		}

--- a/modules/apps/27-interchain-accounts/controller/keeper/handshake_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/handshake_test.go
@@ -325,31 +325,31 @@ func (suite *KeeperTestSuite) TestOnChanOpenAck() {
 	testCases := []struct {
 		name     string
 		malleate func()
-		expPass  bool
+		expErr   error
 	}{
 		{
-			"success", func() {}, true,
+			"success", func() {}, nil,
 		},
 		{
 			"invalid port ID - host chain",
 			func() {
 				path.EndpointA.ChannelConfig.PortID = icatypes.HostPortID
 			},
-			false,
+			icatypes.ErrInvalidControllerPort,
 		},
 		{
 			"invalid port ID - unexpected prefix",
 			func() {
 				path.EndpointA.ChannelConfig.PortID = "invalid-port-id"
 			},
-			false,
+			icatypes.ErrInvalidControllerPort,
 		},
 		{
 			"invalid metadata bytestring",
 			func() {
 				path.EndpointA.Counterparty.ChannelConfig.Version = "invalid-metadata-bytestring"
 			},
-			false,
+			ibcerrors.ErrInvalidType,
 		},
 		{
 			"unsupported encoding format",
@@ -361,7 +361,7 @@ func (suite *KeeperTestSuite) TestOnChanOpenAck() {
 
 				path.EndpointA.Counterparty.ChannelConfig.Version = string(versionBytes)
 			},
-			false,
+			icatypes.ErrInvalidCodec,
 		},
 		{
 			"unsupported transaction type",
@@ -373,7 +373,7 @@ func (suite *KeeperTestSuite) TestOnChanOpenAck() {
 
 				path.EndpointA.Counterparty.ChannelConfig.Version = string(versionBytes)
 			},
-			false,
+			icatypes.ErrUnknownDataType,
 		},
 		{
 			"invalid account address",
@@ -385,7 +385,7 @@ func (suite *KeeperTestSuite) TestOnChanOpenAck() {
 
 				path.EndpointA.Counterparty.ChannelConfig.Version = string(versionBytes)
 			},
-			false,
+			icatypes.ErrInvalidAccountAddress,
 		},
 		{
 			"empty account address",
@@ -397,7 +397,7 @@ func (suite *KeeperTestSuite) TestOnChanOpenAck() {
 
 				path.EndpointA.Counterparty.ChannelConfig.Version = string(versionBytes)
 			},
-			false,
+			icatypes.ErrInvalidAccountAddress,
 		},
 		{
 			"invalid counterparty version",
@@ -409,7 +409,7 @@ func (suite *KeeperTestSuite) TestOnChanOpenAck() {
 
 				path.EndpointA.Counterparty.ChannelConfig.Version = string(versionBytes)
 			},
-			false,
+			icatypes.ErrInvalidVersion,
 		},
 		{
 			"active channel already set",
@@ -420,7 +420,7 @@ func (suite *KeeperTestSuite) TestOnChanOpenAck() {
 
 				// set the active channelID in state
 				suite.chainA.GetSimApp().ICAControllerKeeper.SetActiveChannelID(suite.chainA.GetContext(), ibctesting.FirstConnectionID, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-			}, false,
+			}, icatypes.ErrActiveChannelAlreadySet,
 		},
 	}
 
@@ -455,7 +455,7 @@ func (suite *KeeperTestSuite) TestOnChanOpenAck() {
 					path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointA.Counterparty.ChannelConfig.Version,
 				)
 
-				if tc.expPass {
+				if tc.expErr == nil {
 					suite.Require().NoError(err)
 
 					activeChannelID, found := suite.chainA.GetSimApp().ICAControllerKeeper.GetActiveChannelID(suite.chainA.GetContext(), ibctesting.FirstConnectionID, path.EndpointA.ChannelConfig.PortID)
@@ -468,7 +468,7 @@ func (suite *KeeperTestSuite) TestOnChanOpenAck() {
 
 					suite.Require().Equal(metadata.Address, interchainAccAddress)
 				} else {
-					suite.Require().Error(err)
+					suite.Require().ErrorIs(err, tc.expErr)
 				}
 			})
 		}
@@ -481,10 +481,10 @@ func (suite *KeeperTestSuite) TestOnChanCloseConfirm() {
 	testCases := []struct {
 		name     string
 		malleate func()
-		expPass  bool
+		expErr   error
 	}{
 		{
-			"success", func() {}, true,
+			"success", func() {}, nil,
 		},
 	}
 
@@ -508,7 +508,7 @@ func (suite *KeeperTestSuite) TestOnChanCloseConfirm() {
 
 				activeChannelID, found := suite.chainB.GetSimApp().ICAControllerKeeper.GetActiveChannelID(suite.chainB.GetContext(), ibctesting.FirstConnectionID, path.EndpointB.ChannelConfig.PortID)
 
-				if tc.expPass {
+				if tc.expErr == nil {
 					suite.Require().NoError(err)
 					suite.Require().False(found)
 					suite.Require().Empty(activeChannelID)

--- a/modules/apps/27-interchain-accounts/controller/keeper/keeper_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/keeper_test.go
@@ -112,7 +112,7 @@ func (suite *KeeperTestSuite) TestNewKeeper() {
 	testCases := []struct {
 		name          string
 		instantiateFn func()
-		expPass       bool
+		errMsg        string
 	}{
 		{"success", func() {
 			keeper.NewKeeper(
@@ -126,7 +126,7 @@ func (suite *KeeperTestSuite) TestNewKeeper() {
 				suite.chainA.GetSimApp().MsgServiceRouter(),
 				suite.chainA.GetSimApp().ICAControllerKeeper.GetAuthority(),
 			)
-		}, true},
+		}, ""},
 		{"failure: empty authority", func() {
 			keeper.NewKeeper(
 				suite.chainA.GetSimApp().AppCodec(),
@@ -139,7 +139,7 @@ func (suite *KeeperTestSuite) TestNewKeeper() {
 				suite.chainA.GetSimApp().MsgServiceRouter(),
 				"", // authority
 			)
-		}, false},
+		}, "authority must be non-empty"},
 	}
 
 	for _, tc := range testCases {
@@ -147,12 +147,13 @@ func (suite *KeeperTestSuite) TestNewKeeper() {
 		suite.SetupTest()
 
 		suite.Run(tc.name, func() {
-			if tc.expPass {
+			if tc.errMsg == "" {
 				suite.Require().NotPanics(
 					tc.instantiateFn,
 				)
 			} else {
-				suite.Require().Panics(
+				suite.Require().PanicsWithError(
+					tc.errMsg,
 					tc.instantiateFn,
 				)
 			}
@@ -311,7 +312,7 @@ func (suite *KeeperTestSuite) TestSetAndGetParams() {
 	testCases := []struct {
 		name    string
 		input   types.Params
-		expPass bool
+		expPass bool // This is currently always true.
 	}{
 		// it is not possible to set invalid booleans
 		{"success: set params false", types.NewParams(false), true},

--- a/modules/apps/27-interchain-accounts/controller/keeper/msg_server_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/msg_server_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/cosmos/ibc-go/v9/modules/apps/27-interchain-accounts/controller/keeper"
 	"github.com/cosmos/ibc-go/v9/modules/apps/27-interchain-accounts/controller/types"
 	icatypes "github.com/cosmos/ibc-go/v9/modules/apps/27-interchain-accounts/types"
+	connectiontypes "github.com/cosmos/ibc-go/v9/modules/core/03-connection/types"
 	channeltypes "github.com/cosmos/ibc-go/v9/modules/core/04-channel/types"
 	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
+	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
 	ibctesting "github.com/cosmos/ibc-go/v9/testing"
 )
 
@@ -25,17 +27,17 @@ func (suite *KeeperTestSuite) TestRegisterInterchainAccount_MsgServer() {
 
 	testCases := []struct {
 		name     string
-		expPass  bool
+		expErr   error
 		malleate func()
 	}{
 		{
 			"success",
-			true,
+			nil,
 			func() {},
 		},
 		{
 			"success: ordering falls back to UNORDERED if not specified",
-			true,
+			nil,
 			func() {
 				msg.Ordering = channeltypes.NONE
 				expectedOrderding = channeltypes.UNORDERED
@@ -43,28 +45,28 @@ func (suite *KeeperTestSuite) TestRegisterInterchainAccount_MsgServer() {
 		},
 		{
 			"invalid connection id",
-			false,
+			connectiontypes.ErrConnectionNotFound,
 			func() {
 				msg.ConnectionId = "connection-100"
 			},
 		},
 		{
 			"non-empty owner address is valid",
-			true,
+			nil,
 			func() {
 				msg.Owner = "<invalid-owner>"
 			},
 		},
 		{
 			"empty address invalid",
-			false,
+			icatypes.ErrInvalidAccountAddress,
 			func() {
 				msg.Owner = ""
 			},
 		},
 		{
 			"port is already bound for owner but capability is claimed by another module",
-			false,
+			icatypes.ErrPortAlreadyBound,
 			func() {
 				capability := suite.chainA.GetSimApp().IBCKeeper.PortKeeper.BindPort(suite.chainA.GetContext(), TestPortID)
 				err := suite.chainA.GetSimApp().TransferKeeper.ClaimCapability(suite.chainA.GetContext(), capability, host.PortPath(TestPortID))
@@ -93,7 +95,7 @@ func (suite *KeeperTestSuite) TestRegisterInterchainAccount_MsgServer() {
 				msgServer := keeper.NewMsgServerImpl(&suite.chainA.GetSimApp().ICAControllerKeeper)
 				res, err := msgServer.RegisterInterchainAccount(ctx, msg)
 
-				if tc.expPass {
+				if tc.expErr == nil {
 					suite.Require().NoError(err)
 					suite.Require().NotNil(res)
 					suite.Require().Equal(expectedChannelID, res.ChannelId)
@@ -108,7 +110,7 @@ func (suite *KeeperTestSuite) TestRegisterInterchainAccount_MsgServer() {
 					channel := path.EndpointA.GetChannel()
 					suite.Require().Equal(expectedOrderding, channel.Ordering)
 				} else {
-					suite.Require().Error(err)
+					suite.Require().ErrorIs(err, tc.expErr)
 					suite.Require().Nil(res)
 				}
 			})
@@ -125,31 +127,31 @@ func (suite *KeeperTestSuite) TestSubmitTx() {
 	testCases := []struct {
 		name     string
 		malleate func()
-		expPass  bool
+		expErr   error
 	}{
 		{
 			"success", func() {
 			},
-			true,
+			nil,
 		},
 		{
 			"failure - owner address is empty", func() {
 				msg.Owner = ""
 			},
-			false,
+			icatypes.ErrInvalidAccountAddress,
 		},
 		{
 			"failure - active channel does not exist for connection ID", func() {
 				msg.Owner = TestOwnerAddress
 				msg.ConnectionId = "connection-100"
 			},
-			false,
+			icatypes.ErrActiveChannelNotFound,
 		},
 		{
 			"failure - active channel does not exist for port ID", func() {
 				msg.Owner = "invalid-owner"
 			},
-			false,
+			icatypes.ErrActiveChannelNotFound,
 		},
 		{
 			"failure - controller module does not own capability for this channel", func() {
@@ -160,7 +162,7 @@ func (suite *KeeperTestSuite) TestSubmitTx() {
 				// set the active channel with the incorrect portID in order to reach the capability check
 				suite.chainA.GetSimApp().ICAControllerKeeper.SetActiveChannelID(suite.chainA.GetContext(), path.EndpointA.ConnectionID, portID, path.EndpointA.ChannelID)
 			},
-			false,
+			icatypes.ErrActiveChannelNotFound,
 		},
 	}
 
@@ -212,11 +214,11 @@ func (suite *KeeperTestSuite) TestSubmitTx() {
 				msgServer := keeper.NewMsgServerImpl(&suite.chainA.GetSimApp().ICAControllerKeeper)
 				res, err := msgServer.SendTx(ctx, msg)
 
-				if tc.expPass {
+				if tc.expErr == nil {
 					suite.Require().NoError(err)
 					suite.Require().NotNil(res)
 				} else {
-					suite.Require().Error(err)
+					suite.Require().ErrorIs(err, tc.expErr)
 					suite.Require().Nil(res)
 				}
 			})
@@ -228,34 +230,34 @@ func (suite *KeeperTestSuite) TestSubmitTx() {
 func (suite *KeeperTestSuite) TestUpdateParams() {
 	signer := suite.chainA.GetSimApp().TransferKeeper.GetAuthority()
 	testCases := []struct {
-		name    string
-		msg     *types.MsgUpdateParams
-		expPass bool
+		name   string
+		msg    *types.MsgUpdateParams
+		expErr error
 	}{
 		{
 			"success: valid signer and default params",
 			types.NewMsgUpdateParams(signer, types.NewParams(!types.DefaultControllerEnabled)),
-			true,
+			nil,
 		},
 		{
 			"failure: malformed signer address",
 			types.NewMsgUpdateParams(ibctesting.InvalidID, types.DefaultParams()),
-			false,
+			ibcerrors.ErrUnauthorized,
 		},
 		{
 			"failure: empty signer address",
 			types.NewMsgUpdateParams("", types.DefaultParams()),
-			false,
+			ibcerrors.ErrUnauthorized,
 		},
 		{
 			"failure: whitespace signer address",
 			types.NewMsgUpdateParams("    ", types.DefaultParams()),
-			false,
+			ibcerrors.ErrUnauthorized,
 		},
 		{
 			"failure: unauthorized signer address",
 			types.NewMsgUpdateParams(ibctesting.TestAccAddress, types.DefaultParams()),
-			false,
+			ibcerrors.ErrUnauthorized,
 		},
 	}
 
@@ -265,12 +267,12 @@ func (suite *KeeperTestSuite) TestUpdateParams() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 			_, err := suite.chainA.GetSimApp().ICAControllerKeeper.UpdateParams(suite.chainA.GetContext(), tc.msg)
-			if tc.expPass {
+			if tc.expErr == nil {
 				suite.Require().NoError(err)
 				p := suite.chainA.GetSimApp().ICAControllerKeeper.GetParams(suite.chainA.GetContext())
 				suite.Require().Equal(tc.msg.Params, p)
 			} else {
-				suite.Require().Error(err)
+				suite.Require().ErrorIs(err, tc.expErr)
 			}
 		})
 	}

--- a/modules/apps/27-interchain-accounts/controller/keeper/msg_server_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/msg_server_test.go
@@ -27,51 +27,51 @@ func (suite *KeeperTestSuite) TestRegisterInterchainAccount_MsgServer() {
 
 	testCases := []struct {
 		name     string
-		expErr   error
 		malleate func()
+		expErr   error
 	}{
 		{
 			"success",
-			nil,
 			func() {},
+			nil,
 		},
 		{
 			"success: ordering falls back to UNORDERED if not specified",
-			nil,
 			func() {
 				msg.Ordering = channeltypes.NONE
 				expectedOrderding = channeltypes.UNORDERED
 			},
-		},
-		{
-			"invalid connection id",
-			connectiontypes.ErrConnectionNotFound,
-			func() {
-				msg.ConnectionId = "connection-100"
-			},
-		},
-		{
-			"non-empty owner address is valid",
 			nil,
+		},
+		{
+			"success: non-empty owner address is valid",
 			func() {
 				msg.Owner = "<invalid-owner>"
 			},
+			nil,
+		},
+		{
+			"invalid connection id",
+			func() {
+				msg.ConnectionId = "connection-100"
+			},
+			connectiontypes.ErrConnectionNotFound,
 		},
 		{
 			"empty address invalid",
-			icatypes.ErrInvalidAccountAddress,
 			func() {
 				msg.Owner = ""
 			},
+			icatypes.ErrInvalidAccountAddress,
 		},
 		{
 			"port is already bound for owner but capability is claimed by another module",
-			icatypes.ErrPortAlreadyBound,
 			func() {
 				capability := suite.chainA.GetSimApp().IBCKeeper.PortKeeper.BindPort(suite.chainA.GetContext(), TestPortID)
 				err := suite.chainA.GetSimApp().TransferKeeper.ClaimCapability(suite.chainA.GetContext(), capability, host.PortPath(TestPortID))
 				suite.Require().NoError(err)
 			},
+			icatypes.ErrPortAlreadyBound,
 		},
 	}
 

--- a/modules/apps/27-interchain-accounts/controller/types/codec_test.go
+++ b/modules/apps/27-interchain-accounts/controller/types/codec_test.go
@@ -37,7 +37,7 @@ func TestCodecTypeRegistration(t *testing.T) {
 		{
 			"type not registered on codec",
 			"ibc.invalid.MsgTypeURL",
-			fmt.Errorf("unable to resolve typeURL"),
+			fmt.Errorf("unable to resolve type URL"),
 		},
 	}
 

--- a/modules/apps/27-interchain-accounts/controller/types/codec_test.go
+++ b/modules/apps/27-interchain-accounts/controller/types/codec_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,27 +17,27 @@ func TestCodecTypeRegistration(t *testing.T) {
 	testCases := []struct {
 		name    string
 		typeURL string
-		expPass bool
+		expErr  error
 	}{
 		{
 			"success: MsgRegisterInterchainAccount",
 			sdk.MsgTypeURL(&types.MsgRegisterInterchainAccount{}),
-			true,
+			nil,
 		},
 		{
 			"success: MsgSendTx",
 			sdk.MsgTypeURL(&types.MsgSendTx{}),
-			true,
+			nil,
 		},
 		{
 			"success: MsgUpdateParams",
 			sdk.MsgTypeURL(&types.MsgUpdateParams{}),
-			true,
+			nil,
 		},
 		{
 			"type not registered on codec",
 			"ibc.invalid.MsgTypeURL",
-			false,
+			fmt.Errorf("unable to resolve typeURL"),
 		},
 	}
 
@@ -47,12 +48,12 @@ func TestCodecTypeRegistration(t *testing.T) {
 			encodingCfg := moduletestutil.MakeTestEncodingConfig(ica.AppModuleBasic{})
 			msg, err := encodingCfg.Codec.InterfaceRegistry().Resolve(tc.typeURL)
 
-			if tc.expPass {
+			if tc.expErr == nil {
 				require.NotNil(t, msg)
 				require.NoError(t, err)
 			} else {
 				require.Nil(t, msg)
-				require.Error(t, err)
+				require.ErrorIs(t, err, tc.expErr)
 			}
 		})
 	}

--- a/modules/apps/27-interchain-accounts/controller/types/codec_test.go
+++ b/modules/apps/27-interchain-accounts/controller/types/codec_test.go
@@ -48,12 +48,14 @@ func TestCodecTypeRegistration(t *testing.T) {
 			encodingCfg := moduletestutil.MakeTestEncodingConfig(ica.AppModuleBasic{})
 			msg, err := encodingCfg.Codec.InterfaceRegistry().Resolve(tc.typeURL)
 
+			fmt.Printf("%+v\n", err)
+
 			if tc.expErr == nil {
 				require.NotNil(t, msg)
 				require.NoError(t, err)
 			} else {
 				require.Nil(t, msg)
-				require.ErrorIs(t, err, tc.expErr)
+				require.ErrorContains(t, err, tc.expErr.Error())
 			}
 		})
 	}

--- a/modules/apps/27-interchain-accounts/controller/types/msgs_test.go
+++ b/modules/apps/27-interchain-accounts/controller/types/msgs_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -15,6 +16,8 @@ import (
 	icatypes "github.com/cosmos/ibc-go/v9/modules/apps/27-interchain-accounts/types"
 	feetypes "github.com/cosmos/ibc-go/v9/modules/apps/29-fee/types"
 	channeltypes "github.com/cosmos/ibc-go/v9/modules/core/04-channel/types"
+	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
+	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
 	ibctesting "github.com/cosmos/ibc-go/v9/testing"
 )
 
@@ -24,19 +27,19 @@ func TestMsgRegisterInterchainAccountValidateBasic(t *testing.T) {
 	testCases := []struct {
 		name     string
 		malleate func()
-		expPass  bool
+		expErr   error
 	}{
 		{
 			"success",
 			func() {},
-			true,
+			nil,
 		},
 		{
 			"success: with empty channel version",
 			func() {
 				msg.Version = ""
 			},
-			true,
+			nil,
 		},
 		{
 			"success: with fee enabled channel version",
@@ -49,35 +52,35 @@ func TestMsgRegisterInterchainAccountValidateBasic(t *testing.T) {
 				bz := feetypes.ModuleCdc.MustMarshalJSON(&feeMetadata)
 				msg.Version = string(bz)
 			},
-			true,
+			nil,
 		},
 		{
 			"connection id is invalid",
 			func() {
 				msg.ConnectionId = ""
 			},
-			false,
+			host.ErrInvalidID,
 		},
 		{
 			"owner address is empty",
 			func() {
 				msg.Owner = ""
 			},
-			false,
+			ibcerrors.ErrInvalidAddress,
 		},
 		{
 			"owner address is too long",
 			func() {
 				msg.Owner = ibctesting.GenerateString(types.MaximumOwnerLength + 1)
 			},
-			false,
+			ibcerrors.ErrInvalidAddress,
 		},
 		{
 			"order is not valid",
 			func() {
 				msg.Ordering = channeltypes.NONE
 			},
-			false,
+			channeltypes.ErrInvalidChannelOrdering,
 		},
 	}
 
@@ -94,10 +97,10 @@ func TestMsgRegisterInterchainAccountValidateBasic(t *testing.T) {
 		tc.malleate()
 
 		err := msg.ValidateBasic()
-		if tc.expPass {
+		if tc.expErr == nil {
 			require.NoError(t, err, "valid test case %d failed: %s", i, tc.name)
 		} else {
-			require.Error(t, err, "invalid test case %d passed: %s", i, tc.name)
+			require.ErrorIs(t, err, tc.expErr, "invalid test case %d passed: %s", i, tc.name)
 		}
 	}
 }
@@ -119,47 +122,47 @@ func TestMsgSendTxValidateBasic(t *testing.T) {
 	testCases := []struct {
 		name     string
 		malleate func()
-		expPass  bool
+		expErr   error
 	}{
 		{
 			"success",
 			func() {},
-			true,
+			nil,
 		},
 		{
 			"connection id is invalid",
 			func() {
 				msg.ConnectionId = ""
 			},
-			false,
+			host.ErrInvalidID,
 		},
 		{
 			"owner address is empty",
 			func() {
 				msg.Owner = ""
 			},
-			false,
+			ibcerrors.ErrInvalidAddress,
 		},
 		{
 			"owner address is too long",
 			func() {
 				msg.Owner = ibctesting.GenerateString(types.MaximumOwnerLength + 1)
 			},
-			false,
+			ibcerrors.ErrInvalidAddress,
 		},
 		{
 			"relative timeout is not set",
 			func() {
 				msg.RelativeTimeout = 0
 			},
-			false,
+			ibcerrors.ErrInvalidRequest,
 		},
 		{
 			"messages array is empty",
 			func() {
 				msg.PacketData = icatypes.InterchainAccountPacketData{}
 			},
-			false,
+			icatypes.ErrInvalidOutgoingData,
 		},
 	}
 
@@ -192,10 +195,10 @@ func TestMsgSendTxValidateBasic(t *testing.T) {
 		tc.malleate()
 
 		err = msg.ValidateBasic()
-		if tc.expPass {
+		if tc.expErr == nil {
 			require.NoError(t, err, "valid test case %d failed: %s", i, tc.name)
 		} else {
-			require.Error(t, err, "invalid test case %d passed: %s", i, tc.name)
+			require.ErrorIs(t, err, tc.expErr, "invalid test case %d passed: %s", i, tc.name)
 		}
 	}
 }
@@ -234,23 +237,23 @@ func TestMsgSendTxGetSigners(t *testing.T) {
 // TestMsgUpdateParamsValidateBasic tests ValidateBasic for MsgUpdateParams
 func TestMsgUpdateParamsValidateBasic(t *testing.T) {
 	testCases := []struct {
-		name    string
-		msg     *types.MsgUpdateParams
-		expPass bool
+		name   string
+		msg    *types.MsgUpdateParams
+		expErr error
 	}{
-		{"success: valid signer and valid params", types.NewMsgUpdateParams(ibctesting.TestAccAddress, types.DefaultParams()), true},
-		{"failure: invalid signer with valid params", types.NewMsgUpdateParams("invalidAddress", types.DefaultParams()), false},
-		{"failure: empty signer with valid params", types.NewMsgUpdateParams("", types.DefaultParams()), false},
+		{"success: valid signer and valid params", types.NewMsgUpdateParams(ibctesting.TestAccAddress, types.DefaultParams()), nil},
+		{"failure: invalid signer with valid params", types.NewMsgUpdateParams("invalidAddress", types.DefaultParams()), ibcerrors.ErrInvalidAddress},
+		{"failure: empty signer with valid params", types.NewMsgUpdateParams("", types.DefaultParams()), ibcerrors.ErrInvalidAddress},
 	}
 
 	for i, tc := range testCases {
 		i, tc := i, tc
 
 		err := tc.msg.ValidateBasic()
-		if tc.expPass {
+		if tc.expErr == nil {
 			require.NoError(t, err, "valid test case %d failed: %s", i, tc.name)
 		} else {
-			require.Error(t, err, "invalid test case %d passed: %s", i, tc.name)
+			require.ErrorIs(t, err, tc.expErr, "invalid test case %d passed: %s", i, tc.name)
 		}
 	}
 }
@@ -260,10 +263,10 @@ func TestMsgUpdateParamsGetSigners(t *testing.T) {
 	testCases := []struct {
 		name    string
 		address sdk.AccAddress
-		expPass bool
+		expErr  error
 	}{
-		{"success: valid address", sdk.AccAddress(ibctesting.TestAccAddress), true},
-		{"failure: nil address", nil, false},
+		{"success: valid address", sdk.AccAddress(ibctesting.TestAccAddress), nil},
+		{"failure: nil address", nil, errors.New("empty address string is not allowed")},
 	}
 
 	for _, tc := range testCases {
@@ -276,11 +279,11 @@ func TestMsgUpdateParamsGetSigners(t *testing.T) {
 
 		encodingCfg := moduletestutil.MakeTestEncodingConfig(ica.AppModuleBasic{})
 		signers, _, err := encodingCfg.Codec.GetMsgV1Signers(&msg)
-		if tc.expPass {
+		if tc.expErr == nil {
 			require.NoError(t, err)
 			require.Equal(t, tc.address.Bytes(), signers[0])
 		} else {
-			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expErr.Error())
 		}
 
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #7178

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
