### PR TITLE
chore: dont emit channel information for eureka handlers

### DIFF
--- a/modules/core/04-channel/keeper/events.go
+++ b/modules/core/04-channel/keeper/events.go
@@ -121,23 +121,32 @@ func emitChannelCloseConfirmEvent(ctx sdk.Context, portID string, channelID stri
 
 // emitSendPacketEvent emits an event with packet data along with other packet information for relayer
 // to pick up and relay to other chain
-func EmitSendPacketEvent(ctx sdk.Context, packet types.Packet, channel types.Channel, timeoutHeight exported.Height) {
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeSendPacket,
-			sdk.NewAttribute(types.AttributeKeyDataHex, hex.EncodeToString(packet.GetData())),
-			sdk.NewAttribute(types.AttributeKeyTimeoutHeight, timeoutHeight.String()),
-			sdk.NewAttribute(types.AttributeKeyTimeoutTimestamp, fmt.Sprintf("%d", packet.GetTimeoutTimestamp())),
-			sdk.NewAttribute(types.AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
-			sdk.NewAttribute(types.AttributeKeySrcPort, packet.GetSourcePort()),
-			sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
-			sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
-			sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
+func EmitSendPacketEvent(ctx sdk.Context, packet types.Packet, channel *types.Channel, timeoutHeight exported.Height) {
+	eventAttributes := []sdk.Attribute{
+		sdk.NewAttribute(types.AttributeKeyDataHex, hex.EncodeToString(packet.GetData())),
+		sdk.NewAttribute(types.AttributeKeyTimeoutHeight, timeoutHeight.String()),
+		sdk.NewAttribute(types.AttributeKeyTimeoutTimestamp, fmt.Sprintf("%d", packet.GetTimeoutTimestamp())),
+		sdk.NewAttribute(types.AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
+		sdk.NewAttribute(types.AttributeKeySrcPort, packet.GetSourcePort()),
+		sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
+		sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
+		sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
+	}
+
+	if channel != nil {
+		eventAttributes = append(eventAttributes,
 			sdk.NewAttribute(types.AttributeKeyChannelOrdering, channel.Ordering.String()),
 			// we only support 1-hop packets now, and that is the most important hop for a relayer
 			// (is it going to a chain I am connected to)
 			sdk.NewAttribute(types.AttributeKeyConnection, channel.ConnectionHops[0]), // DEPRECATED
 			sdk.NewAttribute(types.AttributeKeyConnectionID, channel.ConnectionHops[0]),
+		)
+	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeSendPacket,
+			eventAttributes...,
 		),
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
@@ -148,23 +157,32 @@ func EmitSendPacketEvent(ctx sdk.Context, packet types.Packet, channel types.Cha
 
 // EmitRecvPacketEvent emits a receive packet event. It will be emitted both the first time a packet
 // is received for a certain sequence and for all duplicate receives.
-func EmitRecvPacketEvent(ctx sdk.Context, packet types.Packet, channel types.Channel) {
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeRecvPacket,
-			sdk.NewAttribute(types.AttributeKeyDataHex, hex.EncodeToString(packet.GetData())),
-			sdk.NewAttribute(types.AttributeKeyTimeoutHeight, packet.GetTimeoutHeight().String()),
-			sdk.NewAttribute(types.AttributeKeyTimeoutTimestamp, fmt.Sprintf("%d", packet.GetTimeoutTimestamp())),
-			sdk.NewAttribute(types.AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
-			sdk.NewAttribute(types.AttributeKeySrcPort, packet.GetSourcePort()),
-			sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
-			sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
-			sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
+func EmitRecvPacketEvent(ctx sdk.Context, packet types.Packet, channel *types.Channel) {
+	eventAttributes := []sdk.Attribute{
+		sdk.NewAttribute(types.AttributeKeyDataHex, hex.EncodeToString(packet.GetData())),
+		sdk.NewAttribute(types.AttributeKeyTimeoutHeight, packet.GetTimeoutHeight().String()),
+		sdk.NewAttribute(types.AttributeKeyTimeoutTimestamp, fmt.Sprintf("%d", packet.GetTimeoutTimestamp())),
+		sdk.NewAttribute(types.AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
+		sdk.NewAttribute(types.AttributeKeySrcPort, packet.GetSourcePort()),
+		sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
+		sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
+		sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
+	}
+
+	if channel != nil {
+		eventAttributes = append(eventAttributes,
 			sdk.NewAttribute(types.AttributeKeyChannelOrdering, channel.Ordering.String()),
 			// we only support 1-hop packets now, and that is the most important hop for a relayer
 			// (is it going to a chain I am connected to)
 			sdk.NewAttribute(types.AttributeKeyConnection, channel.ConnectionHops[0]), // DEPRECATED
 			sdk.NewAttribute(types.AttributeKeyConnectionID, channel.ConnectionHops[0]),
+		)
+	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeRecvPacket,
+			eventAttributes...,
 		),
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
@@ -174,24 +192,33 @@ func EmitRecvPacketEvent(ctx sdk.Context, packet types.Packet, channel types.Cha
 }
 
 // EmitWriteAcknowledgementEvent emits an event that the relayer can query for
-func EmitWriteAcknowledgementEvent(ctx sdk.Context, packet types.Packet, channel types.Channel, acknowledgement []byte) {
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeWriteAck,
-			sdk.NewAttribute(types.AttributeKeyDataHex, hex.EncodeToString(packet.GetData())),
-			sdk.NewAttribute(types.AttributeKeyTimeoutHeight, packet.GetTimeoutHeight().String()),
-			sdk.NewAttribute(types.AttributeKeyTimeoutTimestamp, fmt.Sprintf("%d", packet.GetTimeoutTimestamp())),
-			sdk.NewAttribute(types.AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
-			sdk.NewAttribute(types.AttributeKeySrcPort, packet.GetSourcePort()),
-			sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
-			sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
-			sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
-			sdk.NewAttribute(types.AttributeKeyAckHex, hex.EncodeToString(acknowledgement)),
+func EmitWriteAcknowledgementEvent(ctx sdk.Context, packet types.Packet, channel *types.Channel, acknowledgement []byte) {
+	eventAttributes := []sdk.Attribute{
+		sdk.NewAttribute(types.AttributeKeyDataHex, hex.EncodeToString(packet.GetData())),
+		sdk.NewAttribute(types.AttributeKeyTimeoutHeight, packet.GetTimeoutHeight().String()),
+		sdk.NewAttribute(types.AttributeKeyTimeoutTimestamp, fmt.Sprintf("%d", packet.GetTimeoutTimestamp())),
+		sdk.NewAttribute(types.AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
+		sdk.NewAttribute(types.AttributeKeySrcPort, packet.GetSourcePort()),
+		sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
+		sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
+		sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
+		sdk.NewAttribute(types.AttributeKeyAckHex, hex.EncodeToString(acknowledgement)),
+	}
+
+	if channel != nil {
+		eventAttributes = append(eventAttributes,
 			sdk.NewAttribute(types.AttributeKeyChannelOrdering, channel.Ordering.String()),
 			// we only support 1-hop packets now, and that is the most important hop for a relayer
 			// (is it going to a chain I am connected to)
 			sdk.NewAttribute(types.AttributeKeyConnection, channel.ConnectionHops[0]), // DEPRECATED
 			sdk.NewAttribute(types.AttributeKeyConnectionID, channel.ConnectionHops[0]),
+		)
+	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeWriteAck,
+			eventAttributes...,
 		),
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
@@ -202,22 +229,31 @@ func EmitWriteAcknowledgementEvent(ctx sdk.Context, packet types.Packet, channel
 
 // EmitAcknowledgePacketEvent emits an acknowledge packet event. It will be emitted both the first time
 // a packet is acknowledged for a certain sequence and for all duplicate acknowledgements.
-func EmitAcknowledgePacketEvent(ctx sdk.Context, packet types.Packet, channel types.Channel) {
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeAcknowledgePacket,
-			sdk.NewAttribute(types.AttributeKeyTimeoutHeight, packet.GetTimeoutHeight().String()),
-			sdk.NewAttribute(types.AttributeKeyTimeoutTimestamp, fmt.Sprintf("%d", packet.GetTimeoutTimestamp())),
-			sdk.NewAttribute(types.AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
-			sdk.NewAttribute(types.AttributeKeySrcPort, packet.GetSourcePort()),
-			sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
-			sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
-			sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
+func EmitAcknowledgePacketEvent(ctx sdk.Context, packet types.Packet, channel *types.Channel) {
+	eventAttributes := []sdk.Attribute{
+		sdk.NewAttribute(types.AttributeKeyTimeoutHeight, packet.GetTimeoutHeight().String()),
+		sdk.NewAttribute(types.AttributeKeyTimeoutTimestamp, fmt.Sprintf("%d", packet.GetTimeoutTimestamp())),
+		sdk.NewAttribute(types.AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
+		sdk.NewAttribute(types.AttributeKeySrcPort, packet.GetSourcePort()),
+		sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
+		sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
+		sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
+	}
+
+	if channel != nil {
+		eventAttributes = append(eventAttributes,
 			sdk.NewAttribute(types.AttributeKeyChannelOrdering, channel.Ordering.String()),
 			// we only support 1-hop packets now, and that is the most important hop for a relayer
 			// (is it going to a chain I am connected to)
 			sdk.NewAttribute(types.AttributeKeyConnection, channel.ConnectionHops[0]), // DEPRECATED
 			sdk.NewAttribute(types.AttributeKeyConnectionID, channel.ConnectionHops[0]),
+		)
+	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeAcknowledgePacket,
+			eventAttributes...,
 		),
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
@@ -228,19 +264,27 @@ func EmitAcknowledgePacketEvent(ctx sdk.Context, packet types.Packet, channel ty
 
 // emitTimeoutPacketEvent emits a timeout packet event. It will be emitted both the first time a packet
 // is timed out for a certain sequence and for all duplicate timeouts.
-func EmitTimeoutPacketEvent(ctx sdk.Context, packet types.Packet, channel types.Channel) {
+func EmitTimeoutPacketEvent(ctx sdk.Context, packet types.Packet, channel *types.Channel) {
+	eventAttributes := []sdk.Attribute{
+		sdk.NewAttribute(types.AttributeKeyTimeoutHeight, packet.GetTimeoutHeight().String()),
+		sdk.NewAttribute(types.AttributeKeyTimeoutTimestamp, fmt.Sprintf("%d", packet.GetTimeoutTimestamp())),
+		sdk.NewAttribute(types.AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
+		sdk.NewAttribute(types.AttributeKeySrcPort, packet.GetSourcePort()),
+		sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
+		sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
+		sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
+	}
+
+	if channel != nil {
+		eventAttributes = append(eventAttributes,
+			sdk.NewAttribute(types.AttributeKeyConnectionID, channel.ConnectionHops[0]),
+			sdk.NewAttribute(types.AttributeKeyChannelOrdering, channel.Ordering.String()),
+		)
+	}
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeTimeoutPacket,
-			sdk.NewAttribute(types.AttributeKeyTimeoutHeight, packet.GetTimeoutHeight().String()),
-			sdk.NewAttribute(types.AttributeKeyTimeoutTimestamp, fmt.Sprintf("%d", packet.GetTimeoutTimestamp())),
-			sdk.NewAttribute(types.AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
-			sdk.NewAttribute(types.AttributeKeySrcPort, packet.GetSourcePort()),
-			sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
-			sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
-			sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
-			sdk.NewAttribute(types.AttributeKeyConnectionID, channel.ConnectionHops[0]),
-			sdk.NewAttribute(types.AttributeKeyChannelOrdering, channel.Ordering.String()),
+			eventAttributes...,
 		),
 		sdk.NewEvent(
 			sdk.EventTypeMessage,

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -77,7 +77,7 @@ func (k *Keeper) TimeoutPacket(
 	commitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 	if len(commitment) == 0 {
-		EmitTimeoutPacketEvent(ctx, packet, channel)
+		EmitTimeoutPacketEvent(ctx, packet, &channel)
 		// This error indicates that the timeout has already been relayed
 		// or there is a misconfigured relayer attempting to prove a timeout
 		// for a packet never sent. Core IBC will treat this error as a no-op in order to
@@ -183,7 +183,7 @@ func (k *Keeper) timeoutExecuted(
 	)
 
 	// emit an event marking that we have processed the timeout
-	EmitTimeoutPacketEvent(ctx, packet, channel)
+	EmitTimeoutPacketEvent(ctx, packet, &channel)
 
 	return nil
 }
@@ -236,7 +236,7 @@ func (k *Keeper) TimeoutOnClose(
 	commitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 	if len(commitment) == 0 {
-		EmitTimeoutPacketEvent(ctx, packet, channel)
+		EmitTimeoutPacketEvent(ctx, packet, &channel)
 		// This error indicates that the timeout has already been relayed
 		// or there is a misconfigured relayer attempting to prove a timeout
 		// for a packet never sent. Core IBC will treat this error as a no-op in order to

--- a/modules/core/packet-server/keeper/keeper.go
+++ b/modules/core/packet-server/keeper/keeper.go
@@ -108,7 +108,7 @@ func (k Keeper) SendPacket(
 
 	k.Logger(ctx).Info("packet sent", "sequence", strconv.FormatUint(packet.Sequence, 10), "src_port", packet.SourcePort, "src_channel", packet.SourceChannel, "dst_port", packet.DestinationPort, "dst_channel", packet.DestinationChannel)
 
-	channelkeeper.EmitSendPacketEvent(ctx, packet, sentinelChannel(sourceChannel), timeoutHeight)
+	channelkeeper.EmitSendPacketEvent(ctx, packet, nil, timeoutHeight)
 
 	return sequence, nil
 }
@@ -153,7 +153,7 @@ func (k Keeper) RecvPacket(
 	// by the increase of the recvStartSequence.
 	_, found := k.ChannelKeeper.GetPacketReceipt(ctx, packet.DestinationPort, packet.DestinationChannel, packet.Sequence)
 	if found {
-		channelkeeper.EmitRecvPacketEvent(ctx, packet, sentinelChannel(packet.DestinationChannel))
+		channelkeeper.EmitRecvPacketEvent(ctx, packet, nil)
 		// This error indicates that the packet has already been relayed. Core IBC will
 		// treat this error as a no-op in order to prevent an entire relay transaction
 		// from failing and consuming unnecessary fees.
@@ -182,7 +182,7 @@ func (k Keeper) RecvPacket(
 
 	k.Logger(ctx).Info("packet received", "sequence", strconv.FormatUint(packet.Sequence, 10), "src_port", packet.SourcePort, "src_channel", packet.SourceChannel, "dst_port", packet.DestinationPort, "dst_channel", packet.DestinationChannel)
 
-	channelkeeper.EmitRecvPacketEvent(ctx, packet, sentinelChannel(packet.DestinationChannel))
+	channelkeeper.EmitRecvPacketEvent(ctx, packet, nil)
 
 	return packet.AppVersion, nil
 }
@@ -240,7 +240,7 @@ func (k Keeper) WriteAcknowledgement(
 
 	k.Logger(ctx).Info("acknowledgement written", "sequence", strconv.FormatUint(packet.Sequence, 10), "src_port", packet.SourcePort, "src_channel", packet.SourceChannel, "dst_port", packet.DestinationPort, "dst_channel", packet.DestinationChannel)
 
-	channelkeeper.EmitWriteAcknowledgementEvent(ctx, packet, sentinelChannel(packet.DestinationChannel), bz)
+	channelkeeper.EmitWriteAcknowledgementEvent(ctx, packet, nil, bz)
 
 	return nil
 }
@@ -276,7 +276,7 @@ func (k Keeper) AcknowledgePacket(
 
 	commitment := k.ChannelKeeper.GetPacketCommitment(ctx, packet.SourcePort, packet.SourceChannel, packet.Sequence)
 	if len(commitment) == 0 {
-		channelkeeper.EmitAcknowledgePacketEvent(ctx, packet, sentinelChannel(packet.SourceChannel))
+		channelkeeper.EmitAcknowledgePacketEvent(ctx, packet, nil)
 
 		// This error indicates that the acknowledgement has already been relayed
 		// or there is a misconfigured relayer attempting to prove an acknowledgement
@@ -311,7 +311,7 @@ func (k Keeper) AcknowledgePacket(
 
 	k.Logger(ctx).Info("packet acknowledged", "sequence", strconv.FormatUint(packet.GetSequence(), 10), "src_port", packet.GetSourcePort(), "src_channel", packet.GetSourceChannel(), "dst_port", packet.GetDestPort(), "dst_channel", packet.GetDestChannel())
 
-	channelkeeper.EmitAcknowledgePacketEvent(ctx, packet, sentinelChannel(packet.SourceChannel))
+	channelkeeper.EmitAcknowledgePacketEvent(ctx, packet, nil)
 
 	return packet.AppVersion, nil
 }
@@ -360,7 +360,7 @@ func (k Keeper) TimeoutPacket(
 	commitment := k.ChannelKeeper.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 	if len(commitment) == 0 {
-		channelkeeper.EmitTimeoutPacketEvent(ctx, packet, sentinelChannel(packet.SourceChannel))
+		channelkeeper.EmitTimeoutPacketEvent(ctx, packet, nil)
 		// This error indicates that the timeout has already been relayed
 		// or there is a misconfigured relayer attempting to prove a timeout
 		// for a packet never sent. Core IBC will treat this error as a no-op in order to
@@ -394,12 +394,7 @@ func (k Keeper) TimeoutPacket(
 
 	k.Logger(ctx).Info("packet timed out", "sequence", strconv.FormatUint(packet.Sequence, 10), "src_port", packet.SourcePort, "src_channel", packet.SourceChannel, "dst_port", packet.DestinationPort, "dst_channel", packet.DestinationChannel)
 
-	channelkeeper.EmitTimeoutPacketEvent(ctx, packet, sentinelChannel(packet.SourceChannel))
+	channelkeeper.EmitTimeoutPacketEvent(ctx, packet, nil)
 
 	return packet.AppVersion, nil
-}
-
-// sentinelChannel creates a sentinel channel for use in events for Eureka protocol handlers.
-func sentinelChannel(clientID string) channeltypes.Channel {
-	return channeltypes.Channel{Ordering: channeltypes.UNORDERED, ConnectionHops: []string{clientID}}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

the other alternative is creating an `events.go` in the packet server and duplicating code there. Perfectly fine with switching to that if people prefer, another perk of it would be private event funcs. 

For now, this just uses a nil channel for packet server and adds attributes based on that.

closes: #7152

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
