### PR TITLE
refactor: use address.Codec to replace deprecated function

### DIFF
--- a/modules/light-clients/08-wasm/go.mod
+++ b/modules/light-clients/08-wasm/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/cosmos/ibc-go/v9 v9.0.0
 	github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/hashicorp/golang-lru v1.0.2
 	github.com/spf13/cast v1.7.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
@@ -143,7 +144,6 @@ require (
 	github.com/hashicorp/go-plugin v1.6.2 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
-	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect


### PR DESCRIPTION
## Description

This PR replaces the deprecated address-related functions with the new `address.Codec` implementations:

* Replace `sdk.AccAddressFromBech32()` with `address.Codec  StringToBytes()`
* Replace `sdk.AccAddress.String()` with address.Codec BytesToString()`

These changes align with the latest SDK address handling practices and remove usage of deprecated functions.

<!-- No related issue for this refactoring work -->