### PR TITLE
(chore) change tests in 23-commitment/types to expect specific error

### DIFF
--- a/modules/core/23-commitment/types/codec_test.go
+++ b/modules/core/23-commitment/types/codec_test.go
@@ -1,39 +1,41 @@
 package types_test
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 
 	ibc "github.com/cosmos/ibc-go/v9/modules/core"
 	"github.com/cosmos/ibc-go/v9/modules/core/23-commitment/types"
-	"github.com/cosmos/ibc-go/v9/modules/core/23-commitment/types/v2"
+	v2 "github.com/cosmos/ibc-go/v9/modules/core/23-commitment/types/v2"
 )
 
 func (suite *MerkleTestSuite) TestCodecTypeRegistration() {
 	testCases := []struct {
 		name    string
 		typeURL string
-		expPass bool
+		expErr  error
 	}{
 		{
 			"success: MerkleRoot",
 			sdk.MsgTypeURL(&types.MerkleRoot{}),
-			true,
+			nil,
 		},
 		{
 			"success: MerklePrefix",
 			sdk.MsgTypeURL(&types.MerklePrefix{}),
-			true,
+			nil,
 		},
 		{
 			"success: MerklePath",
 			sdk.MsgTypeURL(&v2.MerklePath{}),
-			true,
+			nil,
 		},
 		{
 			"type not registered on codec",
 			"ibc.invalid.MsgTypeURL",
-			false,
+			fmt.Errorf("unable to resolve type URL ibc.invalid.MsgTypeURL"),
 		},
 	}
 
@@ -44,12 +46,12 @@ func (suite *MerkleTestSuite) TestCodecTypeRegistration() {
 			encodingCfg := moduletestutil.MakeTestEncodingConfig(ibc.AppModuleBasic{})
 			msg, err := encodingCfg.Codec.InterfaceRegistry().Resolve(tc.typeURL)
 
-			if tc.expPass {
-				suite.Require().NotNil(msg)
+			if tc.expErr == nil {
+				suite.NotNil(msg)
 				suite.Require().NoError(err)
 			} else {
-				suite.Require().Nil(msg)
-				suite.Require().Error(err)
+				suite.Nil(msg)
+				suite.Require().ErrorContains(err, tc.expErr.Error())
 			}
 		})
 	}

--- a/modules/core/23-commitment/types/codec_test.go
+++ b/modules/core/23-commitment/types/codec_test.go
@@ -8,7 +8,7 @@ import (
 
 	ibc "github.com/cosmos/ibc-go/v9/modules/core"
 	"github.com/cosmos/ibc-go/v9/modules/core/23-commitment/types"
-	v2 "github.com/cosmos/ibc-go/v9/modules/core/23-commitment/types/v2"
+	"github.com/cosmos/ibc-go/v9/modules/core/23-commitment/types/v2"
 )
 
 func (suite *MerkleTestSuite) TestCodecTypeRegistration() {

--- a/modules/core/23-commitment/types/utils_test.go
+++ b/modules/core/23-commitment/types/utils_test.go
@@ -26,7 +26,7 @@ func (suite *MerkleTestSuite) TestConvertProofs() {
 		name      string
 		malleate  func()
 		keyExists bool
-		expPass   bool
+		expErr    error
 	}{
 		{
 			"success for ExistenceProof",
@@ -41,13 +41,13 @@ func (suite *MerkleTestSuite) TestConvertProofs() {
 
 				proofOps = res.ProofOps
 			},
-			true, true,
+			true, nil,
 		},
 		{
 			"success for NonexistenceProof",
 			func() {
 				res, err := suite.store.Query(&storetypes.RequestQuery{
-					Path:  fmt.Sprintf("/%s/key", suite.storeKey.Name()), // required path to get key/value+proof
+					Path:  fmt.Sprintf("/%s/key", suite.storeKey.Name()),
 					Data:  []byte("NOTMYKEY"),
 					Prove: true,
 				})
@@ -56,14 +56,14 @@ func (suite *MerkleTestSuite) TestConvertProofs() {
 
 				proofOps = res.ProofOps
 			},
-			false, true,
+			false, nil,
 		},
 		{
 			"nil proofOps",
 			func() {
 				proofOps = nil
 			},
-			true, false,
+			true, types.ErrInvalidMerkleProof,
 		},
 		{
 			"proof op data is nil",
@@ -79,7 +79,7 @@ func (suite *MerkleTestSuite) TestConvertProofs() {
 				proofOps = res.ProofOps
 				proofOps.Ops[0].Data = nil
 			},
-			true, false,
+			true, types.ErrInvalidMerkleProof,
 		},
 	}
 
@@ -89,17 +89,18 @@ func (suite *MerkleTestSuite) TestConvertProofs() {
 		tc.malleate()
 
 		proof, err := types.ConvertProofs(proofOps)
-		if tc.expPass {
+		if tc.expErr == nil {
 			suite.Require().NoError(err, "ConvertProofs unexpectedly returned error for case: %s", tc.name)
 			if tc.keyExists {
 				err := proof.VerifyMembership(types.GetSDKSpecs(), &root, existsPath, value)
 				suite.Require().NoError(err, "converted proof failed to verify membership for case: %s", tc.name)
 			} else {
 				err := proof.VerifyNonMembership(types.GetSDKSpecs(), &root, nonexistPath)
-				suite.Require().NoError(err, "converted proof failed to verify membership for case: %s", tc.name)
+				suite.Require().NoError(err, "converted proof failed to verify non-membership for case: %s", tc.name)
 			}
 		} else {
 			suite.Require().Error(err, "ConvertProofs passed on invalid case for case: %s", tc.name)
+			suite.Require().ErrorIs(err, tc.expErr, "unexpected error returned for case: %s", tc.name)
 		}
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
