### PR TITLE
chore: add ProtocolVersion, Encoding and AppVersion to SendPacket and RecvPacket events.

### DIFF
--- a/modules/core/04-channel/keeper/events.go
+++ b/modules/core/04-channel/keeper/events.go
@@ -131,6 +131,9 @@ func EmitSendPacketEvent(ctx sdk.Context, packet types.Packet, channel *types.Ch
 		sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
 		sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
 		sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
+		sdk.NewAttribute(types.AttributeKeyEncoding, packet.Encoding),
+		sdk.NewAttribute(types.AttributeKeyProtocolVersion, packet.ProtocolVersion.String()),
+		sdk.NewAttribute(types.AttributeKeyAppVersion, packet.AppVersion),
 	}
 
 	if channel != nil {
@@ -167,6 +170,9 @@ func EmitRecvPacketEvent(ctx sdk.Context, packet types.Packet, channel *types.Ch
 		sdk.NewAttribute(types.AttributeKeySrcChannel, packet.GetSourceChannel()),
 		sdk.NewAttribute(types.AttributeKeyDstPort, packet.GetDestPort()),
 		sdk.NewAttribute(types.AttributeKeyDstChannel, packet.GetDestChannel()),
+		sdk.NewAttribute(types.AttributeKeyEncoding, packet.Encoding),
+		sdk.NewAttribute(types.AttributeKeyProtocolVersion, packet.ProtocolVersion.String()),
+		sdk.NewAttribute(types.AttributeKeyAppVersion, packet.AppVersion),
 	}
 
 	if channel != nil {

--- a/modules/core/04-channel/types/events.go
+++ b/modules/core/04-channel/types/events.go
@@ -42,6 +42,9 @@ const (
 	AttributeKeyDstChannel       = "packet_dst_channel"
 	AttributeKeyChannelOrdering  = "packet_channel_ordering"
 	AttributeKeyConnection       = "packet_connection"
+	AttributeKeyEncoding         = "packet_data_encoding"
+	AttributeKeyProtocolVersion  = "packet_protocol_version"
+	AttributeKeyAppVersion       = "packet_app_version"
 )
 
 // IBC channel events vars

--- a/testing/events.go
+++ b/testing/events.go
@@ -133,6 +133,17 @@ func ParsePacketsFromEvents(eventType string, events []abci.Event) ([]channeltyp
 
 					packet.TimeoutTimestamp = timestamp
 
+				case channeltypes.AttributeKeyEncoding:
+					packet.Encoding = attr.Value
+
+				case channeltypes.AttributeKeyProtocolVersion:
+					version, ok := channeltypes.IBCVersion_value[attr.Value]
+					if !ok {
+						return ferr(fmt.Errorf("invalid protocol version attribute %s", attr.Value))
+					}
+
+					packet.ProtocolVersion = channeltypes.IBCVersion(version)
+
 				default:
 					continue
 				}

--- a/testing/events.go
+++ b/testing/events.go
@@ -144,6 +144,9 @@ func ParsePacketsFromEvents(eventType string, events []abci.Event) ([]channeltyp
 
 					packet.ProtocolVersion = channeltypes.IBCVersion(version)
 
+				case channeltypes.AttributeKeyAppVersion:
+					packet.AppVersion = attr.Value
+
 				default:
 					continue
 				}

--- a/testing/events_test.go
+++ b/testing/events_test.go
@@ -61,6 +61,18 @@ func TestParsePacketsFromEvents(t *testing.T) {
 							Key:   channeltypes.AttributeKeyTimeoutTimestamp,
 							Value: "1000",
 						},
+						{
+							Key:   channeltypes.AttributeKeyEncoding,
+							Value: "json",
+						},
+						{
+							Key:   channeltypes.AttributeKeyProtocolVersion,
+							Value: "IBC_VERSION_2",
+						},
+						{
+							Key:   channeltypes.AttributeKeyAppVersion,
+							Value: "ics20-1",
+						},
 					},
 				},
 				{
@@ -117,6 +129,9 @@ func TestParsePacketsFromEvents(t *testing.T) {
 						RevisionHeight: 2,
 					},
 					TimeoutTimestamp: 1000,
+					Encoding:         "json",
+					ProtocolVersion:  channeltypes.IBC_VERSION_2,
+					AppVersion:       "ics20-1",
 				},
 				{
 					Sequence:           43,
@@ -195,6 +210,21 @@ func TestParsePacketsFromEvents(t *testing.T) {
 				},
 			},
 			expectedError: "strconv.ParseUint: parsing \"x\": invalid syntax",
+		},
+		{
+			name: "fail: event packet with invalid AttributeKeyProtocolVersion",
+			events: []abci.Event{
+				{
+					Type: channeltypes.EventTypeSendPacket,
+					Attributes: []abci.EventAttribute{
+						{
+							Key:   channeltypes.AttributeKeyProtocolVersion,
+							Value: "x",
+						},
+					},
+				},
+			},
+			expectedError: "invalid protocol version attribute",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
