### PR TITLE
fix: typos correction

### DIFF
--- a/docs/architecture/adr-006-02-client-refactor.md
+++ b/docs/architecture/adr-006-02-client-refactor.md
@@ -179,7 +179,7 @@ The old verification functions (`VerifyClientState`, `VerifyConnection`, etc) sh
 - Flexibility for light client implementations
 - Well defined interfaces and their required functionality
 - Generic verification functions
-- Applies changes necessary for future client/connection/channel upgrabability features
+- Applies changes necessary for future client/connection/channel upgradability features
 - Timeout processing for solo machines
 - Reduced code complexity
 

--- a/docs/architecture/adr-008-app-caller-cbs.md
+++ b/docs/architecture/adr-008-app-caller-cbs.md
@@ -494,7 +494,7 @@ func (im IBCModule) OnTimeoutPacket(
 //
 // panics if
 //   - the contractExecutor panics for any reason, and the callbackType is SendPacket, or
-//   - the contractExecutor runs out of gas and the relayer has not reserved gas grater than or equal to
+//   - the contractExecutor runs out of gas and the relayer has not reserved gas greater than or equal to
 //     CommitGasLimit.
 func (IBCMiddleware) processCallback(
 	ctx sdk.Context, callbackType types.CallbackType,

--- a/docs/architecture/adr-009-v6-ics27-msgserver.md
+++ b/docs/architecture/adr-009-v6-ics27-msgserver.md
@@ -48,7 +48,7 @@ This will be possible for SDK v0.46.x and above.
 ### Allow `nil` underlying applications
 
 Authentication modules should interact with the controller module via the message server and should not be associated with application logic.
-For now, it will be allowed to set a `nil` underlying application.
+For now, setting a `nil` underlying application will be allowed.
 A future version may remove the underlying application entirely.
 
 See issue [#2040](https://github.com/cosmos/ibc-go/issues/2040)


### PR DESCRIPTION
## Description

This pull request fixes typos in three architecture documentation files:

1. **docs/architecture/adr-006-02-client-refactor.md**:
   - Corrected "upgrabability" to "upgradability".

2. **docs/architecture/adr-008-app-caller-cbs.md**:
   - Corrected "grater" to "greater".

3. **docs/architecture/adr-009-v6-ics27-msgserver.md**:
   - Improved phrasing for clarity by adjusting the sentence structure regarding setting a `nil` underlying application.

These changes improve the clarity and professionalism of the documentation.

## Checklist

- [x] Targeted PR against the correct branch.
- [ ] Linked to GitHub issue with discussion and accepted design (N/A for this PR as it's a simple typo fix).
- [x] Code follows the repository's standards.
- [ ] Wrote unit and integration tests (N/A for documentation changes).
- [x] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` comments (N/A for this PR as it's not code-related).
- [x] Provided a conventional commit message (`fix: typos correction`).
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Reviewed `SonarCloud Report` (not applicable for documentation-only changes).

---

This PR does not introduce any new functionality or code changes, and no additional tests are necessary.
