### PR TITLE
V2 Packet Full Flow

### DIFF
--- a/modules/core/keeper/legacy_ack.go
+++ b/modules/core/keeper/legacy_ack.go
@@ -24,21 +24,21 @@ func NewLegacyMultiAck(cdc codec.BinaryCodec, ack exported.Acknowledgement, appN
 		RecvPacketResult: recvPacketResult,
 	})
 
-	return &legacyMultiAck{
+	return &LegacyMultiAck{
 		cdc:      cdc,
 		multiAck: multiAck,
 	}
 }
 
-type legacyMultiAck struct {
+type LegacyMultiAck struct {
 	cdc      codec.BinaryCodec
 	multiAck channeltypes.MultiAcknowledgement
 }
 
-func (l *legacyMultiAck) Acknowledgement() []byte {
+func (l *LegacyMultiAck) Acknowledgement() []byte {
 	return l.cdc.MustMarshal(&l.multiAck)
 }
 
-func (l *legacyMultiAck) Success() bool {
+func (l *LegacyMultiAck) Success() bool {
 	return l.multiAck.AcknowledgementResults[0].RecvPacketResult.Status == channeltypes.PacketStatus_Success
 }

--- a/modules/core/keeper/msg_server_test.go
+++ b/modules/core/keeper/msg_server_test.go
@@ -3374,7 +3374,7 @@ func (suite *KeeperTestSuite) TestV2PacketFlow() {
 
 	// replay should not fail since it will be treated as a no-op
 	// _, err = suite.chainB.App.GetIBCKeeper().RecvPacket(suite.chainB.GetContext(), msg)
-	//suite.Require().NoError(err)
+	// suite.Require().NoError(err)
 
 	// events := ctx.EventManager().Events()
 
@@ -3440,7 +3440,7 @@ func (suite *KeeperTestSuite) TestV2PacketFlow() {
 
 // replay should not fail since it will be treated as a no-op
 // _, err = suite.chainB.App.GetIBCKeeper().RecvPacket(suite.chainB.GetContext(), msg)
-//suite.Require().NoError(err)
+// suite.Require().NoError(err)
 
 // events := ctx.EventManager().Events()
 
@@ -3463,4 +3463,4 @@ func (suite *KeeperTestSuite) TestV2PacketFlow() {
 //	suite.Require().NoError(err)
 //	suite.Require().NotNil(ackPacketResponse)
 //
-//}
+// }

--- a/modules/core/packet-server/keeper/relay_test.go
+++ b/modules/core/packet-server/keeper/relay_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"fmt"
 	"testing"
+
 	testifysuite "github.com/stretchr/testify/suite"
 
 	clienttypes "github.com/cosmos/ibc-go/v9/modules/core/02-client/types"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR adds a test which does a full Send / Recv / Ack flow for a Packet with the protocol version specified as V2. A second commented out test which will be uncommented when we merge main and remove capabilities.

The test can be cleaned up in a followup PR and updated to be a table test in line with the other ones.

closes: #XXXX

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
