### PR TITLE
chore: add cli/tx for create channel.

### DIFF
--- a/modules/core/04-channel/v2/client/cli/cli.go
+++ b/modules/core/04-channel/v2/client/cli/cli.go
@@ -36,7 +36,8 @@ func NewTxCmd() *cobra.Command {
 	}
 
 	txCmd.AddCommand(
-		newProvideCounterpartyCmd(),
+		newCreateChannelTxCmd(),
+		newProvideCounterpartyTxCmd(),
 	)
 
 	return txCmd

--- a/modules/core/04-channel/v2/client/cli/tx.go
+++ b/modules/core/04-channel/v2/client/cli/tx.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -11,11 +13,42 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 
 	"github.com/cosmos/ibc-go/v9/modules/core/04-channel/v2/types"
+	commitmenttypesv2 "github.com/cosmos/ibc-go/v9/modules/core/23-commitment/types/v2"
 	"github.com/cosmos/ibc-go/v9/modules/core/exported"
 )
 
+// newCreateChannelTxCmd defines the command to create an IBC channel/v2.
+func newCreateChannelTxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "create-channel [client-identifier] [merkle-path-prefix]",
+		Args:    cobra.ExactArgs(2),
+		Short:   "create an IBC channel/v2",
+		Long:    `Creates an IBC channel/v2 using the client identifier representing the counterparty chain and the hex-encoded merkle path prefix under which the counterparty stores packet flow information.`,
+		Example: fmt.Sprintf("%s tx %s %s create-channel 07-tendermint-0 696263,657572656b61", version.AppName, exported.ModuleName, types.SubModuleName),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			clientID := args[0]
+			merklePathPrefix, err := parseMerklePathPrefix(args[2])
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgCreateChannel(clientID, merklePathPrefix, clientCtx.GetFromAddress().String())
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
 // newProvideCounterpartyCmd defines the command to provide the counterparty channel identifier to an IBC channel.
-func newProvideCounterpartyCmd() *cobra.Command {
+func newProvideCounterpartyTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "provide-counterparty [channel-identifier] [counterparty-channel-identifier]",
 		Args:    cobra.ExactArgs(2),
@@ -42,4 +75,19 @@ func newProvideCounterpartyCmd() *cobra.Command {
 
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
+}
+
+// parseMerklePathPrefix parses a comma-separated list of hex-encoded strings into a MerklePath.
+func parseMerklePathPrefix(merklePathPrefixString string) (commitmenttypesv2.MerklePath, error) {
+	var keyPath [][]byte
+	hexPrefixes := strings.Split(merklePathPrefixString, ",")
+	for _, hexPrefix := range hexPrefixes {
+		prefix, err := hex.DecodeString(hexPrefix)
+		if err != nil {
+			return commitmenttypesv2.MerklePath{}, fmt.Errorf("invalid hex merkle path prefix: %w", err)
+		}
+		keyPath = append(keyPath, prefix)
+	}
+
+	return commitmenttypesv2.MerklePath{KeyPath: keyPath}, nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #7425

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
