### PR TITLE
[backport v6.2.x] imp(core): allow huckleberry events with a prefix (#5541)

### DIFF
--- a/modules/core/keeper/events_test.go
+++ b/modules/core/keeper/events_test.go
@@ -1,0 +1,106 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/ibc-go/v6/modules/core/keeper"
+	"github.com/cosmos/ibc-go/v6/modules/core/types"
+)
+
+func TestConvertToErrorEvents(t *testing.T) {
+	var (
+		events    sdk.Events
+		expEvents sdk.Events
+	)
+
+	tc := []struct {
+		name     string
+		malleate func()
+	}{
+		{
+			"success: nil events",
+			func() {
+				events = nil
+				expEvents = nil
+			},
+		},
+		{
+			"success: empty events",
+			func() {
+				events = sdk.Events{}
+				expEvents = sdk.Events{}
+			},
+		},
+		{
+			"success: event with no attributes",
+			func() {
+				events = sdk.Events{
+					sdk.NewEvent("testevent"),
+				}
+				expEvents = sdk.Events{
+					sdk.NewEvent(types.ErrorAttributeKeyPrefix + "testevent"),
+				}
+			},
+		},
+		{
+			"success: event with attributes",
+			func() {
+				events = sdk.Events{
+					sdk.NewEvent("testevent",
+						sdk.NewAttribute("key1", "value1"),
+						sdk.NewAttribute("key2", "value2"),
+					),
+				}
+				expEvents = sdk.Events{
+					sdk.NewEvent(types.ErrorAttributeKeyPrefix+"testevent",
+						sdk.NewAttribute(types.ErrorAttributeKeyPrefix+"key1", "value1"),
+						sdk.NewAttribute(types.ErrorAttributeKeyPrefix+"key2", "value2"),
+					),
+				}
+			},
+		},
+		{
+			"success: multiple events with attributes",
+			func() {
+				events = sdk.Events{
+					sdk.NewEvent("testevent1",
+						sdk.NewAttribute("key1", "value1"),
+						sdk.NewAttribute("key2", "value2"),
+					),
+					sdk.NewEvent("testevent2",
+						sdk.NewAttribute("key3", "value3"),
+						sdk.NewAttribute("key4", "value4"),
+					),
+				}
+				expEvents = sdk.Events{
+					sdk.NewEvent(types.ErrorAttributeKeyPrefix+"testevent1",
+						sdk.NewAttribute(types.ErrorAttributeKeyPrefix+"key1", "value1"),
+						sdk.NewAttribute(types.ErrorAttributeKeyPrefix+"key2", "value2"),
+					),
+					sdk.NewEvent(types.ErrorAttributeKeyPrefix+"testevent2",
+						sdk.NewAttribute(types.ErrorAttributeKeyPrefix+"key3", "value3"),
+						sdk.NewAttribute(types.ErrorAttributeKeyPrefix+"key4", "value4"),
+					),
+				}
+			},
+		},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			// initial events and expected events are reset so that the test fails if
+			// the malleate function does not set them
+			events = nil
+			expEvents = sdk.Events{}
+
+			tc.malleate()
+
+			newEvents := keeper.ConvertToErrorEvents(events)
+			require.Equal(t, expEvents, newEvents)
+		})
+	}
+}

--- a/modules/core/keeper/export_test.go
+++ b/modules/core/keeper/export_test.go
@@ -1,0 +1,9 @@
+package keeper
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// ConvertToErrorEvents is a wrapper around convertToErrorEvents
+// to allow the function to be directly called in tests.
+func ConvertToErrorEvents(events sdk.Events) sdk.Events {
+	return convertToErrorEvents(events)
+}

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -411,6 +411,9 @@ func (k Keeper) RecvPacket(goCtx context.Context, msg *channeltypes.MsgRecvPacke
 	if ack == nil || ack.Success() {
 		// write application state changes for asynchronous and successful acknowledgements
 		writeFn()
+	} else {
+		// Modify events in cached context to reflect unsuccessful acknowledgement
+		ctx.EventManager().EmitEvents(convertToErrorEvents(cacheCtx.EventManager().Events()))
 	}
 
 	// Set packet acknowledgement only if the acknowledgement is not nil.
@@ -631,4 +634,26 @@ func (k Keeper) Acknowledgement(goCtx context.Context, msg *channeltypes.MsgAckn
 	}()
 
 	return &channeltypes.MsgAcknowledgementResponse{Result: channeltypes.SUCCESS}, nil
+}
+
+// convertToErrorEvents converts all events to error events by appending the
+// error attribute prefix to each event's attribute key.
+func convertToErrorEvents(events sdk.Events) sdk.Events {
+	if events == nil {
+		return nil
+	}
+
+	newEvents := make(sdk.Events, len(events))
+	for i, event := range events {
+		newAttributes := make([]sdk.Attribute, len(event.Attributes))
+		for j, attribute := range event.Attributes {
+			newAttributes[j] = sdk.NewAttribute(coretypes.ErrorAttributeKeyPrefix+string(attribute.Key), string(attribute.Value))
+		}
+
+		// no need to append the error attribute prefix to the event type because
+		// the event type is not associated to a value that can be misinterpreted
+		newEvents[i] = sdk.NewEvent(coretypes.ErrorAttributeKeyPrefix+event.Type, newAttributes...)
+	}
+
+	return newEvents
 }

