### PR TITLE
chore: remove fallback logic for GetChannel in timeout handler

### DIFF
--- a/modules/core/04-channel/v2/keeper/packet.go
+++ b/modules/core/04-channel/v2/keeper/packet.go
@@ -288,7 +288,7 @@ func (k *Keeper) timeoutPacket(
 	// that the packet was indeed sent by our counterparty.
 	channel, ok := k.GetChannel(ctx, packet.SourceChannel)
 	if !ok {
-		return errorsmod.Wrap(types.ErrChannelNotFound, packet.DestinationChannel)
+		return errorsmod.Wrap(types.ErrChannelNotFound, packet.SourceChannel)
 	}
 	if channel.CounterpartyChannelId != packet.DestinationChannel {
 		return errorsmod.Wrapf(channeltypes.ErrInvalidChannelIdentifier, "counterparty channel id (%s) does not match packet destination channel id (%s)", channel.CounterpartyChannelId, packet.DestinationChannel)

--- a/modules/core/04-channel/v2/keeper/packet.go
+++ b/modules/core/04-channel/v2/keeper/packet.go
@@ -288,11 +288,7 @@ func (k *Keeper) timeoutPacket(
 	// that the packet was indeed sent by our counterparty.
 	channel, ok := k.GetChannel(ctx, packet.SourceChannel)
 	if !ok {
-		// TODO: figure out how aliasing will work when more than one payload is sent.
-		channel, ok = k.convertV1Channel(ctx, packet.Payloads[0].SourcePort, packet.SourceChannel)
-		if !ok {
-			return errorsmod.Wrap(types.ErrChannelNotFound, packet.DestinationChannel)
-		}
+		return errorsmod.Wrap(types.ErrChannelNotFound, packet.DestinationChannel)
 	}
 	if channel.CounterpartyChannelId != packet.DestinationChannel {
 		return errorsmod.Wrapf(channeltypes.ErrInvalidChannelIdentifier, "counterparty channel id (%s) does not match packet destination channel id (%s)", channel.CounterpartyChannelId, packet.DestinationChannel)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #7488

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
