### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/docs/05-migrations/07-v5-to-v6.md
+++ b/docs/docs/05-migrations/07-v5-to-v6.md
@@ -198,10 +198,10 @@ func DefaultParams() Params {
 
 `SerializeCosmosTx` takes in a `[]proto.Message` instead of `[]sdk.Message`. This allows for the serialization of proto messages without requiring the fulfillment of the `sdk.Msg` interface.
 
-The `27-interchain-accounts` genesis types have been moved to their own package: `modules/apps/27-interchain-acccounts/genesis/types`.
+The `27-interchain-accounts` genesis types have been moved to their own package: `modules/apps/27-interchain-accounts/genesis/types`.
 This change facilitates the addition of the ICS27 controller submodule `MsgServer` and avoids cyclic imports. This should have minimal disruption to chain developers integrating `27-interchain-accounts`.
 
-The ICS27 host submodule `NewKeeper` function in `modules/apps/27-interchain-acccounts/host/keeper` now includes an additional parameter of type `ICS4Wrapper`.
+The ICS27 host submodule `NewKeeper` function in `modules/apps/27-interchain-accounts/host/keeper` now includes an additional parameter of type `ICS4Wrapper`.
 This provides the host submodule with the ability to correctly unwrap channel versions in the event of a channel reopening handshake.
 
 ```diff


### PR DESCRIPTION
Corrected `acccounts` to `accounts`