### PR TITLE
(chore) update tests in modules/core/keeper tests to expect specific error

### DIFF
--- a/modules/core/genesis_test.go
+++ b/modules/core/genesis_test.go
@@ -1,6 +1,7 @@
 package ibc_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -62,12 +63,12 @@ func (suite *IBCTestSuite) TestValidateGenesis() {
 	testCases := []struct {
 		name     string
 		genState *types.GenesisState
-		expPass  bool
+		expError error
 	}{
 		{
 			name:     "default",
 			genState: types.DefaultGenesisState(),
-			expPass:  true,
+			expError: nil,
 		},
 		{
 			name: "valid genesis",
@@ -145,7 +146,7 @@ func (suite *IBCTestSuite) TestValidateGenesis() {
 					channeltypes.Params{UpgradeTimeout: channeltypes.DefaultTimeout},
 				),
 			},
-			expPass: true,
+			expError: nil,
 		},
 		{
 			name: "invalid client genesis",
@@ -172,7 +173,7 @@ func (suite *IBCTestSuite) TestValidateGenesis() {
 				),
 				ConnectionGenesis: connectiontypes.DefaultGenesisState(),
 			},
-			expPass: false,
+			expError: errors.New("genesis metadata key cannot be empty"),
 		},
 		{
 			name: "invalid connection genesis",
@@ -189,7 +190,7 @@ func (suite *IBCTestSuite) TestValidateGenesis() {
 					connectiontypes.Params{},
 				),
 			},
-			expPass: false,
+			expError: errors.New("invalid connection"),
 		},
 		{
 			name: "invalid channel genesis",
@@ -202,17 +203,18 @@ func (suite *IBCTestSuite) TestValidateGenesis() {
 					},
 				},
 			},
-			expPass: false,
+			expError: errors.New("invalid acknowledgement"),
 		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		err := tc.genState.Validate()
-		if tc.expPass {
+		if tc.expError == nil {
 			suite.Require().NoError(err, tc.name)
 		} else {
 			suite.Require().Error(err, tc.name)
+			suite.Require().Contains(err.Error(), tc.expError.Error())
 		}
 	}
 }

