### PR TITLE
chore: document channel id requirements for packet commitment keys

### DIFF
--- a/modules/core/04-channel/v2/keeper/grpc_query.go
+++ b/modules/core/04-channel/v2/keeper/grpc_query.go
@@ -17,6 +17,7 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v9/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v9/modules/core/04-channel/v2/types"
 	host "github.com/cosmos/ibc-go/v9/modules/core/24-host"
+	hostv2 "github.com/cosmos/ibc-go/v9/modules/core/24-host/v2"
 )
 
 var _ types.QueryServer = (*queryServer)(nil)
@@ -138,7 +139,7 @@ func (q *queryServer) PacketCommitments(ctx context.Context, req *types.QueryPac
 	}
 
 	var commitments []*types.PacketState
-	store := prefix.NewStore(runtime.KVStoreAdapter(q.storeService.OpenKVStore(ctx)), types.PacketCommitmentPrefixKey(req.ChannelId))
+	store := prefix.NewStore(runtime.KVStoreAdapter(q.storeService.OpenKVStore(ctx)), hostv2.PacketCommitmentPrefixKey(req.ChannelId))
 
 	pageRes, err := query.Paginate(store, req.Pagination, func(key, value []byte) error {
 		keySplit := strings.Split(string(key), "/")
@@ -205,7 +206,7 @@ func (q *queryServer) PacketAcknowledgements(ctx context.Context, req *types.Que
 	}
 
 	var acks []*types.PacketState
-	store := prefix.NewStore(runtime.KVStoreAdapter(q.storeService.OpenKVStore(ctx)), types.PacketAcknowledgementPrefixKey(req.ChannelId))
+	store := prefix.NewStore(runtime.KVStoreAdapter(q.storeService.OpenKVStore(ctx)), hostv2.PacketAcknowledgementPrefixKey(req.ChannelId))
 
 	// if a list of packet sequences is provided then query for each specific ack and return a list <= len(req.PacketCommitmentSequences)
 	// otherwise, maintain previous behaviour and perform paginated query

--- a/modules/core/04-channel/v2/types/keys.go
+++ b/modules/core/04-channel/v2/types/keys.go
@@ -14,13 +14,3 @@ const (
 	// the creator key is not a part of the ics-24 host specification
 	CreatorKey = "creator"
 )
-
-// PacketCommitmentPrefixKey returns the store key prefix under which packet commitments for a particular channel are stored.
-func PacketCommitmentPrefixKey(channelID string) []byte {
-	return append([]byte(channelID), byte(1))
-}
-
-// PacketAcknowledgementPrefixKey returns the store key prefix under which packet acknowledgements for a particular channel are stored.
-func PacketAcknowledgementPrefixKey(channelID string) []byte {
-	return append([]byte(channelID), byte(3))
-}

--- a/modules/core/24-host/v2/packet_keys.go
+++ b/modules/core/24-host/v2/packet_keys.go
@@ -6,19 +6,40 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// PacketCommitmentPrefixKey returns the store key prefix under which packet commitments for a particular channel are stored.
+// channelID must be a generated identifier, not provided externally so key collisions are not possible.
+func PacketCommitmentPrefixKey(channelID string) []byte {
+	return append([]byte(channelID), byte(1))
+}
+
 // PacketCommitmentKey returns the store key of under which a packet commitment is stored.
+// channelID must be a generated identifier, not provided externally so key collisions are not possible.
 func PacketCommitmentKey(channelID string, sequence uint64) []byte {
-	return append(append([]byte(channelID), byte(1)), sdk.Uint64ToBigEndian(sequence)...)
+	return append(PacketCommitmentPrefixKey((channelID)), sdk.Uint64ToBigEndian(sequence)...)
+}
+
+// PacketReceiptPrefixKey returns the store key prefix under which packet receipts for a particular channel are stored.
+// channelID must be a generated identifier, not provided externally so key collisions are not possible.
+func PacketReceiptPrefixKey(channelID string) []byte {
+	return append([]byte(channelID), byte(2))
 }
 
 // PacketReceiptKey returns the store key of under which a packet receipt is stored.
+// channelID must be a generated identifier, not provided externally so key collisions are not possible.
 func PacketReceiptKey(channelID string, sequence uint64) []byte {
-	return append(append([]byte(channelID), byte(2)), sdk.Uint64ToBigEndian(sequence)...)
+	return append(PacketReceiptPrefixKey(channelID), sdk.Uint64ToBigEndian(sequence)...)
+}
+
+// PacketAcknowledgementPrefixKey returns the store key prefix under which packet acknowledgements for a particular channel are stored.
+// channelID must be a generated identifier, not provided externally so key collisions are not possible.
+func PacketAcknowledgementPrefixKey(channelID string) []byte {
+	return append([]byte(channelID), byte(3))
 }
 
 // PacketAcknowledgementKey returns the store key of under which a packet acknowledgement is stored.
+// channelID must be a generated identifier, not provided externally so key collisions are not possible.
 func PacketAcknowledgementKey(channelID string, sequence uint64) []byte {
-	return append(append([]byte(channelID), byte(3)), sdk.Uint64ToBigEndian(sequence)...)
+	return append(PacketAcknowledgementPrefixKey(channelID), sdk.Uint64ToBigEndian(sequence)...)
 }
 
 // NextSequenceSendKey returns the store key for the next sequence send of a given channelID.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #7632 

I also moved the packet commitment prefix functions to 24-host to not have multiple implementations floating around (and where they will be under unit tests).

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
