### PR TITLE
chore: add ValidateBasic for MsgTimeout in ChannelKeeper V2

### DIFF
--- a/modules/core/04-channel/v2/types/msgs.go
+++ b/modules/core/04-channel/v2/types/msgs.go
@@ -22,6 +22,9 @@ var (
 
 	_ sdk.Msg              = (*MsgRecvPacket)(nil)
 	_ sdk.HasValidateBasic = (*MsgRecvPacket)(nil)
+
+	_ sdk.Msg              = (*MsgTimeout)(nil)
+	_ sdk.HasValidateBasic = (*MsgTimeout)(nil)
 )
 
 // NewMsgProvideCounterparty creates a new MsgProvideCounterparty instance
@@ -157,4 +160,18 @@ func NewMsgTimeout(packet Packet, proofUnreceived []byte, proofHeight clienttype
 		ProofHeight:     proofHeight,
 		Signer:          signer,
 	}
+}
+
+// ValidateBasic performs basic checks on a MsgTimeout
+func (msg *MsgTimeout) ValidateBasic() error {
+	if len(msg.ProofUnreceived) == 0 {
+		return errorsmod.Wrap(commitmenttypesv1.ErrInvalidProof, "proof unreceived can not be empty")
+	}
+
+	_, err := sdk.AccAddressFromBech32(msg.Signer)
+	if err != nil {
+		return errorsmod.Wrapf(ibcerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
+	}
+
+	return msg.Packet.ValidateBasic()
 }

--- a/modules/core/04-channel/v2/types/msgs_test.go
+++ b/modules/core/04-channel/v2/types/msgs_test.go
@@ -268,3 +268,59 @@ func (s *TypesTestSuite) TestMsgRecvPacketValidateBasic() {
 		})
 	}
 }
+
+func (s *TypesTestSuite) TestMsgAcknowledge_ValidateBasic() {
+	var msg *types.MsgTimeout
+
+	testCases := []struct {
+		name     string
+		malleate func()
+		expError error
+	}{
+		{
+			name:     "success",
+			malleate: func() {},
+		},
+		{
+			name: "failure: invalid signer",
+			malleate: func() {
+				msg.Signer = ""
+			},
+			expError: ibcerrors.ErrInvalidAddress,
+		},
+		{
+			name: "failure: invalid packet",
+			malleate: func() {
+				msg.Packet.Sequence = 0
+			},
+			expError: types.ErrInvalidPacket,
+		},
+		{
+			name: "failure: invalid proof unreceived",
+			malleate: func() {
+				msg.ProofUnreceived = []byte{}
+			},
+			expError: commitmenttypes.ErrInvalidProof,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			msg = types.NewMsgTimeout(
+				types.NewPacket(1, ibctesting.FirstChannelID, ibctesting.SecondChannelID, s.chainA.GetTimeoutTimestamp(), mockv2.NewMockPacketData(mockv2.ModuleNameA, mockv2.ModuleNameB)),
+				testProof,
+				clienttypes.ZeroHeight(),
+				s.chainA.SenderAccount.GetAddress().String(),
+			)
+
+			tc.malleate()
+
+			err := msg.ValidateBasic()
+			expPass := tc.expError == nil
+			if expPass {
+				s.Require().NoError(err)
+			} else {
+				ibctesting.RequireErrorIsOrContains(s.T(), err, tc.expError)
+			}
+		})
+	}
+}

--- a/modules/core/04-channel/v2/types/msgs_test.go
+++ b/modules/core/04-channel/v2/types/msgs_test.go
@@ -326,8 +326,7 @@ func (s *TypesTestSuite) TestMsgAcknowledge_ValidateBasic() {
 	}
 }
 
-
-func (s *TypesTestSuite) TestMsgAcknowledge_ValidateBasic() {
+func (s *TypesTestSuite) TestMsgTimeoutValidateBasic() {
 	var msg *types.MsgTimeout
 
 	testCases := []struct {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #7466

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