--- a/modules/core/keeper/keeper_test.go
+++ b/modules/core/keeper/keeper_test.go
@@ -51,29 +51,39 @@ func (suite *KeeperTestSuite) TestNewKeeper() {
 	testCases := []struct {
 		name     string
 		malleate func()
-		expPass  bool
+		expPanic string
 	}{
-		{"failure: empty upgrade keeper value", func() {
-			emptyUpgradeKeeperValue := upgradekeeper.Keeper{}
-
-			upgradeKeeper = emptyUpgradeKeeperValue
-		}, false},
-		{"failure: empty upgrade keeper pointer", func() {
-			emptyUpgradeKeeperPointer := &upgradekeeper.Keeper{}
-
-			upgradeKeeper = emptyUpgradeKeeperPointer
-		}, false},
-		{"failure: empty authority", func() {
-			newIBCKeeperFn = func() {
-				ibckeeper.NewKeeper(
-					suite.chainA.GetSimApp().AppCodec(),
-					runtime.NewKVStoreService(suite.chainA.GetSimApp().GetKey(ibcexported.StoreKey)),
-					suite.chainA.GetSimApp().GetSubspace(ibcexported.ModuleName),
-					upgradeKeeper,
-					"", // authority
-				)
-			}
-		}, false},
+		{
+			name: "failure: empty upgrade keeper value",
+			malleate: func() {
+				emptyUpgradeKeeperValue := upgradekeeper.Keeper{}
+				upgradeKeeper = emptyUpgradeKeeperValue
+			},
+			expPanic: "cannot initialize IBC keeper: empty upgrade keeper",
+		},
+		{
+			name: "failure: empty upgrade keeper pointer",
+			malleate: func() {
+				emptyUpgradeKeeperPointer := &upgradekeeper.Keeper{}
+				upgradeKeeper = emptyUpgradeKeeperPointer
+			},
+			expPanic: "cannot initialize IBC keeper: empty upgrade keeper",
+		},
+		{
+			name: "failure: empty authority",
+			malleate: func() {
+				newIBCKeeperFn = func() {
+					ibckeeper.NewKeeper(
+						suite.chainA.GetSimApp().AppCodec(),
+						runtime.NewKVStoreService(suite.chainA.GetSimApp().GetKey(ibcexported.StoreKey)),
+						suite.chainA.GetSimApp().GetSubspace(ibcexported.ModuleName),
+						upgradeKeeper,
+						"", // authority
+					)
+				}
+			},
+			expPanic: "authority cannot be empty",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -96,14 +106,19 @@ func (suite *KeeperTestSuite) TestNewKeeper() {
 
 			tc.malleate()
 
-			if tc.expPass {
-				suite.Require().NotPanics(
-					newIBCKeeperFn,
-				)
+			if tc.expPanic != "" {
+				suite.Require().Panics(func() {
+					newIBCKeeperFn()
+				}, "expected panic but no panic occurred")
+
+				defer func() {
+					if r := recover(); r != nil {
+						suite.Require().Contains(r.(error).Error(), tc.expPanic, "unexpected panic message")
+					}
+				}()
+
 			} else {
-				suite.Require().Panics(
-					newIBCKeeperFn,
-				)
+				suite.Require().NotPanics(newIBCKeeperFn, "unexpected panic occurred")
 			}
 		})
 	}

--- a/modules/core/keeper/msg_server_test.go
+++ b/modules/core/keeper/msg_server_test.go
@@ -45,7 +45,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 	testCases := []struct {
 		name      string
 		malleate  func()
-		expPass   bool
+		expError  error
 		expRevert bool
 		async     bool // indicate no ack written
 		replay    bool // indicate replay (no-op)
@@ -58,7 +58,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 			suite.Require().NoError(err)
 
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
-		}, true, false, false, false},
+		}, nil, false, false, false},
 		{"success: UNORDERED", func() {
 			path.Setup()
 
@@ -66,7 +66,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 			suite.Require().NoError(err)
 
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
-		}, true, false, false, false},
+		}, nil, false, false, false},
 		{"success: UNORDERED out of order packet", func() {
 			// setup uses an UNORDERED channel
 			path.Setup()
@@ -78,7 +78,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 
 				packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
 			}
-		}, true, false, false, false},
+		}, nil, false, false, false},
 		{"success: OnRecvPacket callback returns revert=true", func() {
 			path.Setup()
 
@@ -86,7 +86,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 			suite.Require().NoError(err)
 
 			packet = channeltypes.NewPacket(ibctesting.MockFailPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
-		}, true, true, false, false},
+		}, nil, true, false, false},
 		{"success: ORDERED - async acknowledgement", func() {
 			path.SetChannelOrdered()
 			path.Setup()
@@ -95,7 +95,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 			suite.Require().NoError(err)
 
 			packet = channeltypes.NewPacket(ibcmock.MockAsyncPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
-		}, true, false, true, false},
+		}, nil, false, true, false},
 		{"success: UNORDERED - async acknowledgement", func() {
 			path.Setup()
 
@@ -103,7 +103,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 			suite.Require().NoError(err)
 
 			packet = channeltypes.NewPacket(ibcmock.MockAsyncPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
-		}, true, false, true, false},
+		}, nil, false, true, false},
 		{"failure: ORDERED out of order packet", func() {
 			path.SetChannelOrdered()
 			path.Setup()
@@ -115,15 +115,15 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 
 				packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
 			}
-		}, false, false, false, false},
+		}, errors.New("packet sequence is out of order"), false, false, false},
 		{"channel does not exist", func() {
 			// any non-nil value of packet is valid
 			suite.Require().NotNil(packet)
-		}, false, false, false, false},
+		}, errors.New("channel not found"), false, false, false},
 		{"packet not sent", func() {
 			path.Setup()
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, 1, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
-		}, false, false, false, false},
+		}, errors.New("receive packet verification failed: couldn't verify counterparty packet commitment"), false, false, false},
 		{"successful no-op: ORDERED - packet already received (replay)", func() {
 			// mock will panic if application callback is called twice on the same packet
 			path.SetChannelOrdered()
@@ -135,7 +135,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
 			err = path.EndpointB.RecvPacket(packet)
 			suite.Require().NoError(err)
-		}, true, false, false, true},
+		}, nil, false, false, true},
 		{"successful no-op: UNORDERED - packet already received (replay)", func() {
 			// mock will panic if application callback is called twice on the same packet
 			path.Setup()
@@ -146,7 +146,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
 			err = path.EndpointB.RecvPacket(packet)
 			suite.Require().NoError(err)
-		}, true, false, false, true},
+		}, nil, false, false, true},
 	}
 
 	for _, tc := range testCases {
@@ -176,7 +176,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 
 			events := ctx.EventManager().Events()
 
-			if tc.expPass {
+			if tc.expError == nil {
 				suite.Require().NoError(err)
 
 				// replay should not fail since it will be treated as a no-op
@@ -211,6 +211,7 @@ func (suite *KeeperTestSuite) TestHandleRecvPacket() {
 				}
 			} else {
 				suite.Require().Error(err)
+				suite.Require().Contains(err.Error(), tc.expError.Error())
 			}
 		})
 	}
