### PR TITLE
chore: migrate 08-wasm to cosmos-sdk appmodule.Environment (#7712)

### DIFF
--- a/modules/light-clients/08-wasm/keeper/keeper.go
+++ b/modules/light-clients/08-wasm/keeper/keeper.go
@@ -8,20 +8,20 @@ import (
 	wasmvm "github.com/CosmWasm/wasmvm/v2"
 
 	"cosmossdk.io/collections"
-	"cosmossdk.io/core/store"
+	"cosmossdk.io/core/appmodule"
 	errorsmod "cosmossdk.io/errors"
-	"cosmossdk.io/log"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
 	clienttypes "github.com/cosmos/ibc-go/v9/modules/core/02-client/types"
-	"github.com/cosmos/ibc-go/v9/modules/core/exported"
 )
 
 // Keeper defines the 08-wasm keeper
 type Keeper struct {
+	appmodule.Environment
+
 	// implements gRPC QueryServer interface
 	types.QueryServer
 
@@ -30,8 +30,7 @@ type Keeper struct {
 
 	vm types.WasmEngine
 
-	checksums    collections.KeySet[[]byte]
-	storeService store.KVStoreService
+	checksums collections.KeySet[[]byte]
 
 	queryPlugins QueryPlugins
 
@@ -46,15 +45,6 @@ func (k Keeper) Codec() codec.BinaryCodec {
 // GetAuthority returns the 08-wasm module's authority.
 func (k Keeper) GetAuthority() string {
 	return k.authority
-}
-
-// Logger returns a module-specific logger.
-func (Keeper) Logger(ctx sdk.Context) log.Logger {
-	return moduleLogger(ctx)
-}
-
-func moduleLogger(ctx sdk.Context) log.Logger {
-	return ctx.Logger().With("module", "x/"+exported.ModuleName+"-"+types.ModuleName)
 }
 
 // GetVM returns the keeper's vm engine.

--- a/modules/light-clients/08-wasm/keeper/keeper_vm.go
+++ b/modules/light-clients/08-wasm/keeper/keeper_vm.go
@@ -10,7 +10,7 @@ import (
 	wasmvm "github.com/CosmWasm/wasmvm/v2"
 
 	"cosmossdk.io/collections"
-	"cosmossdk.io/core/store"
+	"cosmossdk.io/core/appmodule"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 
@@ -22,7 +22,7 @@ import (
 // and the same Wasm VM instance should be shared with it.
 func NewKeeperWithVM(
 	cdc codec.BinaryCodec,
-	storeService store.KVStoreService,
+	env appmodule.Environment,
 	clientKeeper types.ClientKeeper,
 	authority string,
 	vm types.WasmEngine,
@@ -41,7 +41,7 @@ func NewKeeperWithVM(
 		panic(errors.New("wasm VM must not be nil"))
 	}
 
-	if storeService == nil {
+	if env.KVStoreService == nil {
 		panic(errors.New("store service must not be nil"))
 	}
 
@@ -49,13 +49,13 @@ func NewKeeperWithVM(
 		panic(errors.New("authority must be non-empty"))
 	}
 
-	sb := collections.NewSchemaBuilder(storeService)
+	sb := collections.NewSchemaBuilder(env.KVStoreService)
 
 	keeper := &Keeper{
+		Environment:  env,
 		cdc:          cdc,
 		vm:           vm,
 		checksums:    collections.NewKeySet(sb, types.ChecksumsKey, "checksums", collections.BytesKey),
-		storeService: storeService,
 		clientKeeper: clientKeeper,
 		authority:    authority,
 	}
@@ -81,7 +81,7 @@ func NewKeeperWithVM(
 // and a Wasm VM needs to be instantiated using the provided parameters.
 func NewKeeperWithConfig(
 	cdc codec.BinaryCodec,
-	storeService store.KVStoreService,
+	env appmodule.Environment,
 	clientKeeper types.ClientKeeper,
 	authority string,
 	wasmConfig types.WasmConfig,
@@ -93,5 +93,5 @@ func NewKeeperWithConfig(
 		panic(fmt.Errorf("failed to instantiate new Wasm VM instance: %v", err))
 	}
 
-	return NewKeeperWithVM(cdc, storeService, clientKeeper, authority, vm, queryRouter, opts...)
+	return NewKeeperWithVM(cdc, env, clientKeeper, authority, vm, queryRouter, opts...)
 }

--- a/modules/light-clients/08-wasm/keeper/migrations.go
+++ b/modules/light-clients/08-wasm/keeper/migrations.go
@@ -41,13 +41,13 @@ func (m Migrator) MigrateChecksums(ctx sdk.Context) error {
 		return err
 	}
 
-	m.keeper.Logger(ctx).Info("successfully migrated Checksums to collections")
+	m.keeper.Logger.Info("successfully migrated Checksums to collections")
 	return nil
 }
 
 // getStoredChecksums returns the checksums stored under the KeyChecksums key.
 func (m Migrator) getStoredChecksums(ctx sdk.Context) ([][]byte, error) {
-	store := m.keeper.storeService.OpenKVStore(ctx)
+	store := m.keeper.KVStoreService.OpenKVStore(ctx)
 
 	bz, err := store.Get([]byte(types.KeyChecksums))
 	if err != nil {
@@ -65,7 +65,7 @@ func (m Migrator) getStoredChecksums(ctx sdk.Context) ([][]byte, error) {
 
 // deleteChecksums deletes the checksums stored under the KeyChecksums key.
 func (m Migrator) deleteChecksums(ctx sdk.Context) error {
-	store := m.keeper.storeService.OpenKVStore(ctx)
+	store := m.keeper.KVStoreService.OpenKVStore(ctx)
 	err := store.Delete([]byte(types.KeyChecksums))
 
 	return err

--- a/modules/light-clients/08-wasm/keeper/options_test.go
+++ b/modules/light-clients/08-wasm/keeper/options_test.go
@@ -6,11 +6,9 @@ import (
 
 	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
 
-	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/keeper"
-	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
 )
 
 func mockErrorCustomQuerier() func(sdk.Context, json.RawMessage) ([]byte, error) {
@@ -37,7 +35,7 @@ func (suite *KeeperTestSuite) TestNewKeeperWithOptions() {
 			func() {
 				k = keeper.NewKeeperWithVM(
 					GetSimApp(suite.chainA).AppCodec(),
-					runtime.NewKVStoreService(GetSimApp(suite.chainA).GetKey(types.StoreKey)),
+					suite.env,
 					GetSimApp(suite.chainA).IBCKeeper.ClientKeeper,
 					GetSimApp(suite.chainA).WasmClientKeeper.GetAuthority(),
 					GetSimApp(suite.chainA).WasmClientKeeper.GetVM(),
@@ -62,7 +60,7 @@ func (suite *KeeperTestSuite) TestNewKeeperWithOptions() {
 				})
 				k = keeper.NewKeeperWithVM(
 					GetSimApp(suite.chainA).AppCodec(),
-					runtime.NewKVStoreService(GetSimApp(suite.chainA).GetKey(types.StoreKey)),
+					suite.env,
 					GetSimApp(suite.chainA).IBCKeeper.ClientKeeper,
 					GetSimApp(suite.chainA).WasmClientKeeper.GetAuthority(),
 					GetSimApp(suite.chainA).WasmClientKeeper.GetVM(),
@@ -88,7 +86,7 @@ func (suite *KeeperTestSuite) TestNewKeeperWithOptions() {
 				})
 				k = keeper.NewKeeperWithVM(
 					GetSimApp(suite.chainA).AppCodec(),
-					runtime.NewKVStoreService(GetSimApp(suite.chainA).GetKey(types.StoreKey)),
+					suite.env,
 					GetSimApp(suite.chainA).IBCKeeper.ClientKeeper,
 					GetSimApp(suite.chainA).WasmClientKeeper.GetAuthority(),
 					GetSimApp(suite.chainA).WasmClientKeeper.GetVM(),
@@ -115,7 +113,7 @@ func (suite *KeeperTestSuite) TestNewKeeperWithOptions() {
 				})
 				k = keeper.NewKeeperWithVM(
 					GetSimApp(suite.chainA).AppCodec(),
-					runtime.NewKVStoreService(GetSimApp(suite.chainA).GetKey(types.StoreKey)),
+					suite.env,
 					GetSimApp(suite.chainA).IBCKeeper.ClientKeeper,
 					GetSimApp(suite.chainA).WasmClientKeeper.GetAuthority(),
 					GetSimApp(suite.chainA).WasmClientKeeper.GetVM(),

--- a/modules/light-clients/08-wasm/keeper/querier.go
+++ b/modules/light-clients/08-wasm/keeper/querier.go
@@ -7,6 +7,7 @@ import (
 
 	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
 
+	"cosmossdk.io/core/log"
 	errorsmod "cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 
@@ -15,6 +16,7 @@ import (
 	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
 
 	"github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
+	"github.com/cosmos/ibc-go/v9/modules/core/exported"
 )
 
 /*
@@ -77,6 +79,9 @@ func (q *queryHandler) Query(request wasmvmtypes.QueryRequest, gasLimit uint64) 
 
 	moduleLogger(q.Ctx).Debug("Redacting query error", "cause", err)
 	return nil, redactError(err)
+}
+func moduleLogger(ctx sdk.Context) log.Logger {
+	return ctx.Logger().With("module", "x/"+exported.ModuleName+"-"+types.ModuleName)
 }
 
 type (

--- a/modules/light-clients/08-wasm/testing/simapp/app.go
+++ b/modules/light-clients/08-wasm/testing/simapp/app.go
@@ -547,13 +547,27 @@ func NewSimApp(
 	if mockVM != nil {
 		// NOTE: mockVM is used for testing purposes only!
 		app.WasmClientKeeper = wasmkeeper.NewKeeperWithVM(
-			appCodec, runtime.NewKVStoreService(keys[wasmtypes.StoreKey]), app.IBCKeeper.ClientKeeper,
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(), mockVM, app.GRPCQueryRouter(),
+			appCodec,
+			runtime.NewEnvironment(
+				runtime.NewKVStoreService(keys[wasmtypes.StoreKey]),
+				logger.With(log.ModuleKey, "x/"+ibcexported.ModuleName+"-"+wasmtypes.ModuleName),
+			),
+			app.IBCKeeper.ClientKeeper,
+			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			mockVM,
+			app.GRPCQueryRouter(),
 		)
 	} else {
 		app.WasmClientKeeper = wasmkeeper.NewKeeperWithConfig(
-			appCodec, runtime.NewKVStoreService(keys[wasmtypes.StoreKey]), app.IBCKeeper.ClientKeeper,
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(), wasmConfig, app.GRPCQueryRouter(),
+			appCodec,
+			runtime.NewEnvironment(
+				runtime.NewKVStoreService(keys[wasmtypes.StoreKey]),
+				logger.With(log.ModuleKey, "x/"+ibcexported.ModuleName+"-"+wasmtypes.ModuleName),
+			),
+			app.IBCKeeper.ClientKeeper,
+			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			wasmConfig,
+			app.GRPCQueryRouter(),
 		)
 	}
 


### PR DESCRIPTION
## Issue: #7712 

## Description
Replace the 08-wasm keeper's storeService implementation with the cosmos-sdk appmodule.Environment.



