### PR TITLE
fix: correct error message for payload validation in packet ValidateBasic

### DIFF
--- a/modules/core/04-channel/v2/types/packet.go
+++ b/modules/core/04-channel/v2/types/packet.go
@@ -34,7 +34,7 @@ func NewPayload(sourcePort, destPort, version, encoding string, value []byte) Pa
 // ValidateBasic validates that a Packet satisfies the basic requirements.
 func (p Packet) ValidateBasic() error {
 	if len(p.Payloads) != 1 {
-		return errorsmod.Wrap(ErrInvalidPacket, "payloads must not be empty")
+		return errorsmod.Wrap(ErrInvalidPacket, "payloads must contain exactly one payload")
 	}
 
 	for _, pd := range p.Payloads {


### PR DESCRIPTION
Closes: #7630 