@@ -307,7 +308,7 @@ func (suite *KeeperTestSuite) TestHandleAcknowledgePacket() {
 	testCases := []struct {
 		name     string
 		malleate func()
-		expPass  bool
+		expError error
 		replay   bool // indicate replay (no-op)
 	}{
 		{"success: ORDERED", func() {
@@ -320,7 +321,7 @@ func (suite *KeeperTestSuite) TestHandleAcknowledgePacket() {
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
 			err = path.EndpointB.RecvPacket(packet)
 			suite.Require().NoError(err)
-		}, true, false},
+		}, nil, false},
 		{"success: UNORDERED", func() {
 			path.Setup()
 
@@ -330,7 +331,7 @@ func (suite *KeeperTestSuite) TestHandleAcknowledgePacket() {
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
 			err = path.EndpointB.RecvPacket(packet)
 			suite.Require().NoError(err)
-		}, true, false},
+		}, nil, false},
 		{"success: UNORDERED acknowledge out of order packet", func() {
 			// setup uses an UNORDERED channel
 			path.Setup()
@@ -344,7 +345,7 @@ func (suite *KeeperTestSuite) TestHandleAcknowledgePacket() {
 				err = path.EndpointB.RecvPacket(packet)
 				suite.Require().NoError(err)
 			}
-		}, true, false},
+		}, nil, false},
 		{"failure: ORDERED acknowledge out of order packet", func() {
 			path.SetChannelOrdered()
 			path.Setup()
@@ -358,11 +359,11 @@ func (suite *KeeperTestSuite) TestHandleAcknowledgePacket() {
 				err = path.EndpointB.RecvPacket(packet)
 				suite.Require().NoError(err)
 			}
-		}, false, false},
+		}, errors.New("packet sequence is out of order"), false},
 		{"channel does not exist", func() {
 			// any non-nil value of packet is valid
 			suite.Require().NotNil(packet)
-		}, false, false},
+		}, errors.New("channel not found"), false},
 		{"packet not received", func() {
 			path.Setup()
 
@@ -370,7 +371,7 @@ func (suite *KeeperTestSuite) TestHandleAcknowledgePacket() {
 			suite.Require().NoError(err)
 
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
-		}, false, false},
+		}, errors.New("invalid proof"), false},
 		{"successful no-op: ORDERED - packet already acknowledged (replay)", func() {
 			path.Setup()
 
@@ -383,7 +384,7 @@ func (suite *KeeperTestSuite) TestHandleAcknowledgePacket() {
 
 			err = path.EndpointA.AcknowledgePacket(packet, ibctesting.MockAcknowledgement)
 			suite.Require().NoError(err)
-		}, true, true},
+		}, nil, true},
 		{"successful no-op: UNORDERED - packet already acknowledged (replay)", func() {
 			path.Setup()
 
@@ -396,7 +397,7 @@ func (suite *KeeperTestSuite) TestHandleAcknowledgePacket() {
 
 			err = path.EndpointA.AcknowledgePacket(packet, ibctesting.MockAcknowledgement)
 			suite.Require().NoError(err)
-		}, true, true},
+		}, nil, true},
 	}
 
 	for _, tc := range testCases {
@@ -424,7 +425,7 @@ func (suite *KeeperTestSuite) TestHandleAcknowledgePacket() {
 
 			events := ctx.EventManager().Events()
 
-			if tc.expPass {
+			if tc.expError == nil {
 				suite.Require().NoError(err)
 
 				// verify packet commitment was deleted on source chain
@@ -444,6 +445,7 @@ func (suite *KeeperTestSuite) TestHandleAcknowledgePacket() {
 				}
 			} else {
 				suite.Require().Error(err)
+				suite.Require().Contains(err.Error(), tc.expError.Error())
 			}
 		})
 	}
