### PR TITLE
Add MaxTimeout condition

### DIFF
--- a/modules/core/04-channel/v2/keeper/msg_server_test.go
+++ b/modules/core/04-channel/v2/keeper/msg_server_test.go
@@ -117,12 +117,30 @@ func (suite *KeeperTestSuite) TestMsgSendPacket() {
 			expError: nil,
 		},
 		{
+			name: "success: valid timeout timestamp",
+			malleate: func() {
+				// ensure a message timeout.
+				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + channeltypesv2.MaxTimeout - 10
+				expectedPacket = channeltypesv2.NewPacket(1, path.EndpointA.ChannelID, path.EndpointB.ChannelID, timeoutTimestamp, payload)
+
+			},
+			expError: nil,
+		},
+		{
 			name: "failure: timeout elapsed",
 			malleate: func() {
 				// ensure a message timeout.
 				timeoutTimestamp = uint64(1)
 			},
 			expError: channeltypesv1.ErrTimeoutElapsed,
+		},
+		{
+			name: "failure: timeout timestamp exceeds max allowed input",
+			malleate: func() {
+				// ensure message timeout exceeds max allowed input.
+				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + channeltypesv2.MaxTimeout + 10
+			},
+			expError: channeltypesv2.ErrInvalidTimeout,
 		},
 		{
 			name: "failure: inactive client",

--- a/modules/core/04-channel/v2/keeper/msg_server_test.go
+++ b/modules/core/04-channel/v2/keeper/msg_server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -120,7 +121,7 @@ func (suite *KeeperTestSuite) TestMsgSendPacket() {
 			name: "success: valid timeout timestamp",
 			malleate: func() {
 				// ensure a message timeout.
-				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + channeltypesv2.MaxTimeoutDelta - 10
+				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Add(channeltypesv2.MaxTimeoutDelta - 10*time.Second).Unix())
 				expectedPacket = channeltypesv2.NewPacket(1, path.EndpointA.ChannelID, path.EndpointB.ChannelID, timeoutTimestamp, payload)
 			},
 			expError: nil,
@@ -137,7 +138,7 @@ func (suite *KeeperTestSuite) TestMsgSendPacket() {
 			name: "failure: timeout timestamp exceeds max allowed input",
 			malleate: func() {
 				// ensure message timeout exceeds max allowed input.
-				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + channeltypesv2.MaxTimeoutDelta + 10
+				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Add(channeltypesv2.MaxTimeoutDelta + 10*time.Second).Unix())
 			},
 			expError: channeltypesv2.ErrMaxTimeoutDeltaExceeded,
 		},

--- a/modules/core/04-channel/v2/keeper/msg_server_test.go
+++ b/modules/core/04-channel/v2/keeper/msg_server_test.go
@@ -120,7 +120,7 @@ func (suite *KeeperTestSuite) TestMsgSendPacket() {
 			name: "success: valid timeout timestamp",
 			malleate: func() {
 				// ensure a message timeout.
-				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + channeltypesv2.MaxTimeout - 10
+				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + channeltypesv2.MaxTimeoutDelta - 10
 				expectedPacket = channeltypesv2.NewPacket(1, path.EndpointA.ChannelID, path.EndpointB.ChannelID, timeoutTimestamp, payload)
 			},
 			expError: nil,
@@ -137,9 +137,17 @@ func (suite *KeeperTestSuite) TestMsgSendPacket() {
 			name: "failure: timeout timestamp exceeds max allowed input",
 			malleate: func() {
 				// ensure message timeout exceeds max allowed input.
-				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + channeltypesv2.MaxTimeout + 10
+				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + channeltypesv2.MaxTimeoutDelta + 10
 			},
-			expError: channeltypesv2.ErrInvalidTimeout,
+			expError: channeltypesv2.ErrMaxTimeoutDeltaExceeded,
+		},
+		{
+			name: "failure: timeout timestamp less than current block timestamp",
+			malleate: func() {
+				// ensure message timeout exceeds max allowed input.
+				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) - 1
+			},
+			expError: channeltypesv2.ErrTimeoutTooLow,
 		},
 		{
 			name: "failure: inactive client",

--- a/modules/core/04-channel/v2/keeper/msg_server_test.go
+++ b/modules/core/04-channel/v2/keeper/msg_server_test.go
@@ -122,7 +122,6 @@ func (suite *KeeperTestSuite) TestMsgSendPacket() {
 				// ensure a message timeout.
 				timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + channeltypesv2.MaxTimeout - 10
 				expectedPacket = channeltypesv2.NewPacket(1, path.EndpointA.ChannelID, path.EndpointB.ChannelID, timeoutTimestamp, payload)
-
 			},
 			expError: nil,
 		},

