### PR TITLE
chore: Add PacketV2 ValidateBasic() function

### DIFF
--- a/modules/core/04-channel/v2/types/errors.go
+++ b/modules/core/04-channel/v2/types/errors.go
@@ -1,0 +1,11 @@
+package types
+
+import (
+	errorsmod "cosmossdk.io/errors"
+)
+
+// IBC channel sentinel errors
+var (
+	ErrInvalidPacket  = errorsmod.Register(SubModuleName, 1, "invalid packet")
+	ErrInvalidPayload = errorsmod.Register(SubModuleName, 2, "invalid payload")
+)

--- a/modules/core/04-channel/v2/types/packet.go
+++ b/modules/core/04-channel/v2/types/packet.go
@@ -10,6 +10,26 @@ import (
 	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
 )
 
+// NewPacket constructs a new packet.
+func NewPacket(sequence uint64, sourceID, destinationID string, timeoutTimestamp uint64, data ...PacketData) Packet {
+	return Packet{
+		Sequence:         sequence,
+		SourceId:         sourceID,
+		DestinationId:    destinationID,
+		TimeoutTimestamp: timeoutTimestamp,
+		Data:             data,
+	}
+}
+
+// NewPayload constructs a new Payload
+func NewPayload(version, encoding string, value []byte) Payload {
+	return Payload{
+		Version:  version,
+		Encoding: encoding,
+		Value:    value,
+	}
+}
+
 // ValidateBasic validates that a Packet satisfies the basic requirements.
 func (p Packet) ValidateBasic() error {
 	if len(p.Data) == 0 {

--- a/modules/core/04-channel/v2/types/packet.go
+++ b/modules/core/04-channel/v2/types/packet.go
@@ -2,9 +2,71 @@ package types
 
 import (
 	"crypto/sha256"
+	"strings"
+
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
 )
+
+func NewPacket(sequence uint64, sourceID, destinationID string, timeoutTimestamp uint64, data ...PacketData) Packet {
+	return Packet{
+		Sequence:         sequence,
+		SourceId:         sourceID,
+		DestinationId:    destinationID,
+		TimeoutTimestamp: timeoutTimestamp,
+		Data:             data,
+	}
+}
+
+func (p Packet) ValidateBasic() error {
+	if len(p.Data) != 1 {
+		return errorsmod.Wrapf(ErrInvalidPacket, "packet data length must be 1, got %d", len(p.Data))
+	}
+
+	for _, pd := range p.Data {
+		if err := host.PortIdentifierValidator(pd.SourcePort); err != nil {
+			return errorsmod.Wrap(err, "invalid source port ID")
+		}
+		if err := host.PortIdentifierValidator(pd.DestinationPort); err != nil {
+			return errorsmod.Wrap(err, "invalid destination port ID")
+		}
+		if err := pd.Payload.Validate(); err != nil {
+			return err
+		}
+	}
+
+	if err := host.ChannelIdentifierValidator(p.SourceId); err != nil {
+		return errorsmod.Wrap(err, "invalid source channel ID")
+	}
+	if err := host.ChannelIdentifierValidator(p.DestinationId); err != nil {
+		return errorsmod.Wrap(err, "invalid destination channel ID")
+	}
+
+	if p.Sequence == 0 {
+		return errorsmod.Wrap(ErrInvalidPacket, "packet sequence cannot be 0")
+	}
+	if p.TimeoutTimestamp == 0 {
+		return errorsmod.Wrap(ErrInvalidPacket, "packet timeout timestamp cannot be 0")
+	}
+
+	return nil
+}
+
+// Validate validates a  Payload.
+func (p Payload) Validate() error {
+	if strings.TrimSpace(p.Version) == "" {
+		return errorsmod.Wrap(ErrInvalidPayload, "payload version cannot be empty")
+	}
+	if strings.TrimSpace(p.Encoding) == "" {
+		return errorsmod.Wrap(ErrInvalidPayload, "payload encoding cannot be empty")
+	}
+	if len(p.Value) == 0 {
+		return errorsmod.Wrap(ErrInvalidPayload, "payload value cannot be empty")
+	}
+	return nil
+}
 
 // CommitPacket returns the V2 packet commitment bytes. The commitment consists of:
 // sha256_hash(timeout) + sha256_hash(destinationID) + sha256_hash(packetData) from a given packet.

--- a/modules/core/04-channel/v2/types/packet.go
+++ b/modules/core/04-channel/v2/types/packet.go
@@ -10,16 +10,6 @@ import (
 	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
 )
 
-func NewPacket(sequence uint64, sourceID, destinationID string, timeoutTimestamp uint64, data ...PacketData) Packet {
-	return Packet{
-		Sequence:         sequence,
-		SourceId:         sourceID,
-		DestinationId:    destinationID,
-		TimeoutTimestamp: timeoutTimestamp,
-		Data:             data,
-	}
-}
-
 func (p Packet) ValidateBasic() error {
 	if len(p.Data) != 1 {
 		return errorsmod.Wrapf(ErrInvalidPacket, "packet data length must be 1, got %d", len(p.Data))

--- a/modules/core/04-channel/v2/types/packet.go
+++ b/modules/core/04-channel/v2/types/packet.go
@@ -38,14 +38,8 @@ func (p Packet) ValidateBasic() error {
 	}
 
 	for _, pd := range p.Data {
-		if err := host.PortIdentifierValidator(pd.SourcePort); err != nil {
-			return errorsmod.Wrap(err, "invalid source port ID")
-		}
-		if err := host.PortIdentifierValidator(pd.DestinationPort); err != nil {
-			return errorsmod.Wrap(err, "invalid destination port ID")
-		}
-		if err := pd.Payload.Validate(); err != nil {
-			return err
+		if err := pd.ValidateBasic(); err != nil {
+			return errorsmod.Wrap(err, "invalid Packet Data")
 		}
 	}
 
@@ -63,6 +57,20 @@ func (p Packet) ValidateBasic() error {
 		return errorsmod.Wrap(ErrInvalidPacket, "packet timeout timestamp cannot be 0")
 	}
 
+	return nil
+}
+
+// ValidateBasic validates a PacketData
+func (p PacketData) ValidateBasic() error {
+	if err := host.PortIdentifierValidator(p.SourcePort); err != nil {
+		return errorsmod.Wrap(err, "invalid source port ID")
+	}
+	if err := host.PortIdentifierValidator(p.DestinationPort); err != nil {
+		return errorsmod.Wrap(err, "invalid destination port ID")
+	}
+	if err := p.Payload.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/modules/core/04-channel/v2/types/packet.go
+++ b/modules/core/04-channel/v2/types/packet.go
@@ -7,6 +7,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
 )
 

--- a/modules/core/04-channel/v2/types/packet.go
+++ b/modules/core/04-channel/v2/types/packet.go
@@ -10,9 +10,10 @@ import (
 	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
 )
 
+// ValidateBasic validates that a Packet satisfies the basic requirements.
 func (p Packet) ValidateBasic() error {
-	if len(p.Data) != 1 {
-		return errorsmod.Wrapf(ErrInvalidPacket, "packet data length must be 1, got %d", len(p.Data))
+	if len(p.Data) == 0 {
+		return errorsmod.Wrap(ErrInvalidPacket, "packet data must not be empty")
 	}
 
 	for _, pd := range p.Data {
@@ -44,7 +45,7 @@ func (p Packet) ValidateBasic() error {
 	return nil
 }
 
-// Validate validates a  Payload.
+// Validate validates a Payload.
 func (p Payload) Validate() error {
 	if strings.TrimSpace(p.Version) == "" {
 		return errorsmod.Wrap(ErrInvalidPayload, "payload version cannot be empty")

--- a/modules/core/04-channel/v2/types/packet_test.go
+++ b/modules/core/04-channel/v2/types/packet_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
 	"github.com/cosmos/ibc-go/v9/testing/mock"
-	"github.com/stretchr/testify/require"
 )
 
 // TestValidate tests the Validate function of Packet

--- a/modules/core/04-channel/v2/types/packet_test.go
+++ b/modules/core/04-channel/v2/types/packet_test.go
@@ -1,4 +1,4 @@
-package types
+package types_test
 
 import (
 	"testing"
@@ -6,7 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cosmos/ibc-go/v9/modules/core/04-channel/v2/types"
 	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
+	ibctesting "github.com/cosmos/ibc-go/v9/testing"
 	"github.com/cosmos/ibc-go/v9/testing/mock"
 )
 
@@ -14,28 +16,28 @@ import (
 func TestValidate(t *testing.T) {
 	testCases := []struct {
 		name    string
-		payload Payload
+		payload types.Payload
 		expErr  error
 	}{
 		{
 			"success",
-			NewPayload("ics20-v1", "json", mock.MockPacketData),
+			types.NewPayload("ics20-v1", "json", mock.MockPacketData),
 			nil,
 		},
 		{
 			"failure: empty version",
-			NewPayload("", "json", mock.MockPacketData),
-			ErrInvalidPayload,
+			types.NewPayload("", "json", mock.MockPacketData),
+			types.ErrInvalidPayload,
 		},
 		{
 			"failure: empty encoding",
-			NewPayload("ics20-v2", "", mock.MockPacketData),
-			ErrInvalidPayload,
+			types.NewPayload("ics20-v2", "", mock.MockPacketData),
+			types.ErrInvalidPayload,
 		},
 		{
 			"failure: empty value",
-			NewPayload("ics20-v1", "json", []byte{}),
-			ErrInvalidPayload,
+			types.NewPayload("ics20-v1", "json", []byte{}),
+			types.ErrInvalidPayload,
 		},
 	}
 	for _, tc := range testCases {
@@ -52,7 +54,7 @@ func TestValidate(t *testing.T) {
 
 // TestValidateBasic tests the ValidateBasic functio of Packet
 func TestValidateBasic(t *testing.T) {
-	var packet Packet
+	var packet types.Packet
 	testCases := []struct {
 		name     string
 		malleate func()
@@ -66,9 +68,9 @@ func TestValidateBasic(t *testing.T) {
 		{
 			"failure: empty data",
 			func() {
-				packet.Data = []PacketData{}
+				packet.Data = []types.PacketData{}
 			},
-			ErrInvalidPacket,
+			types.ErrInvalidPacket,
 		},
 		{
 			"failure: invalid data source port ID",
@@ -103,24 +105,24 @@ func TestValidateBasic(t *testing.T) {
 			func() {
 				packet.Sequence = 0
 			},
-			ErrInvalidPacket,
+			types.ErrInvalidPacket,
 		},
 		{
 			"failure: invalid timestamp",
 			func() {
 				packet.TimeoutTimestamp = 0
 			},
-			ErrInvalidPacket,
+			types.ErrInvalidPacket,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			packet = NewPacket(1, "sourceChannelID", "destChannelID", uint64(time.Now().Unix()), PacketData{
-				SourcePort:      "sourcePort",
-				DestinationPort: "destPort",
-				Payload: Payload{
+			packet = types.NewPacket(1, ibctesting.FirstClientID, ibctesting.FirstClientID, uint64(time.Now().Unix()), types.PacketData{
+				SourcePort:      ibctesting.MockPort,
+				DestinationPort: ibctesting.MockPort,
+				Payload: types.Payload{
 					Version:  "ics20-v2",
-					Encoding: "encoding",
+					Encoding: "json",
 					Value:    mock.MockPacketData,
 				},
 			})

--- a/modules/core/04-channel/v2/types/packet_test.go
+++ b/modules/core/04-channel/v2/types/packet_test.go
@@ -1,0 +1,137 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
+	"github.com/cosmos/ibc-go/v9/testing/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidate tests the Validate function of Packet
+func TestValidate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		payload Payload
+		expErr  error
+	}{
+		{
+			"success",
+			NewPayload("ics20-v1", "json", mock.MockPacketData),
+			nil,
+		},
+		{
+			"failure: empty version",
+			NewPayload("", "json", mock.MockPacketData),
+			ErrInvalidPayload,
+		},
+		{
+			"failure: empty encoding",
+			NewPayload("ics20-v2", "", mock.MockPacketData),
+			ErrInvalidPayload,
+		},
+		{
+			"failure: empty value",
+			NewPayload("ics20-v1", "json", []byte{}),
+			ErrInvalidPayload,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.payload.Validate()
+			if tc.expErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expErr)
+			}
+		})
+	}
+}
+
+// TestValidateBasic tests the ValidateBasic functio of Packet
+func TestValidateBasic(t *testing.T) {
+	var packet Packet
+	testCases := []struct {
+		name     string
+		malleate func()
+		expErr   error
+	}{
+		{
+			"success",
+			func() {},
+			nil,
+		},
+		{
+			"failure: empty data",
+			func() {
+				packet.Data = []PacketData{}
+			},
+			ErrInvalidPacket,
+		},
+		{
+			"failure: invalid data source port ID",
+			func() {
+				packet.Data[0].SourcePort = ""
+			},
+			host.ErrInvalidID,
+		},
+		{
+			"failure: invalid data dest port ID",
+			func() {
+				packet.Data[0].DestinationPort = ""
+			},
+			host.ErrInvalidID,
+		},
+		{
+			"failure: invalid source channel ID",
+			func() {
+				packet.SourceId = ""
+			},
+			host.ErrInvalidID,
+		},
+		{
+			"failure: invalid dest channel ID",
+			func() {
+				packet.DestinationId = ""
+			},
+			host.ErrInvalidID,
+		},
+		{
+			"failure: invalid sequence",
+			func() {
+				packet.Sequence = 0
+			},
+			ErrInvalidPacket,
+		},
+		{
+			"failure: invalid timestamp",
+			func() {
+				packet.TimeoutTimestamp = 0
+			},
+			ErrInvalidPacket,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			packet = NewPacket(1, "sourceChannelID", "destChannelID", uint64(time.Now().Unix()), PacketData{
+				SourcePort:      "sourcePort",
+				DestinationPort: "destPort",
+				Payload: Payload{
+					Version:  "ics20-v2",
+					Encoding: "encoding",
+					Value:    mock.MockPacketData,
+				},
+			})
+
+			tc.malleate()
+
+			err := packet.ValidateBasic()
+			if tc.expErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #7385 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