@@ -464,7 +466,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutPacket() {
 	testCases := []struct {
 		name     string
 		malleate func()
-		expPass  bool
+		expErr   error
 		noop     bool // indicate no-op
 	}{
 		{"success: ORDERED", func() {
@@ -484,7 +486,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutPacket() {
 
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, timeoutTimestamp)
 			packetKey = host.NextSequenceRecvKey(packet.GetDestPort(), packet.GetDestChannel())
-		}, true, false},
+		}, nil, false},
 		{"success: UNORDERED", func() {
 			path.Setup()
 
@@ -501,7 +503,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutPacket() {
 
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, timeoutTimestamp)
 			packetKey = host.PacketReceiptKey(packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
-		}, true, false},
+		}, nil, false},
 		{"success: UNORDERED timeout out of order packet", func() {
 			// setup uses an UNORDERED channel
 			path.Setup()
@@ -522,7 +524,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutPacket() {
 			suite.Require().NoError(err)
 
 			packetKey = host.PacketReceiptKey(packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
-		}, true, false},
+		}, nil, false},
 		{"success: ORDERED timeout out of order packet", func() {
 			path.SetChannelOrdered()
 			path.Setup()
@@ -543,18 +545,18 @@ func (suite *KeeperTestSuite) TestHandleTimeoutPacket() {
 			suite.Require().NoError(err)
 
 			packetKey = host.NextSequenceRecvKey(packet.GetDestPort(), packet.GetDestChannel())
-		}, true, false},
+		}, nil, false},
 		{"channel does not exist", func() {
 			// any non-nil value of packet is valid
 			suite.Require().NotNil(packet)
 
 			packetKey = host.NextSequenceRecvKey(packet.GetDestPort(), packet.GetDestChannel())
-		}, false, false},
+		}, errors.New("channel not found"), false},
 		{"successful no-op: UNORDERED - packet not sent", func() {
 			path.Setup()
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, 1, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, clienttypes.NewHeight(0, 1), 0)
 			packetKey = host.PacketReceiptKey(packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
-		}, true, true},
+		}, nil, true},
 	}
 
 	for _, tc := range testCases {
@@ -581,7 +583,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutPacket() {
 
 			events := ctx.EventManager().Events()
 
-			if tc.expPass {
+			if tc.expErr == nil {
 				suite.Require().NoError(err)
 
 				// replay should not return an error as it is treated as a no-op
@@ -602,6 +604,8 @@ func (suite *KeeperTestSuite) TestHandleTimeoutPacket() {
 
 			} else {
 				suite.Require().Error(err)
+
+				suite.Require().Contains(err.Error(), tc.expErr.Error())
 			}
 		})
 	}
@@ -623,7 +627,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutOnClosePacket() {
 	testCases := []struct {
 		name     string
 		malleate func()
-		expPass  bool
+		expError error
 	}{
 		{"success: ORDERED", func() {
 			path.SetChannelOrdered()
@@ -642,7 +646,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutOnClosePacket() {
 
 			// close counterparty channel
 			path.EndpointB.UpdateChannel(func(channel *channeltypes.Channel) { channel.State = channeltypes.CLOSED })
-		}, true},
+		}, nil},
 		{"success: UNORDERED", func() {
 			path.Setup()
 
@@ -659,7 +663,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutOnClosePacket() {
 
 			// close counterparty channel
 			path.EndpointB.UpdateChannel(func(channel *channeltypes.Channel) { channel.State = channeltypes.CLOSED })
-		}, true},
+		}, nil},
 		{"success: UNORDERED timeout out of order packet", func() {
 			// setup uses an UNORDERED channel
 			path.Setup()
@@ -681,7 +685,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutOnClosePacket() {
 
 			// close counterparty channel
 			path.EndpointB.UpdateChannel(func(channel *channeltypes.Channel) { channel.State = channeltypes.CLOSED })
-		}, true},
+		}, nil},
 		{"success: ORDERED timeout out of order packet", func() {
 			path.SetChannelOrdered()
 			path.Setup()
@@ -703,13 +707,13 @@ func (suite *KeeperTestSuite) TestHandleTimeoutOnClosePacket() {
 
 			// close counterparty channel
 			path.EndpointB.UpdateChannel(func(channel *channeltypes.Channel) { channel.State = channeltypes.CLOSED })
-		}, true},
+		}, nil},
 		{"channel does not exist", func() {
 			// any non-nil value of packet is valid
 			suite.Require().NotNil(packet)
 
 			packetKey = host.NextSequenceRecvKey(packet.GetDestPort(), packet.GetDestChannel())
-		}, false},
+		}, errors.New("channel not found")},
 		{"successful no-op: UNORDERED - packet not sent", func() {
 			path.Setup()
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, 1, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, clienttypes.NewHeight(0, 1), 0)
@@ -717,7 +721,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutOnClosePacket() {
 
 			// close counterparty channel
 			path.EndpointB.UpdateChannel(func(channel *channeltypes.Channel) { channel.State = channeltypes.CLOSED })
-		}, true},
+		}, nil},
 		{"ORDERED: channel not closed", func() {
 			path.SetChannelOrdered()
 			path.Setup()
@@ -732,7 +736,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutOnClosePacket() {
 
 			packet = channeltypes.NewPacket(ibctesting.MockPacketData, sequence, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, 0)
 			packetKey = host.NextSequenceRecvKey(packet.GetDestPort(), packet.GetDestChannel())
-		}, false},
+		}, errors.New("invalid proof")},
 	}
 
 	for _, tc := range testCases {
@@ -753,7 +757,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutOnClosePacket() {
 
 			_, err := suite.chainA.App.GetIBCKeeper().TimeoutOnClose(suite.chainA.GetContext(), msg)
 
-			if tc.expPass {
+			if tc.expError == nil {
 				suite.Require().NoError(err)
 
 				// replay should not return an error as it will be treated as a no-op
@@ -766,6 +770,7 @@ func (suite *KeeperTestSuite) TestHandleTimeoutOnClosePacket() {
 
 			} else {
 				suite.Require().Error(err)
+				suite.Require().Contains(err.Error(), tc.expError.Error())
 			}
 		})
 	}
@@ -782,9 +787,9 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 		msg               *clienttypes.MsgUpgradeClient
 	)
 	cases := []struct {
-		name    string
-		setup   func()
-		expPass bool
+		name   string
+		setup  func()
+		expErr error
 	}{
 		{
 			name: "successful upgrade",
@@ -822,7 +827,7 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 					upgradeClientProof, upgradedConsensusStateProof, suite.chainA.SenderAccount.GetAddress().String())
 				suite.Require().NoError(err)
 			},