--- a/modules/core/04-channel/v2/types/errors.go
+++ b/modules/core/04-channel/v2/types/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrInvalidAcknowledgement   = errorsmod.Register(SubModuleName, 7, "invalid acknowledgement")
 	ErrPacketCommitmentNotFound = errorsmod.Register(SubModuleName, 8, "packet commitment not found")
 	ErrAcknowledgementNotFound  = errorsmod.Register(SubModuleName, 9, "packet acknowledgement not found")
+	ErrInvalidTimeout           = errorsmod.Register(SubModuleName, 10, "invalid channel")
 )

--- a/modules/core/04-channel/v2/types/errors.go
+++ b/modules/core/04-channel/v2/types/errors.go
@@ -13,5 +13,6 @@ var (
 	ErrInvalidAcknowledgement   = errorsmod.Register(SubModuleName, 7, "invalid acknowledgement")
 	ErrPacketCommitmentNotFound = errorsmod.Register(SubModuleName, 8, "packet commitment not found")
 	ErrAcknowledgementNotFound  = errorsmod.Register(SubModuleName, 9, "packet acknowledgement not found")
-	ErrInvalidTimeout           = errorsmod.Register(SubModuleName, 10, "timeout exceeds max allowed value")
+	ErrMaxTimeoutDeltaExceeded  = errorsmod.Register(SubModuleName, 10, "timeoutTimestamp exceeds max allowed value")
+	ErrTimeoutTooLow            = errorsmod.Register(SubModuleName, 11, "timeoutTimestamp is less than current block timestamp")
 )

--- a/modules/core/04-channel/v2/types/errors.go
+++ b/modules/core/04-channel/v2/types/errors.go
@@ -13,5 +13,5 @@ var (
 	ErrInvalidAcknowledgement   = errorsmod.Register(SubModuleName, 7, "invalid acknowledgement")
 	ErrPacketCommitmentNotFound = errorsmod.Register(SubModuleName, 8, "packet commitment not found")
 	ErrAcknowledgementNotFound  = errorsmod.Register(SubModuleName, 9, "packet acknowledgement not found")
-	ErrInvalidTimeout           = errorsmod.Register(SubModuleName, 10, "invalid channel")
+	ErrInvalidTimeout           = errorsmod.Register(SubModuleName, 10, "timeout exceeds max allowed value")
 )

--- a/modules/core/04-channel/v2/types/msgs.go
+++ b/modules/core/04-channel/v2/types/msgs.go
@@ -13,6 +13,8 @@ import (
 	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
 )
 
+const MaxTimeout uint64 = 86400 // 24h in seconds
+
 var (
 	_ sdk.Msg              = (*MsgCreateChannel)(nil)
 	_ sdk.HasValidateBasic = (*MsgCreateChannel)(nil)

--- a/modules/core/04-channel/v2/types/msgs.go
+++ b/modules/core/04-channel/v2/types/msgs.go
@@ -13,7 +13,7 @@ import (
 	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
 )
 
-const MaxTimeout uint64 = 86400 // 24h in seconds
+const MaxTimeoutDelta uint64 = 24 * 60 * 60 // 24h in seconds
 
 var (
 	_ sdk.Msg              = (*MsgCreateChannel)(nil)

--- a/modules/core/04-channel/v2/types/msgs.go
+++ b/modules/core/04-channel/v2/types/msgs.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"time"
+
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,7 +15,7 @@ import (
 	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
 )
 
-const MaxTimeoutDelta uint64 = 24 * 60 * 60 // 24h in seconds
+const MaxTimeoutDelta time.Duration = 24 * time.Hour
 
 var (
 	_ sdk.Msg              = (*MsgCreateChannel)(nil)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Add MaxTimeout condition in the SendPacket function as specified in [004](https://github.com/cosmos/ibc/blob/d234b5be813f412f8fb47e234ccb1d542f0995a6/spec/core/v2/ics-004-channel-and-packet-semantics/README.md#:~:text=//%20disallow%20packet%20with%20timeoutTimestamp%20less%20than%20currentTimestamp%20and%20timeoutTimestamp%20value%20bigger%20than%20currentTimestamp%20%2B%20MaxTimeoutDelta%20%0A%20%20%20%20assert(currentTimestamp()%20%3C%20timeoutTimestamp%20%3C%20currentTimestamp()%20%2B%20MAX_TIMEOUT_DELTA))


closes: https://github.com/cosmos/ibc-go/issues/7337

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
