### PR TITLE
chore: use encoding fields for packet data unmarshaling

### DIFF
--- a/modules/apps/transfer/ibc_module.go
+++ b/modules/apps/transfer/ibc_module.go
@@ -184,7 +184,7 @@ func (im IBCModule) OnRecvPacket(
 		events.EmitOnRecvPacketEvent(ctx, data, ack, ackErr)
 	}()
 
-	data, ackErr = types.UnmarshalPacketData(packet.GetData(), channelVersion)
+	data, ackErr = types.UnmarshalPacketData(packet.GetData(), channelVersion, "")
 	if ackErr != nil {
 		ack = channeltypes.NewErrorAcknowledgement(ackErr)
 		im.keeper.Logger(ctx).Error(fmt.Sprintf("%s sequence %d", ackErr.Error(), packet.Sequence))
@@ -221,7 +221,7 @@ func (im IBCModule) OnAcknowledgementPacket(
 		return errorsmod.Wrapf(ibcerrors.ErrUnknownRequest, "cannot unmarshal ICS-20 transfer packet acknowledgement: %v", err)
 	}
 
-	data, err := types.UnmarshalPacketData(packet.GetData(), channelVersion)
+	data, err := types.UnmarshalPacketData(packet.GetData(), channelVersion, "")
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func (im IBCModule) OnTimeoutPacket(
 	packet channeltypes.Packet,
 	relayer sdk.AccAddress,
 ) error {
-	data, err := types.UnmarshalPacketData(packet.GetData(), channelVersion)
+	data, err := types.UnmarshalPacketData(packet.GetData(), channelVersion, "")
 	if err != nil {
 		return err
 	}
@@ -305,6 +305,6 @@ func (im IBCModule) UnmarshalPacketData(ctx context.Context, portID string, chan
 		return types.FungibleTokenPacketDataV2{}, "", errorsmod.Wrapf(ibcerrors.ErrNotFound, "app version not found for port %s and channel %s", portID, channelID)
 	}
 
-	ftpd, err := types.UnmarshalPacketData(bz, ics20Version)
+	ftpd, err := types.UnmarshalPacketData(bz, ics20Version, "")
 	return ftpd, ics20Version, err
 }

--- a/modules/apps/transfer/types/packet.go
+++ b/modules/apps/transfer/types/packet.go
@@ -24,8 +24,8 @@ var (
 )
 
 const (
-	JsonEncoding  = "application/json"
-	ProtoEncoding = "application/x-protobuf"
+	EncodingJSON     = "application/json"
+	EncodingProtobuf = "application/x-protobuf"
 )
 
 // NewFungibleTokenPacketData constructs a new FungibleTokenPacketData instance
@@ -222,12 +222,12 @@ func UnmarshalPacketData(bz []byte, ics20Version string, encoding string) (Fungi
 	switch ics20Version {
 	case V1:
 		if encoding == "" {
-			encoding = JsonEncoding
+			encoding = EncodingJSON
 		}
 		data = &FungibleTokenPacketData{}
 	case V2:
 		if encoding == "" {
-			encoding = ProtoEncoding
+			encoding = EncodingProtobuf
 		}
 		data = &FungibleTokenPacketDataV2{}
 	default:
@@ -244,11 +244,11 @@ func UnmarshalPacketData(bz []byte, ics20Version string, encoding string) (Fungi
 	// The underlying type is either FungibleTokenPacketData or FungibleTokenPacketDataV2, based on the value
 	// of "ics20Version".
 	switch encoding {
-	case JsonEncoding:
+	case EncodingJSON:
 		if err := json.Unmarshal(bz, &data); err != nil {
 			return FungibleTokenPacketDataV2{}, errorsmod.Wrapf(ibcerrors.ErrInvalidType, failedUnmarshalingErrorMsg, errorMsgVersion, err.Error())
 		}
-	case ProtoEncoding:
+	case EncodingProtobuf:
 		if err := unknownproto.RejectUnknownFieldsStrict(bz, data, unknownproto.DefaultAnyResolver{}); err != nil {
 			return FungibleTokenPacketDataV2{}, errorsmod.Wrapf(ibcerrors.ErrInvalidType, failedUnmarshalingErrorMsg, errorMsgVersion, err.Error())
 		}
@@ -258,7 +258,7 @@ func UnmarshalPacketData(bz []byte, ics20Version string, encoding string) (Fungi
 		}
 
 	default:
-		return FungibleTokenPacketDataV2{}, errorsmod.Wrapf(ibcerrors.ErrInvalidType, "invalid encoding provided, must be either empty or one of [%q, %q], got %s", JsonEncoding, ProtoEncoding, encoding)
+		return FungibleTokenPacketDataV2{}, errorsmod.Wrapf(ibcerrors.ErrInvalidType, "invalid encoding provided, must be either empty or one of [%q, %q], got %s", EncodingJSON, EncodingProtobuf, encoding)
 	}
 
 	// When the unmarshaling is done, we want to retrieve the underlying data type based on the value of ics20Version

--- a/modules/apps/transfer/types/packet.go
+++ b/modules/apps/transfer/types/packet.go
@@ -23,6 +23,11 @@ var (
 	_ ibcexported.PacketDataProvider = (*FungibleTokenPacketDataV2)(nil)
 )
 
+const (
+	JsonEncoding  = "application/json"
+	ProtoEncoding = "application/proto"
+)
+
 // NewFungibleTokenPacketData constructs a new FungibleTokenPacketData instance
 func NewFungibleTokenPacketData(
 	denom string, amount string,
@@ -217,12 +222,12 @@ func UnmarshalPacketData(bz []byte, ics20Version string, encoding string) (Fungi
 	switch ics20Version {
 	case V1:
 		if encoding == "" {
-			encoding = "json"
+			encoding = JsonEncoding
 		}
 		data = &FungibleTokenPacketData{}
 	case V2:
 		if encoding == "" {
-			encoding = "proto"
+			encoding = ProtoEncoding
 		}
 		data = &FungibleTokenPacketDataV2{}
 	default:
@@ -239,11 +244,11 @@ func UnmarshalPacketData(bz []byte, ics20Version string, encoding string) (Fungi
 	// The underlying type is either FungibleTokenPacketData or FungibleTokenPacketDataV2, based on the value
 	// of "ics20Version".
 	switch encoding {
-	case "json":
+	case JsonEncoding:
 		if err := json.Unmarshal(bz, &data); err != nil {
 			return FungibleTokenPacketDataV2{}, errorsmod.Wrapf(ibcerrors.ErrInvalidType, failedUnmarshalingErrorMsg, errorMsgVersion, err.Error())
 		}
-	case "proto":
+	case ProtoEncoding:
 		if err := unknownproto.RejectUnknownFieldsStrict(bz, data, unknownproto.DefaultAnyResolver{}); err != nil {
 			return FungibleTokenPacketDataV2{}, errorsmod.Wrapf(ibcerrors.ErrInvalidType, failedUnmarshalingErrorMsg, errorMsgVersion, err.Error())
 		}
@@ -253,7 +258,7 @@ func UnmarshalPacketData(bz []byte, ics20Version string, encoding string) (Fungi
 		}
 
 	default:
-		return FungibleTokenPacketDataV2{}, errorsmod.Wrapf(ibcerrors.ErrInvalidType, "invalid encoding provided, must be either empty or one of `json`,`proto`, got %s", encoding)
+		return FungibleTokenPacketDataV2{}, errorsmod.Wrapf(ibcerrors.ErrInvalidType, "invalid encoding provided, must be either empty or one of [%q, %q], got %s", JsonEncoding, ProtoEncoding, encoding)
 	}
 
 	// When the unmarshaling is done, we want to retrieve the underlying data type based on the value of ics20Version

--- a/modules/apps/transfer/types/packet.go
+++ b/modules/apps/transfer/types/packet.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/cosmos/cosmos-sdk/codec/unknownproto"
 	"github.com/cosmos/gogoproto/proto"
 
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
+
+	"github.com/cosmos/cosmos-sdk/codec/unknownproto"
 
 	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
 	ibcexported "github.com/cosmos/ibc-go/v9/modules/core/exported"

--- a/modules/apps/transfer/types/packet.go
+++ b/modules/apps/transfer/types/packet.go
@@ -25,7 +25,7 @@ var (
 
 const (
 	JsonEncoding  = "application/json"
-	ProtoEncoding = "application/proto"
+	ProtoEncoding = "application/x-protobuf"
 )
 
 // NewFungibleTokenPacketData constructs a new FungibleTokenPacketData instance

--- a/modules/apps/transfer/types/packet_test.go
+++ b/modules/apps/transfer/types/packet_test.go
@@ -819,7 +819,7 @@ func TestV2ForwardsCompatibilityFails(t *testing.T) {
 
 		tc.malleate()
 
-		packetData, err := types.UnmarshalPacketData(packetDataBz, types.V2, types.ProtoEncoding)
+		packetData, err := types.UnmarshalPacketData(packetDataBz, types.V2, types.EncodingProtobuf)
 
 		expPass := tc.expError == nil
 		if expPass {

--- a/modules/apps/transfer/types/packet_test.go
+++ b/modules/apps/transfer/types/packet_test.go
@@ -765,7 +765,7 @@ func TestUnmarshalPacketData(t *testing.T) {
 
 		tc.malleate()
 
-		packetData, err := types.UnmarshalPacketData(packetDataBz, version)
+		packetData, err := types.UnmarshalPacketData(packetDataBz, version, "")
 
 		expPass := tc.expError == nil
 		if expPass {
@@ -819,7 +819,7 @@ func TestV2ForwardsCompatibilityFails(t *testing.T) {
 
 		tc.malleate()
 
-		packetData, err := types.UnmarshalPacketData(packetDataBz, types.V2)
+		packetData, err := types.UnmarshalPacketData(packetDataBz, types.V2, "proto")
 
 		expPass := tc.expError == nil
 		if expPass {

--- a/modules/apps/transfer/types/packet_test.go
+++ b/modules/apps/transfer/types/packet_test.go
@@ -819,7 +819,7 @@ func TestV2ForwardsCompatibilityFails(t *testing.T) {
 
 		tc.malleate()
 
-		packetData, err := types.UnmarshalPacketData(packetDataBz, types.V2, "proto")
+		packetData, err := types.UnmarshalPacketData(packetDataBz, types.V2, types.ProtoEncoding)
 
 		expPass := tc.expError == nil
 		if expPass {

--- a/modules/apps/transfer/v2/ibc_module.go
+++ b/modules/apps/transfer/v2/ibc_module.go
@@ -41,7 +41,7 @@ func (im *IBCModule) OnSendPacket(goCtx context.Context, sourceChannel string, d
 		return errorsmod.Wrapf(ibcerrors.ErrUnauthorized, "%s is not allowed to send funds", signer)
 	}
 
-	data, err := transfertypes.UnmarshalPacketData(payload.Value, payload.Version)
+	data, err := transfertypes.UnmarshalPacketData(payload.Value, payload.Version, payload.Encoding)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (im *IBCModule) OnRecvPacket(ctx context.Context, sourceChannel string, des
 		events.EmitOnRecvPacketEvent(ctx, data, ack, ackErr)
 	}()
 
-	data, ackErr = transfertypes.UnmarshalPacketData(payload.Value, payload.Version)
+	data, ackErr = transfertypes.UnmarshalPacketData(payload.Value, payload.Version, payload.Encoding)
 	if ackErr != nil {
 		ack = channeltypes.NewErrorAcknowledgement(ackErr)
 		im.keeper.Logger(ctx).Error(fmt.Sprintf("%s sequence %d", ackErr.Error(), sequence))
@@ -99,7 +99,7 @@ func (im *IBCModule) OnRecvPacket(ctx context.Context, sourceChannel string, des
 }
 
 func (im *IBCModule) OnTimeoutPacket(ctx context.Context, sourceChannel string, destinationChannel string, sequence uint64, payload types.Payload, relayer sdk.AccAddress) error {
-	data, err := transfertypes.UnmarshalPacketData(payload.Value, payload.Version)
+	data, err := transfertypes.UnmarshalPacketData(payload.Value, payload.Version, payload.Encoding)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (im *IBCModule) OnAcknowledgementPacket(ctx context.Context, sourceChannel 
 		return errorsmod.Wrapf(ibcerrors.ErrUnknownRequest, "cannot unmarshal ICS-20 transfer packet acknowledgement: %v", err)
 	}
 
-	data, err := transfertypes.UnmarshalPacketData(payload.Value, payload.Version)
+	data, err := transfertypes.UnmarshalPacketData(payload.Value, payload.Version, payload.Encoding)
 	if err != nil {
 		return err
 	}

--- a/modules/apps/transfer/v2/keeper/msg_server_test.go
+++ b/modules/apps/transfer/v2/keeper/msg_server_test.go
@@ -68,7 +68,7 @@ func (suite *KeeperTestSuite) TestMsgSendPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timestamp := suite.chainA.GetTimeoutTimestampSecs()
-			payload = channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
+			payload = channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
 
 			tc.malleate()
 
@@ -163,7 +163,7 @@ func (suite *KeeperTestSuite) TestMsgRecvPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timestamp := suite.chainA.GetTimeoutTimestampSecs()
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
 			var err error
 			packet, err = path.EndpointA.MsgSendPacket(timestamp, payload)
 			suite.Require().NoError(err)
@@ -272,7 +272,7 @@ func (suite *KeeperTestSuite) TestMsgAckPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timestamp := suite.chainA.GetTimeoutTimestampSecs()
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
 
 			var err error
 			packet, err = path.EndpointA.MsgSendPacket(timestamp, payload)
@@ -373,7 +373,7 @@ func (suite *KeeperTestSuite) TestMsgTimeoutPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + uint64(time.Hour.Seconds())
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
 
 			var err error
 			packet, err = path.EndpointA.MsgSendPacket(timeoutTimestamp, payload)
@@ -494,7 +494,7 @@ func (suite *KeeperTestSuite) TestV2RetainsFungibility() {
 			bz := suite.chainB.Codec.MustMarshal(&ftpd)
 
 			timeoutTimestamp := uint64(suite.chainB.GetContext().BlockTime().Unix()) + uint64(time.Hour.Seconds())
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
 
 			var err error
 			packetV2, err = pathv2.EndpointA.MsgSendPacket(timeoutTimestamp, payload)
@@ -533,7 +533,7 @@ func (suite *KeeperTestSuite) TestV2RetainsFungibility() {
 			bz := suite.chainC.Codec.MustMarshal(&ftpd)
 
 			timeoutTimestamp := uint64(suite.chainC.GetContext().BlockTime().Unix()) + uint64(time.Hour.Seconds())
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
 
 			var err error
 			packetV2, err = pathv2.EndpointB.MsgSendPacket(timeoutTimestamp, payload)

--- a/modules/apps/transfer/v2/keeper/msg_server_test.go
+++ b/modules/apps/transfer/v2/keeper/msg_server_test.go
@@ -68,7 +68,7 @@ func (suite *KeeperTestSuite) TestMsgSendPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timestamp := suite.chainA.GetTimeoutTimestampSecs()
-			payload = channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
+			payload = channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.EncodingProtobuf, bz)
 
 			tc.malleate()
 
@@ -163,7 +163,7 @@ func (suite *KeeperTestSuite) TestMsgRecvPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timestamp := suite.chainA.GetTimeoutTimestampSecs()
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.EncodingProtobuf, bz)
 			var err error
 			packet, err = path.EndpointA.MsgSendPacket(timestamp, payload)
 			suite.Require().NoError(err)
@@ -272,7 +272,7 @@ func (suite *KeeperTestSuite) TestMsgAckPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timestamp := suite.chainA.GetTimeoutTimestampSecs()
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.EncodingProtobuf, bz)
 
 			var err error
 			packet, err = path.EndpointA.MsgSendPacket(timestamp, payload)
@@ -373,7 +373,7 @@ func (suite *KeeperTestSuite) TestMsgTimeoutPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + uint64(time.Hour.Seconds())
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.EncodingProtobuf, bz)
 
 			var err error
 			packet, err = path.EndpointA.MsgSendPacket(timeoutTimestamp, payload)
@@ -494,7 +494,7 @@ func (suite *KeeperTestSuite) TestV2RetainsFungibility() {
 			bz := suite.chainB.Codec.MustMarshal(&ftpd)
 
 			timeoutTimestamp := uint64(suite.chainB.GetContext().BlockTime().Unix()) + uint64(time.Hour.Seconds())
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.EncodingProtobuf, bz)
 
 			var err error
 			packetV2, err = pathv2.EndpointA.MsgSendPacket(timeoutTimestamp, payload)
@@ -533,7 +533,7 @@ func (suite *KeeperTestSuite) TestV2RetainsFungibility() {
 			bz := suite.chainC.Codec.MustMarshal(&ftpd)
 
 			timeoutTimestamp := uint64(suite.chainC.GetContext().BlockTime().Unix()) + uint64(time.Hour.Seconds())
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.ProtoEncoding, bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, transfertypes.EncodingProtobuf, bz)
 
 			var err error
 			packetV2, err = pathv2.EndpointB.MsgSendPacket(timeoutTimestamp, payload)

--- a/modules/apps/transfer/v2/keeper/msg_server_test.go
+++ b/modules/apps/transfer/v2/keeper/msg_server_test.go
@@ -68,10 +68,7 @@ func (suite *KeeperTestSuite) TestMsgSendPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timestamp := suite.chainA.GetTimeoutTimestampSecs()
-			// TODO: note, encoding field currently not respected in the implementation. encoding is determined by the version.
-			// ics20-v1 == json
-			// ics20-v2 == proto
-			payload = channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "json", bz)
+			payload = channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
 
 			tc.malleate()
 
@@ -166,7 +163,7 @@ func (suite *KeeperTestSuite) TestMsgRecvPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timestamp := suite.chainA.GetTimeoutTimestampSecs()
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "json", bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
 			var err error
 			packet, err = path.EndpointA.MsgSendPacket(timestamp, payload)
 			suite.Require().NoError(err)
@@ -275,7 +272,7 @@ func (suite *KeeperTestSuite) TestMsgAckPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timestamp := suite.chainA.GetTimeoutTimestampSecs()
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "json", bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
 
 			var err error
 			packet, err = path.EndpointA.MsgSendPacket(timestamp, payload)
@@ -376,7 +373,7 @@ func (suite *KeeperTestSuite) TestMsgTimeoutPacketTransfer() {
 			bz := suite.chainA.Codec.MustMarshal(&ftpd)
 
 			timeoutTimestamp = uint64(suite.chainA.GetContext().BlockTime().Unix()) + uint64(time.Hour.Seconds())
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "json", bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
 
 			var err error
 			packet, err = path.EndpointA.MsgSendPacket(timeoutTimestamp, payload)
@@ -497,7 +494,7 @@ func (suite *KeeperTestSuite) TestV2RetainsFungibility() {
 			bz := suite.chainB.Codec.MustMarshal(&ftpd)
 
 			timeoutTimestamp := uint64(suite.chainB.GetContext().BlockTime().Unix()) + uint64(time.Hour.Seconds())
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "json", bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
 
 			var err error
 			packetV2, err = pathv2.EndpointA.MsgSendPacket(timeoutTimestamp, payload)
@@ -536,7 +533,7 @@ func (suite *KeeperTestSuite) TestV2RetainsFungibility() {
 			bz := suite.chainC.Codec.MustMarshal(&ftpd)
 
 			timeoutTimestamp := uint64(suite.chainC.GetContext().BlockTime().Unix()) + uint64(time.Hour.Seconds())
-			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "json", bz)
+			payload := channeltypesv2.NewPayload(transfertypes.ModuleName, transfertypes.ModuleName, transfertypes.V2, "proto", bz)
 
 			var err error
 			packetV2, err = pathv2.EndpointB.MsgSendPacket(timeoutTimestamp, payload)

--- a/modules/core/04-channel/v2/types/msgs_test.go
+++ b/modules/core/04-channel/v2/types/msgs_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	transfertypes "github.com/cosmos/ibc-go/v9/modules/apps/transfer/types"
 	clienttypes "github.com/cosmos/ibc-go/v9/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v9/modules/core/04-channel/v2/types"
 	commitmenttypes "github.com/cosmos/ibc-go/v9/modules/core/23-commitment/types"
@@ -205,7 +206,7 @@ func (s *TypesTestSuite) TestMsgSendPacketValidateBasic() {
 			msg = types.NewMsgSendPacket(
 				ibctesting.FirstChannelID, s.chainA.GetTimeoutTimestamp(),
 				s.chainA.SenderAccount.GetAddress().String(),
-				types.Payload{SourcePort: ibctesting.MockPort, DestinationPort: ibctesting.MockPort, Version: "ics20-1", Encoding: "json", Value: ibctesting.MockPacketData},
+				types.Payload{SourcePort: ibctesting.MockPort, DestinationPort: ibctesting.MockPort, Version: "ics20-1", Encoding: transfertypes.JsonEncoding, Value: ibctesting.MockPacketData},
 			)
 
 			tc.malleate()

--- a/modules/core/04-channel/v2/types/msgs_test.go
+++ b/modules/core/04-channel/v2/types/msgs_test.go
@@ -206,7 +206,7 @@ func (s *TypesTestSuite) TestMsgSendPacketValidateBasic() {
 			msg = types.NewMsgSendPacket(
 				ibctesting.FirstChannelID, s.chainA.GetTimeoutTimestamp(),
 				s.chainA.SenderAccount.GetAddress().String(),
-				types.Payload{SourcePort: ibctesting.MockPort, DestinationPort: ibctesting.MockPort, Version: "ics20-1", Encoding: transfertypes.JsonEncoding, Value: ibctesting.MockPacketData},
+				types.Payload{SourcePort: ibctesting.MockPort, DestinationPort: ibctesting.MockPort, Version: "ics20-1", Encoding: transfertypes.EncodingJSON, Value: ibctesting.MockPacketData},
 			)
 
 			tc.malleate()

--- a/modules/core/04-channel/v2/types/packet_test.go
+++ b/modules/core/04-channel/v2/types/packet_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	transfertypes "github.com/cosmos/ibc-go/v9/modules/apps/transfer/types"
 	"github.com/cosmos/ibc-go/v9/modules/core/04-channel/v2/types"
 	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
 	ibctesting "github.com/cosmos/ibc-go/v9/testing"
@@ -109,7 +110,7 @@ func TestValidateBasic(t *testing.T) {
 				SourcePort:      ibctesting.MockPort,
 				DestinationPort: ibctesting.MockPort,
 				Version:         "ics20-v2",
-				Encoding:        "proto",
+				Encoding:        transfertypes.ProtoEncoding,
 				Value:           mock.MockPacketData,
 			})
 

--- a/modules/core/04-channel/v2/types/packet_test.go
+++ b/modules/core/04-channel/v2/types/packet_test.go
@@ -110,7 +110,7 @@ func TestValidateBasic(t *testing.T) {
 				SourcePort:      ibctesting.MockPort,
 				DestinationPort: ibctesting.MockPort,
 				Version:         "ics20-v2",
-				Encoding:        transfertypes.ProtoEncoding,
+				Encoding:        transfertypes.EncodingProtobuf,
 				Value:           mock.MockPacketData,
 			})
 

--- a/modules/core/04-channel/v2/types/packet_test.go
+++ b/modules/core/04-channel/v2/types/packet_test.go
@@ -109,7 +109,7 @@ func TestValidateBasic(t *testing.T) {
 				SourcePort:      ibctesting.MockPort,
 				DestinationPort: ibctesting.MockPort,
 				Version:         "ics20-v2",
-				Encoding:        "json",
+				Encoding:        "proto",
 				Value:           mock.MockPacketData,
 			})
 

--- a/testing/mock/v2/mock.go
+++ b/testing/mock/v2/mock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	transfertypes "github.com/cosmos/ibc-go/v9/modules/apps/transfer/types"
 	channeltypesv2 "github.com/cosmos/ibc-go/v9/modules/core/04-channel/v2/types"
 	mockv1 "github.com/cosmos/ibc-go/v9/testing/mock"
 )
@@ -24,7 +25,7 @@ func NewMockPayload(sourcePort, destPort string) channeltypesv2.Payload {
 	return channeltypesv2.Payload{
 		SourcePort:      sourcePort,
 		DestinationPort: destPort,
-		Encoding:        "proto",
+		Encoding:        transfertypes.ProtoEncoding,
 		Value:           mockv1.MockPacketData,
 		Version:         mockv1.Version,
 	}

--- a/testing/mock/v2/mock.go
+++ b/testing/mock/v2/mock.go
@@ -25,7 +25,7 @@ func NewMockPayload(sourcePort, destPort string) channeltypesv2.Payload {
 	return channeltypesv2.Payload{
 		SourcePort:      sourcePort,
 		DestinationPort: destPort,
-		Encoding:        transfertypes.ProtoEncoding,
+		Encoding:        transfertypes.EncodingProtobuf,
 		Value:           mockv1.MockPacketData,
 		Version:         mockv1.Version,
 	}

--- a/testing/mock/v2/mock.go
+++ b/testing/mock/v2/mock.go
@@ -24,7 +24,7 @@ func NewMockPayload(sourcePort, destPort string) channeltypesv2.Payload {
 	return channeltypesv2.Payload{
 		SourcePort:      sourcePort,
 		DestinationPort: destPort,
-		Encoding:        "json",
+		Encoding:        "proto",
 		Value:           mockv1.MockPacketData,
 		Version:         mockv1.Version,
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