-			expPass: true,
+			expErr: nil,
 		},
 		{
 			name: "VerifyUpgrade fails",
@@ -855,7 +860,7 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 				msg, err = clienttypes.NewMsgUpgradeClient(path.EndpointA.ClientID, upgradedClient, upgradedConsState, nil, nil, suite.chainA.SenderAccount.GetAddress().String())
 				suite.Require().NoError(err)
 			},
-			expPass: false,
+			expErr: errors.New("invalid merkle proof"),
 		},
 	}
 
@@ -879,7 +884,7 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 		ctx := suite.chainA.GetContext()
 		_, err = suite.chainA.GetSimApp().GetIBCKeeper().UpgradeClient(ctx, msg)
 
-		if tc.expPass {
+		if tc.expErr == nil {
 			suite.Require().NoError(err, "upgrade handler failed on valid case: %s", tc.name)
 			newClient, ok := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetClientState(suite.chainA.GetContext(), path.EndpointA.ClientID)
 			suite.Require().True(ok)
@@ -899,6 +904,7 @@ func (suite *KeeperTestSuite) TestUpgradeClient() {
 			ibctesting.AssertEvents(&suite.Suite, expectedEvents, ctx.EventManager().Events().ToABCIEvents())
 		} else {
 			suite.Require().Error(err, "upgrade handler passed on invalid case: %s", tc.name)
+			suite.Require().Contains(err.Error(), tc.expErr.Error())
 		}
 	}
 }