--- a/modules/core/types/events.go
+++ b/modules/core/types/events.go
@@ -1,0 +1,3 @@
+package types
+
+const ErrorAttributeKeyPrefix = "ibccallbackerror-"

--- a/testing/mock/events.go
+++ b/testing/mock/events.go
@@ -1,0 +1,39 @@
+package mock
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+const (
+	MockEventTypeRecvPacket    = "mock-recv-packet"
+	MockEventTypeAckPacket     = "mock-ack-packet"
+	MockEventTypeTimeoutPacket = "mock-timeout"
+
+	MockAttributeKey1 = "mock-attribute-key-1"
+	MockAttributeKey2 = "mock-attribute-key-2"
+
+	MockAttributeValue1 = "mock-attribute-value-1"
+	MockAttributeValue2 = "mock-attribute-value-2"
+)
+
+// NewMockRecvPacketEvent returns a mock receive packet event
+func NewMockRecvPacketEvent() sdk.Event {
+	return newMockEvent(MockEventTypeRecvPacket)
+}
+
+// NewMockAckPacketEvent returns a mock acknowledgement packet event
+func NewMockAckPacketEvent() sdk.Event {
+	return newMockEvent(MockEventTypeAckPacket)
+}
+
+// NewMockTimeoutPacketEvent emits a mock timeout packet event
+func NewMockTimeoutPacketEvent() sdk.Event {
+	return newMockEvent(MockEventTypeTimeoutPacket)
+}
+
+// emitMockEvent returns a mock event with the given event type
+func newMockEvent(eventType string) sdk.Event {
+	return sdk.NewEvent(
+		eventType,
+		sdk.NewAttribute(MockAttributeKey1, MockAttributeValue1),
+		sdk.NewAttribute(MockAttributeKey2, MockAttributeValue2),
+	)
+}

--- a/testing/mock/ibc_module.go
+++ b/testing/mock/ibc_module.go
@@ -121,6 +121,8 @@ func (im IBCModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, re
 		panic(err)
 	}
 
+	ctx.EventManager().EmitEvent(NewMockRecvPacketEvent())
+
 	if bytes.Equal(MockPacketData, packet.GetData()) {
 		return MockAcknowledgement
 	} else if bytes.Equal(MockAsyncPacketData, packet.GetData()) {
@@ -143,6 +145,8 @@ func (im IBCModule) OnAcknowledgementPacket(ctx sdk.Context, packet channeltypes
 		panic(err)
 	}
 
+	ctx.EventManager().EmitEvent(NewMockAckPacketEvent())
+
 	return nil
 }
 
@@ -158,6 +162,8 @@ func (im IBCModule) OnTimeoutPacket(ctx sdk.Context, packet channeltypes.Packet,
 		// must never occur
 		panic(err)
 	}
+
+	ctx.EventManager().EmitEvent(NewMockTimeoutPacketEvent())
 
 	return nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR is a cherry-pick of [#2375109](https://github.com/cosmos/ibc-go/commit/2375109ae0eea8ca5843a32470d7fd997abe2bf9#diff-3636a133c799c675b76a6ebfbdc143d6b160745dce5c20b2702564bb19dbcd9f).

The only notable diff is converting `attribute.Key` and `attribute.Value` using built-in `string()` in `convertToErrorEvents` due to the fields being `[]byte` on this version of cosmos-sdk.

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
