### PR TITLE
refactor: use header info for interchain accounts address generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,16 +36,14 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-### Testing
-
-* [\#7430](https://github.com/cosmos/ibc-go/pull/7430) Update the block proposer in test chains for each block.
-
 ### Dependencies
 
-* [\#7540](https://github.com/cosmos/ibc-go/pull/7540) Bump CometBFT to v0.38.15.
+* [\#7261](https://github.com/cosmos/ibc-go/pull/7261) Bump CometBFT to v1.0.0.
+* [\#7261](https://github.com/cosmos/ibc-go/pull/7261) Bump Cosmos SDK to v0.52.0.
 
 ### API Breaking
 
+* (apps/27-interchain-accounts) [\#7713](https://github.com/cosmos/ibc-go/pull/7713) Update interchain accounts `GenerateAddress` func to now accept `header.Info` in favour of `sdk.Context`. This function now uses `AppHash` and `Hash` (merkle root of block) instead of `AppHash` and `DataHash` as pre-image data for address generation.
 * (core, apps) [\#7213](https://github.com/cosmos/ibc-go/pull/7213) Remove capabilities from `SendPacket`.
 * (core, apps) [\#7213](https://github.com/cosmos/ibc-go/pull/7225) Remove capabilities from `WriteAcknowledgement`.
 * (core, apps) [\#7232](https://github.com/cosmos/ibc-go/pull/7232) Remove capabilities from channel handshake methods. TODO list all changes 
@@ -62,6 +60,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### State Machine Breaking
 
 ### Improvements
+
+* (testing)[\#7430](https://github.com/cosmos/ibc-go/pull/7430) Update the block proposer in test chains for each block.
 
 ### Features
 

--- a/modules/apps/27-interchain-accounts/controller/keeper/genesis_test.go
+++ b/modules/apps/27-interchain-accounts/controller/keeper/genesis_test.go
@@ -21,7 +21,7 @@ func (suite *KeeperTestSuite) TestInitGenesis() {
 		},
 	}
 
-	interchainAccAddr := icatypes.GenerateAddress(suite.chainB.GetContext(), ibctesting.FirstConnectionID, TestPortID)
+	interchainAccAddr := icatypes.GenerateAddress(suite.chainB.GetContext().HeaderInfo(), ibctesting.FirstConnectionID, TestPortID)
 	genesisState := genesistypes.ControllerGenesisState{
 		ActiveChannels: []genesistypes.ActiveChannel{
 			{

--- a/modules/apps/27-interchain-accounts/host/ibc_module_test.go
+++ b/modules/apps/27-interchain-accounts/host/ibc_module_test.go
@@ -149,7 +149,7 @@ func (suite *InterchainAccountsTestSuite) TestOnChanOpenTry() {
 		},
 		{
 			"account address generation is block dependent", func() {
-				interchainAccAddr := icatypes.GenerateAddress(suite.chainB.GetContext(), path.EndpointB.ConnectionID, path.EndpointA.ChannelConfig.PortID)
+				interchainAccAddr := icatypes.GenerateAddress(suite.chainB.GetContext().HeaderInfo(), path.EndpointB.ConnectionID, path.EndpointA.ChannelConfig.PortID)
 				interchainAcc := icatypes.NewInterchainAccount(authtypes.NewBaseAccountWithAddress(interchainAccAddr), path.EndpointA.ChannelConfig.PortID)
 				suite.chainB.GetSimApp().AuthKeeper.NewAccount(suite.chainB.GetContext(), interchainAcc)
 				suite.chainB.GetSimApp().AuthKeeper.SetAccount(suite.chainB.GetContext(), interchainAcc)

--- a/modules/apps/27-interchain-accounts/host/keeper/account.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/account.go
@@ -15,7 +15,7 @@ import (
 // and block dependent information. An error is returned if an account already exists for the generated account.
 // An interchain account type is set in the account keeper and the interchain account address mapping is updated.
 func (k Keeper) createInterchainAccount(ctx context.Context, connectionID, controllerPortID string) (sdk.AccAddress, error) {
-	accAddress := icatypes.GenerateAddress(ctx, connectionID, controllerPortID)
+	accAddress := icatypes.GenerateAddress(k.HeaderService.HeaderInfo(ctx), connectionID, controllerPortID)
 
 	if acc := k.authKeeper.GetAccount(ctx, accAddress); acc != nil {
 		return nil, errorsmod.Wrapf(icatypes.ErrAccountAlreadyExist, "existing account for newly generated interchain account address %s", accAddress)

--- a/modules/apps/27-interchain-accounts/host/keeper/genesis_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/genesis_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (suite *KeeperTestSuite) TestInitGenesis() {
-	interchainAccAddr := icatypes.GenerateAddress(suite.chainB.GetContext(), ibctesting.FirstConnectionID, TestPortID)
+	interchainAccAddr := icatypes.GenerateAddress(suite.chainB.GetContext().HeaderInfo(), ibctesting.FirstConnectionID, TestPortID)
 	genesisState := genesistypes.HostGenesisState{
 		ActiveChannels: []genesistypes.ActiveChannel{
 			{
@@ -65,7 +65,7 @@ func (suite *KeeperTestSuite) TestGenesisParams() {
 
 		suite.Run(tc.name, func() {
 			suite.SetupTest() // reset
-			interchainAccAddr := icatypes.GenerateAddress(suite.chainB.GetContext(), ibctesting.FirstConnectionID, TestPortID)
+			interchainAccAddr := icatypes.GenerateAddress(suite.chainB.GetContext().HeaderInfo(), ibctesting.FirstConnectionID, TestPortID)
 			genesisState := genesistypes.HostGenesisState{
 				ActiveChannels: []genesistypes.ActiveChannel{
 					{

--- a/modules/apps/27-interchain-accounts/host/keeper/handshake_test.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/handshake_test.go
@@ -171,7 +171,7 @@ func (suite *KeeperTestSuite) TestOnChanOpenTry() {
 			{
 				"account already exists",
 				func() {
-					interchainAccAddr := icatypes.GenerateAddress(suite.chainB.GetContext(), path.EndpointB.ConnectionID, path.EndpointA.ChannelConfig.PortID)
+					interchainAccAddr := icatypes.GenerateAddress(suite.chainB.GetContext().HeaderInfo(), path.EndpointB.ConnectionID, path.EndpointA.ChannelConfig.PortID)
 					interchainAcc := icatypes.NewInterchainAccount(authtypes.NewBaseAccountWithAddress(interchainAccAddr), path.EndpointA.ChannelConfig.PortID)
 					suite.chainB.GetSimApp().AuthKeeper.NewAccount(suite.chainB.GetContext(), interchainAcc)
 					suite.chainB.GetSimApp().AuthKeeper.SetAccount(suite.chainB.GetContext(), interchainAcc)

--- a/modules/apps/27-interchain-accounts/types/account.go
+++ b/modules/apps/27-interchain-accounts/types/account.go
@@ -1,13 +1,13 @@
 package types
 
 import (
-	"context"
 	"encoding/json"
 	"regexp"
 	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 
+	"cosmossdk.io/core/header"
 	errorsmod "cosmossdk.io/errors"
 
 	crypto "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -43,15 +43,13 @@ type interchainAccountPretty struct {
 }
 
 // GenerateAddress returns an sdk.AccAddress derived using a host module account address, host connection ID, the controller portID,
-// the current block app hash, and the current block data hash. The sdk.AccAddress returned is a sub-address of the host module account.
-func GenerateAddress(ctx context.Context, connectionID, portID string) sdk.AccAddress {
+// the current block app hash, and the current block hash (merkle root of block). The sdk.AccAddress returned is a sub-address of the host module account.
+func GenerateAddress(headerInfo header.Info, connectionID, portID string) sdk.AccAddress {
 	hostModuleAcc := sdkaddress.Module(ModuleName, []byte(hostAccountsKey))
-	sdkCtx := sdk.UnwrapSDKContext(ctx) // TODO: https://github.com/cosmos/ibc-go/issues/5917
-	header := sdkCtx.BlockHeader()
 
 	buf := []byte(connectionID + portID)
-	buf = append(buf, header.AppHash...)
-	buf = append(buf, header.DataHash...)
+	buf = append(buf, headerInfo.AppHash...)
+	buf = append(buf, headerInfo.Hash...)
 
 	return sdkaddress.Derive(hostModuleAcc, buf)
 }

--- a/modules/apps/27-interchain-accounts/types/account_test.go
+++ b/modules/apps/27-interchain-accounts/types/account_test.go
@@ -44,7 +44,7 @@ func TestTypesTestSuite(t *testing.T) {
 }
 
 func (suite *TypesTestSuite) TestGenerateAddress() {
-	addr := types.GenerateAddress(suite.chainA.GetContext(), "test-connection-id", "test-port-id")
+	addr := types.GenerateAddress(suite.chainA.GetContext().HeaderInfo(), "test-connection-id", "test-port-id")
 	accAddr, err := sdk.AccAddressFromBech32(addr.String())
 
 	suite.Require().NoError(err, "TestGenerateAddress failed")

--- a/testing/chain.go
+++ b/testing/chain.go
@@ -201,8 +201,13 @@ func NewTestChain(t *testing.T, coord *Coordinator, chainID string) *TestChain {
 func (chain *TestChain) GetContext() sdk.Context {
 	ctx := chain.App.GetBaseApp().NewUncachedContext(false, chain.ProposedHeader)
 
+	cmtHeader, err := cmttypes.HeaderFromProto(&chain.ProposedHeader)
+	require.NoError(chain.TB, err)
+
 	// since:cosmos-sdk/v0.52 when fetching time from context, it now returns from HeaderInfo
 	headerInfo := header.Info{
+		AppHash: chain.ProposedHeader.AppHash,
+		Hash:    cmtHeader.Hash(),
 		Time:    chain.ProposedHeader.Time,
 		ChainID: chain.ProposedHeader.ChainID,
 	}
@@ -337,6 +342,7 @@ func (chain *TestChain) commitBlock(res *abci.FinalizeBlockResponse) {
 
 	// increment the current header
 	chain.ProposedHeader = cmtproto.Header{
+		Version: cmtprotoversion.Consensus{Block: cmtversion.BlockProtocol, App: 1},
 		ChainID: chain.ChainID,
 		Height:  chain.App.LastBlockHeight() + 1,
 		AppHash: chain.App.LastCommitID().Hash,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Removes `UnwrapSDKContext` for interchain accounts. 
Now uses block hash (merkle root of block) instead of dataHash for interchain accounts address generation.

The `ctx.BlockHeader` is deprecated and recommended to now use service based approach. The `HeaderService` provided by cosmos-sdk returns `header.Info` which only contains `appHash`, `hash` (merkle root of block), `height`, `time` and `chainID`.

It is recommended to use `cometservice` when anything else is needed.


<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