@@ -2529,34 +2535,34 @@ func (suite *KeeperTestSuite) TestIBCSoftwareUpgrade() {
 func (suite *KeeperTestSuite) TestUpdateClientParams() {
 	signer := suite.chainA.App.GetIBCKeeper().GetAuthority()
 	testCases := []struct {
-		name    string
-		msg     *clienttypes.MsgUpdateParams
-		expPass bool
+		name     string
+		msg      *clienttypes.MsgUpdateParams
+		expError error
 	}{
 		{
 			"success: valid signer and default params",
 			clienttypes.NewMsgUpdateParams(signer, clienttypes.DefaultParams()),
-			true,
+			nil,
 		},
 		{
 			"failure: malformed signer address",
 			clienttypes.NewMsgUpdateParams(ibctesting.InvalidID, clienttypes.DefaultParams()),
-			false,
+			errors.New("unauthorized"),
 		},
 		{
 			"failure: empty signer address",
 			clienttypes.NewMsgUpdateParams("", clienttypes.DefaultParams()),
-			false,
+			errors.New("unauthorized"),
 		},
 		{
 			"failure: whitespace signer address",
 			clienttypes.NewMsgUpdateParams("    ", clienttypes.DefaultParams()),
-			false,
+			errors.New("unauthorized"),
 		},
 		{
 			"failure: unauthorized signer address",
 			clienttypes.NewMsgUpdateParams(ibctesting.TestAccAddress, clienttypes.DefaultParams()),
-			false,
+			errors.New("unauthorized"),
 		},
 	}
 
@@ -2565,12 +2571,13 @@ func (suite *KeeperTestSuite) TestUpdateClientParams() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 			_, err := suite.chainA.App.GetIBCKeeper().UpdateClientParams(suite.chainA.GetContext(), tc.msg)
-			if tc.expPass {
+			if tc.expError == nil {
 				suite.Require().NoError(err)
 				p := suite.chainA.App.GetIBCKeeper().ClientKeeper.GetParams(suite.chainA.GetContext())
 				suite.Require().Equal(tc.msg.Params, p)
 			} else {
 				suite.Require().Error(err)
+				suite.Require().Contains(err.Error(), tc.expError.Error())
 			}
 		})
 	}
@@ -2580,34 +2587,34 @@ func (suite *KeeperTestSuite) TestUpdateClientParams() {
 func (suite *KeeperTestSuite) TestUpdateConnectionParams() {
 	signer := suite.chainA.App.GetIBCKeeper().GetAuthority()
 	testCases := []struct {
-		name    string
-		msg     *connectiontypes.MsgUpdateParams
-		expPass bool
+		name   string
+		msg    *connectiontypes.MsgUpdateParams
+		expErr error
 	}{
 		{
 			"success: valid signer and default params",
 			connectiontypes.NewMsgUpdateParams(signer, connectiontypes.DefaultParams()),
-			true,
+			nil,
 		},
 		{
 			"failure: malformed signer address",
 			connectiontypes.NewMsgUpdateParams(ibctesting.InvalidID, connectiontypes.DefaultParams()),
-			false,
+			errors.New("unauthorized"),
 		},
 		{
 			"failure: empty signer address",
 			connectiontypes.NewMsgUpdateParams("", connectiontypes.DefaultParams()),
-			false,
+			errors.New("unauthorized"),
 		},
 		{
 			"failure: whitespace signer address",
 			connectiontypes.NewMsgUpdateParams("    ", connectiontypes.DefaultParams()),
-			false,
+			errors.New("unauthorized"),
 		},
 		{
 			"failure: unauthorized signer address",
 			connectiontypes.NewMsgUpdateParams(ibctesting.TestAccAddress, connectiontypes.DefaultParams()),
-			false,
+			errors.New("unauthorized"),
 		},
 	}
 
@@ -2616,12 +2623,13 @@ func (suite *KeeperTestSuite) TestUpdateConnectionParams() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 			_, err := suite.chainA.App.GetIBCKeeper().UpdateConnectionParams(suite.chainA.GetContext(), tc.msg)
-			if tc.expPass {
+			if tc.expErr == nil {
 				suite.Require().NoError(err)
 				p := suite.chainA.App.GetIBCKeeper().ConnectionKeeper.GetParams(suite.chainA.GetContext())
 				suite.Require().Equal(tc.msg.Params, p)
 			} else {
 				suite.Require().Error(err)
+				suite.Require().Contains(err.Error(), tc.expErr.Error())
 			}
 		})
 	}


### PR DESCRIPTION
ref: #7175 

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
