### PR TITLE
(chore) update tests in internal/validate to expect specific error

### DIFF
--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -47,7 +47,7 @@ func TestGRPCRequest(t *testing.T) {
 			if tc.expErr == nil {
 				require.NoError(t, err, tc.msg)
 			} else {
-				require.Error(t, err)
+				require.Error(t, err, tc.msg)
 				require.Equal(t, err.Error(), tc.expErr.Error())
 			}
 		})

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,6 +1,7 @@
 package validate_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -18,35 +19,36 @@ func TestGRPCRequest(t *testing.T) {
 		msg       string
 		portID    string
 		channelID string
-		expPass   bool
+		expErr    error
 	}{
 		{
 			"success",
 			validID,
 			validID,
-			true,
+			nil,
 		},
 		{
 			"invalid portID",
 			invalidID,
 			validID,
-			false,
+			errors.New("rpc error: code = InvalidArgument desc = identifier cannot be blank: invalid identifier"),
 		},
 		{
 			"invalid channelID",
 			validID,
 			invalidID,
-			false,
+			errors.New("rpc error: code = InvalidArgument desc = identifier cannot be blank: invalid identifier"),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Case %s", tc.msg), func(t *testing.T) {
 			err := validate.GRPCRequest(tc.portID, tc.channelID)
-			if tc.expPass {
+			if tc.expErr == nil {
 				require.NoError(t, err, tc.msg)
 			} else {
-				require.Error(t, err, tc.msg)
+				require.Error(t, err)
+				require.Equal(t, err.Error(), tc.expErr.Error())
 			}
 		})
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

ref: #7175 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
