### PR TITLE
refactor: use address.Codec to replace deprecated function

### DIFF
--- a/modules/light-clients/08-wasm/client/cli/tx.go
+++ b/modules/light-clients/08-wasm/client/cli/tx.go
@@ -44,11 +44,14 @@ func newSubmitStoreCodeProposalCmd() *cobra.Command {
 
 			authority, _ := cmd.Flags().GetString(FlagAuthority)
 			if authority != "" {
-				if _, err = sdk.AccAddressFromBech32(authority); err != nil {
+				if _, err = clientCtx.AddressCodec.StringToBytes(authority); err != nil {
 					return fmt.Errorf("invalid authority address: %w", err)
 				}
 			} else {
-				authority = sdk.AccAddress(address.Module(govtypes.ModuleName)).String()
+				authority, err = clientCtx.AddressCodec.BytesToString(address.Module(govtypes.ModuleName))
+				if err != nil {
+					return fmt.Errorf("failed to get authority address: %w", err)
+				}
 			}
 
 			code, err := os.ReadFile(args[0])


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR replaces the deprecated address-related functions with the new address.Codec implementations:

Replace sdk.AccAddressFromBech32() with address.Codec  StringToBytes()
Replace sdk.AccAddress.String() with address.Codec BytesToString()`
These changes align with the latest SDK address handling practices and remove usage of deprecated functions.
