### PR TITLE
fix: avoid invalid identifier error when validate genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (core/03-connection) [\#7397](https://github.com/cosmos/ibc-go/pull/7397) Skip the genesis validation connectionID for localhost client.
+
 ## [v7.4.1](https://github.com/cosmos/ibc-go/releases/tag/v7.4.1) - 2024-05-22
 
 ### Improvements

--- a/modules/core/03-connection/types/genesis.go
+++ b/modules/core/03-connection/types/genesis.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 )
 
 // NewConnectionPaths creates a ConnectionPaths instance.
@@ -45,13 +46,15 @@ func (gs GenesisState) Validate() error {
 	var maxSequence uint64
 
 	for i, conn := range gs.Connections {
-		sequence, err := ParseConnectionSequence(conn.Id)
-		if err != nil {
-			return err
-		}
+		if conn.Id != exported.LocalhostConnectionID {
+			sequence, err := ParseConnectionSequence(conn.Id)
+			if err != nil {
+				return err
+			}
 
-		if sequence > maxSequence {
-			maxSequence = sequence
+			if sequence > maxSequence {
+				maxSequence = sequence
+			}
 		}
 
 		if err := conn.ValidateBasic(); err != nil {

--- a/modules/core/03-connection/types/genesis_test.go
+++ b/modules/core/03-connection/types/genesis_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cosmos/ibc-go/v7/modules/core/03-connection/types"
 	commitmenttypes "github.com/cosmos/ibc-go/v7/modules/core/23-commitment/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"
 )
 
@@ -90,6 +91,20 @@ func TestValidateGenesis(t *testing.T) {
 				types.DefaultParams(),
 			),
 			expPass: false,
+		},
+		{
+			name: "localhost connection identifier",
+			genState: types.NewGenesisState(
+				[]types.IdentifiedConnection{
+					types.NewIdentifiedConnection(exported.LocalhostConnectionID, types.NewConnectionEnd(types.INIT, clientID, types.Counterparty{clientID2, connectionID2, commitmenttypes.NewMerklePrefix([]byte("prefix"))}, []*types.Version{ibctesting.ConnectionVersion}, 500)),
+				},
+				[]types.ConnectionPaths{
+					{clientID, []string{connectionID}},
+				},
+				0,
+				types.DefaultParams(),
+			),
+			expPass: true,
 		},
 		{
 			name: "next connection sequence is not greater than maximum connection identifier sequence provided",


### PR DESCRIPTION
that contains local client

backports #7397

## Description

closes: #7396 for the v7.4.x branch which is not (yet) EOL 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
