### PR TITLE
chore: change v2 router mapping to use port id rather than module name

### DIFF
--- a/modules/core/api/router_test.go
+++ b/modules/core/api/router_test.go
@@ -16,53 +16,42 @@ func (suite *APITestSuite) TestRouter() {
 		{
 			name: "success",
 			malleate: func() {
-				router.AddRoute("module01", &mockv2.IBCModule{})
+				router.AddRoute("port01", &mockv2.IBCModule{})
 			},
 			assertionFn: func() {
-				suite.Require().True(router.HasRoute("module01"))
+				suite.Require().True(router.HasRoute("port01"))
 			},
 		},
 		{
 			name: "success: multiple modules",
 			malleate: func() {
-				router.AddRoute("module01", &mockv2.IBCModule{})
-				router.AddRoute("module02", &mockv2.IBCModule{})
-				router.AddRoute("module03", &mockv2.IBCModule{})
+				router.AddRoute("port01", &mockv2.IBCModule{})
+				router.AddRoute("port02", &mockv2.IBCModule{})
+				router.AddRoute("port03", &mockv2.IBCModule{})
 			},
 			assertionFn: func() {
-				suite.Require().True(router.HasRoute("module01"))
-				suite.Require().True(router.HasRoute("module02"))
-				suite.Require().True(router.HasRoute("module03"))
-			},
-		},
-		{
-			name: "success: find by prefix",
-			malleate: func() {
-				router.AddRoute("module01", &mockv2.IBCModule{})
-			},
-			assertionFn: func() {
-				suite.Require().True(router.HasRoute("module01-foo"))
+				suite.Require().True(router.HasRoute("port01"))
+				suite.Require().True(router.HasRoute("port02"))
+				suite.Require().True(router.HasRoute("port03"))
 			},
 		},
 		{
 			name: "failure: panics on duplicate module",
 			malleate: func() {
-				router.AddRoute("module01", &mockv2.IBCModule{})
+				router.AddRoute("port01", &mockv2.IBCModule{})
 			},
 			assertionFn: func() {
-				suite.Require().PanicsWithError("route module01 has already been registered", func() {
-					router.AddRoute("module01", &mockv2.IBCModule{})
+				suite.Require().PanicsWithError("route port01 has already been registered", func() {
+					router.AddRoute("port01", &mockv2.IBCModule{})
 				})
 			},
 		},
 		{
-			name: "failure: panics invalid-name",
-			malleate: func() {
-				router.AddRoute("module01", &mockv2.IBCModule{})
-			},
+			name:     "failure: panics invalid-name",
+			malleate: func() {},
 			assertionFn: func() {
 				suite.Require().PanicsWithError("route expressions can only contain alphanumeric characters", func() {
-					router.AddRoute("module-02", &mockv2.IBCModule{})
+					router.AddRoute("port-02", &mockv2.IBCModule{})
 				})
 			},
 		},

--- a/modules/light-clients/08-wasm/testing/simapp/app.go
+++ b/modules/light-clients/08-wasm/testing/simapp/app.go
@@ -570,7 +570,7 @@ func NewSimApp(
 
 	// register the transfer v2 module.
 	app.TransferKeeperV2 = ibctransferkeeperv2.NewKeeper(app.TransferKeeper, app.IBCKeeper.ChannelKeeperV2)
-	ibcRouterV2.AddRoute(ibctransfertypes.ModuleName, transferv2.NewIBCModule(app.TransferKeeperV2))
+	ibcRouterV2.AddRoute(ibctransfertypes.PortID, transferv2.NewIBCModule(app.TransferKeeperV2))
 
 	// Seal the IBC Routers.
 	app.IBCKeeper.SetRouter(ibcRouter)

--- a/testing/mock/v2/ibc_module.go
+++ b/testing/mock/v2/ibc_module.go
@@ -16,6 +16,10 @@ const (
 	ModuleNameA = ModuleName + "A"
 	// ModuleNameB is a name that can be used for the second mock application.
 	ModuleNameB = ModuleName + "B"
+	// PortIDA is a port ID that can be used for the first mock application.
+	PortIDA = ModuleNameA
+	// PortIDB is a port ID that can be used for the second mock application.
+	PortIDB = ModuleNameB
 )
 
 // IBCModule is a mock implementation of the IBCModule interface.

--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -480,16 +480,16 @@ func NewSimApp(
 
 	// create two separate mock v2 applications so that it is possible to test multi packet data.
 	mockV2A := mockv2.NewIBCModule()
-	ibcRouterV2.AddRoute(mockv2.ModuleNameA, mockV2A)
+	ibcRouterV2.AddRoute(mockv2.PortIDA, mockV2A)
 	app.MockModuleV2A = mockV2A
 
 	mockV2B := mockv2.NewIBCModule()
-	ibcRouterV2.AddRoute(mockv2.ModuleNameB, mockV2B)
+	ibcRouterV2.AddRoute(mockv2.PortIDB, mockV2B)
 	app.MockModuleV2B = mockV2B
 
 	// register the transfer v2 module.
 	app.TransferKeeperV2 = ibctransferkeeperv2.NewKeeper(app.TransferKeeper, app.IBCKeeper.ChannelKeeperV2)
-	ibcRouterV2.AddRoute(ibctransfertypes.ModuleName, transferv2.NewIBCModule(app.TransferKeeperV2))
+	ibcRouterV2.AddRoute(ibctransfertypes.PortID, transferv2.NewIBCModule(app.TransferKeeperV2))
 
 	// Seal the IBC Router
 	app.IBCKeeper.SetRouter(ibcRouter)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #7638

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
