### PR TITLE
(chore) update tests in core/24-host to expect specific error

### DIFF
--- a/cmd/build_test_matrix/main.go
+++ b/cmd/build_test_matrix/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -139,7 +140,7 @@ func getGithubActionMatrixForTests(e2eRootDirectory, testName string, suite stri
 	}
 
 	if len(gh.Include) == 0 {
-		return GithubActionTestMatrix{}, fmt.Errorf("no test cases found")
+		return GithubActionTestMatrix{}, errors.New("no test cases found")
 	}
 
 	// Sort the test cases by name so that the order is consistent.

--- a/modules/core/24-host/validate_test.go
+++ b/modules/core/24-host/validate_test.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,25 +13,25 @@ import (
 var longID = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eros neque, ultricies vel ligula ac, convallis porttitor elit. Maecenas tincidunt turpis elit, vel faucibus nisl pellentesque sodales"
 
 type testCase struct {
-	msg     string
-	id      string
-	expPass bool
+	msg    string
+	id     string
+	expErr error
 }
 
 func TestDefaultIdentifierValidator(t *testing.T) {
 	testCases := []testCase{
-		{"valid lowercase", "lowercaseid", true},
-		{"valid id special chars", "._+-#[]<>._+-#[]<>", true},
-		{"valid id lower and special chars", "lower._+-#[]<>", true},
-		{"numeric id", "1234567890", true},
-		{"uppercase id", "NOTLOWERCASE", true},
-		{"numeric id", "1234567890", true},
-		{"blank id", "               ", false},
-		{"id length out of range", "1", false},
-		{"id is too long", "this identifier is too long to be used as a valid identifier", false},
-		{"path-like id", "lower/case/id", false},
-		{"invalid id", "(clientid)", false},
-		{"empty string", "", false},
+		{"valid lowercase", "lowercaseid", nil},
+		{"valid id special chars", "._+-#[]<>._+-#[]<>", nil},
+		{"valid id lower and special chars", "lower._+-#[]<>", nil},
+		{"numeric id", "1234567890", nil},
+		{"uppercase id", "NOTLOWERCASE", nil},
+		{"numeric id", "1234567890", nil},
+		{"blank id", "               ", errors.New("the ID is blank - contains only spaces")},
+		{"id length out of range", "1", errors.New("the ID length is too short")},
+		{"id is too long", "this identifier is too long to be used as a valid identifier", errors.New("the ID exceeds the maximum allowed length")},
+		{"path-like id", "lower/case/id", errors.New("the ID contains path-like characters, which are invalid for an ID")},
+		{"invalid id", "(clientid)", errors.New("the ID contains invalid characters")},
+		{"empty string", "", errors.New("the ID cannot be empty")},
 	}
 
 	for _, tc := range testCases {
@@ -40,7 +41,7 @@ func TestDefaultIdentifierValidator(t *testing.T) {
 		err1 := ConnectionIdentifierValidator(tc.id)
 		err2 := ChannelIdentifierValidator(tc.id)
 		err3 := PortIdentifierValidator(tc.id)
-		if tc.expPass {
+		if tc.expErr == nil {
 			require.NoError(t, err, tc.msg)
 			require.NoError(t, err1, tc.msg)
 			require.NoError(t, err2, tc.msg)
@@ -56,25 +57,25 @@ func TestDefaultIdentifierValidator(t *testing.T) {
 
 func TestPortIdentifierValidator(t *testing.T) {
 	testCases := []testCase{
-		{"valid lowercase", "transfer", true},
-		{"valid id special chars", "._+-#[]<>._+-#[]<>", true},
-		{"valid id lower and special chars", "lower._+-#[]<>", true},
-		{"numeric id", "1234567890", true},
-		{"uppercase id", "NOTLOWERCASE", true},
-		{"numeric id", "1234567890", true},
-		{"blank id", "               ", false},
-		{"id length out of range", "1", false},
-		{"id is too long", longID, false},
-		{"path-like id", "lower/case/id", false},
-		{"invalid id", "(clientid)", false},
-		{"empty string", "", false},
+		{"valid lowercase", "transfer", nil},
+		{"valid id special chars", "._+-#[]<>._+-#[]<>", nil},
+		{"valid id lower and special chars", "lower._+-#[]<>", nil},
+		{"numeric id", "1234567890", nil},
+		{"uppercase id", "NOTLOWERCASE", nil},
+		{"numeric id", "1234567890", nil},
+		{"blank id", "               ", errors.New("the ID is blank - contains only spaces")},
+		{"id length out of range", "1", errors.New("the ID length is too short")},
+		{"id is too long", longID, errors.New("the ID exceeds the maximum allowed length")},
+		{"path-like id", "lower/case/id", errors.New("the ID contains path-like characters, which are invalid for an ID")},
+		{"invalid id", "(clientid)", errors.New("the ID contains invalid characters")},
+		{"empty string", "", errors.New("the ID cannot be empty")},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 
 		err := PortIdentifierValidator(tc.id)
-		if tc.expPass {
+		if tc.expErr == nil {
 			require.NoError(t, err, tc.msg)
 		} else {
 			require.Error(t, err, tc.msg)
@@ -84,24 +85,24 @@ func TestPortIdentifierValidator(t *testing.T) {
 
 func TestPathValidator(t *testing.T) {
 	testCases := []testCase{
-		{"valid lowercase", "p/lowercaseid", true},
-		{"numeric path", "p/239123", true},
-		{"valid id special chars", "p/._+-#[]<>._+-#[]<>", true},
-		{"valid id lower and special chars", "lower/._+-#[]<>", true},
-		{"id length out of range", "p/l", true},
-		{"uppercase id", "p/NOTLOWERCASE", true},
-		{"invalid path", "lowercaseid", false},
-		{"blank id", "p/               ", false},
-		{"id length out of range", "p/12345678901234567890123456789012345678901234567890123456789012345", false},
-		{"invalid id", "p/(clientid)", false},
-		{"empty string", "", false},
-		{"separators only", "////", false},
-		{"just separator", "/", false},
-		{"begins with separator", "/id", false},
-		{"blank before separator", "    /id", false},
-		{"ends with separator", "id/", false},
-		{"blank after separator", "id/       ", false},
-		{"blanks with separator", "  /  ", false},
+		{"valid lowercase", "p/lowercaseid", nil},
+		{"numeric path", "p/239123", nil},
+		{"valid id special chars", "p/._+-#[]<>._+-#[]<>", nil},
+		{"valid id lower and special chars", "lower/._+-#[]<>", nil},
+		{"id length out of range", "p/l", nil},
+		{"uppercase id", "p/NOTLOWERCASE", nil},
+		{"invalid path", "lowercaseid", errors.New("the path is invalid")},
+		{"blank id", "p/               ", errors.New("the ID is blank or contains only whitespace after the separator")},
+		{"id length out of range", "p/12345678901234567890123456789012345678901234567890123456789012345", errors.New("the ID exceeds the maximum allowed length")},
+		{"invalid id", "p/(clientid)", errors.New("the ID contains invalid characters, such as parentheses")},
+		{"empty string", "", errors.New("the ID cannot be empty")},
+		{"separators only", "////", errors.New("the ID contains only separators, which is invalid")},
+		{"just separator", "/", errors.New("the ID cannot be just a separato")},
+		{"begins with separator", "/id", errors.New("the ID should not begin with a separator")},
+		{"blank before separator", "    /id", errors.New("the ID cannot have leading spaces before the separator")},
+		{"ends with separator", "id/", errors.New("the ID cannot end with a separator")},
+		{"blank after separator", "id/       ", errors.New("the ID cannot have trailing spaces after the separato")},
+		{"blanks with separator", "  /  ", errors.New("the ID cannot have spaces before or after the separato")},
 	}
 
 	for _, tc := range testCases {
@@ -113,7 +114,7 @@ func TestPathValidator(t *testing.T) {
 
 		err := f(tc.id)
 
-		if tc.expPass {
+		if tc.expErr == nil {
 			seps := strings.Count(tc.id, "/")
 			require.Equal(t, 1, seps)
 			require.NoError(t, err, tc.msg)
@@ -132,21 +133,21 @@ func TestCustomPathValidator(t *testing.T) {
 	})
 
 	testCases := []testCase{
-		{"valid custom path", "id_client/id_one", true},
-		{"invalid path", "client", false},
-		{"invalid custom path", "id_one/client", false},
-		{"invalid identifier", "id_client/id_1234567890123456789012345678901234567890123457890123456789012345", false},
-		{"separators only", "////", false},
-		{"just separator", "/", false},
-		{"ends with separator", "id_client/id_one/", false},
-		{"beings with separator", "/id_client/id_one", false},
+		{"valid custom path", "id_client/id_one", nil},
+		{"invalid path", "client", errors.New("the path is invalid")},
+		{"invalid custom path", "id_one/client", errors.New("the path contains an invalid structure")},
+		{"invalid identifier", "id_client/id_1234567890123456789012345678901234567890123457890123456789012345", errors.New("the identifier exceeds the maximum allowed length for an ID")},
+		{"separators only", "////", errors.New("the path contains only separators, which is invalid")},
+		{"just separator", "/", errors.New("the path cannot be just a separator")},
+		{"ends with separator", "id_client/id_one/", errors.New("the path cannot end with a separator")},
+		{"beings with separator", "/id_client/id_one", errors.New("the path cannot begin with a separator")},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 
 		err := validateFn(tc.id)
-		if tc.expPass {
+		if tc.expErr == nil {
 			require.NoError(t, err, tc.msg)
 		} else {
 			require.Error(t, err, tc.msg)

--- a/modules/core/24-host/validate_test.go
+++ b/modules/core/24-host/validate_test.go
@@ -97,12 +97,12 @@ func TestPathValidator(t *testing.T) {
 		{"invalid id", "p/(clientid)", errors.New("the ID contains invalid characters, such as parentheses")},
 		{"empty string", "", errors.New("the ID cannot be empty")},
 		{"separators only", "////", errors.New("the ID contains only separators, which is invalid")},
-		{"just separator", "/", errors.New("the ID cannot be just a separato")},
+		{"just separator", "/", errors.New("the ID cannot be just a separator")},
 		{"begins with separator", "/id", errors.New("the ID should not begin with a separator")},
 		{"blank before separator", "    /id", errors.New("the ID cannot have leading spaces before the separator")},
 		{"ends with separator", "id/", errors.New("the ID cannot end with a separator")},
-		{"blank after separator", "id/       ", errors.New("the ID cannot have trailing spaces after the separato")},
-		{"blanks with separator", "  /  ", errors.New("the ID cannot have spaces before or after the separato")},
+		{"blank after separator", "id/       ", errors.New("the ID cannot have trailing spaces after the separator")},
+		{"blanks with separator", "  /  ", errors.New("the ID cannot have spaces before or after the separator")},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

ref: #7175 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
