### PR TITLE
Fix failing transfer e2es

### DIFF
--- a/.github/workflows/e2e-test-workflow-call.yml
+++ b/.github/workflows/e2e-test-workflow-call.yml
@@ -277,6 +277,8 @@ jobs:
       CHAIN_BINARY: '${{ inputs.chain-binary }}'
       CHAIN_UPGRADE_TAG: '${{ inputs.chain-upgrade-tag }}'
       CHAIN_UPGRADE_PLAN: '${{ inputs.upgrade-plan-name }}'
+      # explicitly set to true so that if a test fails, it doesn't delete the chain and cause other tests to fail.
+      KEEP_CONTAINERS: "true"
     strategy:
       fail-fast: false
       matrix:

--- a/e2e/sample.config.extended.yaml
+++ b/e2e/sample.config.extended.yaml
@@ -18,7 +18,7 @@
 ---
 chains:
   # the entry at index 0 corresponds to CHAIN_A
-- chainId: chain-1
+- chainId: chainA-1
   numValidators: 4
   numFullNodes: 1
   image: ghcr.io/cosmos/ibc-go-simd # override with CHAIN_IMAGE
@@ -26,7 +26,7 @@ chains:
   binary: simd # override with CHAIN_BINARY
 
   # the entry at index 1 corresponds to CHAIN_B
-- chainId: chain-2
+- chainId: chainB-1
   numValidators: 4
   numFullNodes: 1
   image: ghcr.io/cosmos/ibc-go-simd # override with CHAIN_IMAGE

--- a/e2e/testsuite/testconfig.go
+++ b/e2e/testsuite/testconfig.go
@@ -147,6 +147,13 @@ func (tc TestConfig) validateChains() error {
 			}
 		}
 	}
+
+	// clienttypes.ParseChainID is used to determine revision heights. If the chainIDs are not in the expected format,
+	// tests can fail with timeout errors.
+	if clienttypes.ParseChainID(tc.GetChainAID()) != clienttypes.ParseChainID(tc.GetChainBID()) {
+		return fmt.Errorf("ensure both chainIDs are in the format {chainID}-{revision} and have the same revision. Got: chainA: %s, chainB: %s", tc.GetChainAID(), tc.GetChainBID())
+	}
+
 	return nil
 }
 
@@ -229,19 +236,21 @@ func (tc TestConfig) GetChainNumFullNodes(idx int) int {
 }
 
 // GetChainAID returns the chain-id for chain A.
+// NOTE: the default return value will ensure that ParseChainID will return 1 as the revision number.
 func (tc TestConfig) GetChainAID() string {
 	if tc.ChainConfigs[0].ChainID != "" {
 		return tc.ChainConfigs[0].ChainID
 	}
-	return "chain-1"
+	return "chainA-1"
 }
 
 // GetChainBID returns the chain-id for chain B.
+// NOTE: the default return value will ensure that ParseChainID will return 1 as the revision number.
 func (tc TestConfig) GetChainBID() string {
 	if tc.ChainConfigs[1].ChainID != "" {
 		return tc.ChainConfigs[1].ChainID
 	}
-	return "chain-2"
+	return "chainB-1"
 }
 
 // GetChainName returns the name of the chain given an index.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR is fixing 2 issues with the E2Es.

1. Previously, we were not explicitly telling the tests to retain containers upon test failure, this meant that if one test fails, the chains would be removed and all tests still running would fail.
2. The chain IDs had been changed, but we were actually relying on them for parsing the revision when generating timeouts (causing test timeout failures). I added some validation that ensures the revision ID is the same for both chains. In the case of requiring different revision numbers in a test I figured we can re-visit this later. For now this just ensures a test doesn't run when a config will cause a test to fail at runtime. 

closes: #XXXX

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
