### PR TITLE
Ignore files with no tests when searching for test files

### DIFF
--- a/cmd/build_test_matrix/main.go
+++ b/cmd/build_test_matrix/main.go
@@ -112,7 +112,7 @@ func getGithubActionMatrixForTests(e2eRootDirectory, testName string, suite stri
 
 		suiteNameForFile, testCases, err := extractSuiteAndTestNames(f)
 		if err != nil {
-			return fmt.Errorf("failed extracting test suite name and test cases: %s", err)
+			return nil
 		}
 
 		if testName != "" && contains(testName, testCases) {
@@ -145,6 +145,11 @@ func getGithubActionMatrixForTests(e2eRootDirectory, testName string, suite stri
 			})
 		}
 	}
+
+	if len(gh.Include) == 0 {
+		return GithubActionTestMatrix{}, fmt.Errorf("no test cases found")
+	}
+
 	// Sort the test cases by name so that the order is consistent.
 	sort.SliceStable(gh.Include, func(i, j int) bool {
 		return gh.Include[i].Test < gh.Include[j].Test

--- a/cmd/build_test_matrix/main_test.go
+++ b/cmd/build_test_matrix/main_test.go
@@ -17,10 +17,10 @@ const (
 )
 
 func TestGetGithubActionMatrixForTests(t *testing.T) {
-	t.Run("empty dir does not fail", func(t *testing.T) {
+	t.Run("empty dir with no test cases fails", func(t *testing.T) {
 		testingDir := t.TempDir()
 		_, err := getGithubActionMatrixForTests(testingDir, "", "", nil)
-		assert.NoError(t, err)
+		assert.Error(t, err)
 	})
 
 	t.Run("only test functions are picked up", func(t *testing.T) {
@@ -105,12 +105,12 @@ func TestGetGithubActionMatrixForTests(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("non test files are not picked up", func(t *testing.T) {
+	t.Run("non test files are skipped", func(t *testing.T) {
 		testingDir := t.TempDir()
 		createFileWithTestSuiteAndTests(t, "FeeMiddlewareTestSuite", "TestA", "TestB", testingDir, nonTestFile)
 
 		gh, err := getGithubActionMatrixForTests(testingDir, "", "", nil)
-		assert.NoError(t, err)
+		assert.Error(t, err)
 		assert.Empty(t, gh.Include)
 	})
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

When the script that crawls test files to pick up test names encounters a file in a test directory that does not have any tests it explodes, instead we can just skip those files, and fail only if we have not found any files after crawling the entire directory.



<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
