### PR TITLE
Add helper functions for MsgSendPacket, MsgRecvPacket and MsgAcknowledgePacket

### DIFF
--- a/modules/core/04-channel/v2/keeper/msg_server_test.go
+++ b/modules/core/04-channel/v2/keeper/msg_server_test.go
@@ -334,6 +334,7 @@ func (suite *KeeperTestSuite) TestMsgAcknowledgement() {
 	var (
 		path   *ibctesting.Path
 		packet channeltypesv2.Packet
+		ack    channeltypesv2.Acknowledgement
 	)
 	testCases := []struct {
 		name     string
@@ -380,6 +381,13 @@ func (suite *KeeperTestSuite) TestMsgAcknowledgement() {
 			},
 			expError: channeltypesv2.ErrInvalidPacket,
 		},
+		{
+			name: "failure: failed membership verification",
+			malleate: func() {
+				ack.AcknowledgementResults[0].RecvPacketResult.Acknowledgement = mock.MockFailPacketData
+			},
+			expError: errors.New("failed packet acknowledgement verification"),
+		},
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
@@ -399,7 +407,7 @@ func (suite *KeeperTestSuite) TestMsgAcknowledgement() {
 			suite.Require().NoError(err)
 
 			// Construct expected acknowledgement
-			ack := channeltypesv2.Acknowledgement{
+			ack = channeltypesv2.Acknowledgement{
 				AcknowledgementResults: []channeltypesv2.AcknowledgementResult{
 					{
 						AppName: mockv2.ModuleNameB,

--- a/modules/core/04-channel/v2/keeper/msg_server_test.go
+++ b/modules/core/04-channel/v2/keeper/msg_server_test.go
@@ -122,7 +122,6 @@ func (suite *KeeperTestSuite) TestMsgSendPacket() {
 func (suite *KeeperTestSuite) TestMsgRecvPacket() {
 	var (
 		path        *ibctesting.Path
-		msg         *channeltypesv2.MsgRecvPacket
 		packet      channeltypesv2.Packet
 		expectedAck channeltypesv2.Acknowledgement
 	)
@@ -223,21 +222,13 @@ func (suite *KeeperTestSuite) TestMsgRecvPacket() {
 
 			tc.malleate()
 
-			// get proof of packet commitment from chainA
-			packetKey := hostv2.PacketCommitmentKey(packet.SourceChannel, packet.Sequence)
-			proof, proofHeight := path.EndpointA.QueryProof(packetKey)
-
-			msg = channeltypesv2.NewMsgRecvPacket(packet, proof, proofHeight, suite.chainB.SenderAccount.GetAddress().String())
-
-			res, err := path.EndpointB.Chain.SendMsgs(msg)
-			suite.Require().NoError(path.EndpointA.UpdateClient())
+			err = path.EndpointB.MsgRecvPacket(packet)
 
 			ck := path.EndpointB.Chain.GetSimApp().IBCKeeper.ChannelKeeperV2
 
 			expPass := tc.expError == nil
 			if expPass {
 				suite.Require().NoError(err)
-				suite.Require().NotNil(res)
 
 				// packet receipt should be written
 				_, ok := ck.GetPacketReceipt(path.EndpointB.Chain.GetContext(), packet.SourceChannel, packet.Sequence)

--- a/testing/endpoint_v2.go
+++ b/testing/endpoint_v2.go
@@ -47,7 +47,9 @@ func (endpoint *Endpoint) MsgRecvPacket(packet channeltypesv2.Packet) error {
 func (endpoint *Endpoint) MsgAcknowledgePacket(packet channeltypesv2.Packet, ack channeltypesv2.Acknowledgement) error {
 	packetKey := hostv2.PacketAcknowledgementKey(packet.DestinationChannel, packet.Sequence)
 	proof, proofHeight := endpoint.Counterparty.QueryProof(packetKey)
+
 	msg := channeltypesv2.NewMsgAcknowledgement(packet, ack, proof, proofHeight, endpoint.Chain.SenderAccount.GetAddress().String())
+
 	if err := endpoint.Chain.sendMsgs(msg); err != nil {
 		return err
 	}

--- a/testing/endpoint_v2.go
+++ b/testing/endpoint_v2.go
@@ -1,0 +1,49 @@
+package ibctesting
+
+import (
+	channeltypesv2 "github.com/cosmos/ibc-go/v9/modules/core/04-channel/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// MsgSendPacket sends a packet on the associated endpoint. The constructed packet is returned.
+func (endpoint *Endpoint) MsgSendPacket(timeoutTimestamp uint64, packetData channeltypesv2.PacketData) (channeltypesv2.Packet, error) {
+	msgSendPacket := channeltypesv2.NewMsgSendPacket(endpoint.ChannelID, timeoutTimestamp, endpoint.Chain.SenderAccount.GetAddress().String(), packetData)
+
+	_, err := endpoint.Chain.SendMsgs(msgSendPacket)
+	if err != nil {
+		return channeltypesv2.Packet{}, err
+	}
+
+	if err := endpoint.Counterparty.UpdateClient(); err != nil {
+		return channeltypesv2.Packet{}, err
+	}
+
+	// TODO: parse the packet from events instead of manually constructing it. https://github.com/cosmos/ibc-go/issues/7459
+	nextSequenceSend, ok := endpoint.Chain.GetSimApp().IBCKeeper.ChannelKeeperV2.GetNextSequenceSend(endpoint.Chain.GetContext(), endpoint.ChannelID)
+	require.True(endpoint.Chain.TB, ok)
+	packet := channeltypesv2.NewPacket(nextSequenceSend-1, endpoint.ChannelID, endpoint.Counterparty.ChannelID, timeoutTimestamp, packetData)
+
+	return packet, nil
+}
+
+//// RecvPacketWithResult receives a packet on the associated endpoint and the result
+//// of the transaction is returned. The counterparty client is updated.
+//func (endpoint *Endpoint) RecvPacketWithResult(packet channeltypes.Packet) (*abci.ExecTxResult, error) {
+//	// get proof of packet commitment on source
+//	packetKey := host.PacketCommitmentKey(packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+//	proof, proofHeight := endpoint.Counterparty.Chain.QueryProof(packetKey)
+//
+//	recvMsg := channeltypes.NewMsgRecvPacket(packet, proof, proofHeight, endpoint.Chain.SenderAccount.GetAddress().String())
+//
+//	// receive on counterparty and update source client
+//	res, err := endpoint.Chain.SendMsgs(recvMsg)
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	if err := endpoint.Counterparty.UpdateClient(); err != nil {
+//		return nil, err
+//	}
+//
+//	return res, nil
+//}

--- a/testing/endpoint_v2.go
+++ b/testing/endpoint_v2.go
@@ -43,7 +43,7 @@ func (endpoint *Endpoint) MsgRecvPacket(packet channeltypesv2.Packet) error {
 	return endpoint.Counterparty.UpdateClient()
 }
 
-// MsgAcknowledgePacket
+// MsgAcknowledgePacket sends a MsgAcknowledgement on the associated endpoint with the provided packet and ack.
 func (endpoint *Endpoint) MsgAcknowledgePacket(packet channeltypesv2.Packet, ack channeltypesv2.Acknowledgement) error {
 	packetKey := hostv2.PacketAcknowledgementKey(packet.DestinationChannel, packet.Sequence)
 	proof, proofHeight := endpoint.Counterparty.QueryProof(packetKey)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

ref: #7459

This PR adds helper functions for MsgSendPacket, MsgRecvPacket and MsgAcknowledgePacket and refactors the associated tests.

The referenced issue has additional items so it won't be closed until those are all checked off.

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
