### PR TITLE
Update links and fix typos

### DIFF
--- a/modules/apps/callbacks/testing/simapp/app.go
+++ b/modules/apps/callbacks/testing/simapp/app.go
@@ -725,7 +725,7 @@ func NewSimApp(
 	// not need it by default, so feel free to comment the next line if you do
 	// not need tips.
 	// To read more about tips:
-	// https://docs.cosmos.network/main/core/tips.html
+	// https://docs.cosmos.network/v0.46/core/tips.html
 	//
 	// Please note that changing any of the anteHandler or postHandler chain is
 	// likely to be a state-machine breaking change, which needs a coordinated

--- a/modules/light-clients/08-wasm/testing/simapp/app.go
+++ b/modules/light-clients/08-wasm/testing/simapp/app.go
@@ -852,7 +852,7 @@ func NewSimApp(
 	// not need it by default, so feel free to comment the next line if you do
 	// not need tips.
 	// To read more about tips:
-	// https://docs.cosmos.network/main/core/tips.html
+	// https://docs.cosmos.network/v0.46/core/tips.html
 	//
 	// Please note that changing any of the anteHandler or postHandler chain is
 	// likely to be a state-machine breaking change, which needs a coordinated

--- a/modules/light-clients/08-wasm/testing/wasm_endpoint.go
+++ b/modules/light-clients/08-wasm/testing/wasm_endpoint.go
@@ -22,7 +22,7 @@ func NewWasmEndpoint(chain *ibctesting.TestChain) *WasmEndpoint {
 	}
 }
 
-// CreateClient creates an wasm client on a mock cometbft chain.
+// CreateClient creates a wasm client on a mock cometbft chain.
 // The client and consensus states are represented by byte slices
 // and the starting height is 1.
 func (endpoint *WasmEndpoint) CreateClient() error {


### PR DESCRIPTION
This pull request addresses two issues in the codebase:
1. Corrected outdated links to the Cosmos SDK documentation in `app.go` files:
   - Updated from `https://docs.cosmos.network/main/core/tips.html` to `https://docs.cosmos.network/v0.46/core/tips.html`.
2. Fixed a grammatical error in the `wasm_endpoint.go` file:
   - Changed `an wasm client` to `a wasm client` for proper article usage.

---

### Changes:
1. **`modules/apps/callbacks/testing/simapp/app.go`**:
   - Updated the link to the correct Cosmos SDK documentation for "Transaction Tips."
2. **`modules/light-clients/08-wasm/testing/simapp/app.go`**:
   - Updated the same link to point to the correct resource.
3. **`modules/light-clients/08-wasm/testing/wasm_endpoint.go`**:
   - Fixed the grammatical error in the comment by correcting the article usage.

---

### Checklist:
- [x] Targeted PR against the correct branch.
- [x] Linked to relevant GitHub issue or discussion (if applicable).
- [x] Verified that all updated links are functional.
- [x] Reviewed code for accuracy and adherence to repository standards.
- [x] Added a conventional commit message for each change.

---

### Commit Messages:
1. **fix: update outdated link in app.go to point to v0.46 docs**
2. **fix: correct article usage in wasm_endpoint.go**
3. **docs: update link for transaction tips in app.go**