### PR TITLE
Compare Timeout timestamps in seconds instead of nanoseconds

### DIFF
--- a/modules/core/04-channel/v2/keeper/packet.go
+++ b/modules/core/04-channel/v2/keeper/packet.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"strconv"
+	"time"
 
 	errorsmod "cosmossdk.io/errors"
 
@@ -53,15 +54,17 @@ func (k *Keeper) sendPacket(
 		return 0, "", errorsmod.Wrapf(clienttypes.ErrInvalidHeight, "cannot send packet using client (%s) with zero height", sourceClient)
 	}
 
+	// client timestamps are in nanoseconds while packet timeouts are in seconds
+	// thus to compare them, we convert the client timestamp to seconds in uint64
+	// to be consistent with IBC V2 specified timeout behaviour
 	latestTimestamp, err := k.ClientKeeper.GetClientTimestampAtHeight(ctx, sourceClient, latestHeight)
 	if err != nil {
 		return 0, "", err
 	}
+	latestTimestampSecs := uint64(time.Unix(0, int64(latestTimestamp)).Unix())
 
-	// client timestamps are in nanoseconds while packet timeouts are in seconds
-	// thus to compare them, we convert the packet timeout to nanoseconds
 	timeoutTimestamp = types.TimeoutTimestampToNanos(packet.TimeoutTimestamp)
-	if latestTimestamp >= timeoutTimestamp {
+	if latestTimestampSecs >= packet.TimeoutTimestamp {
 		return 0, "", errorsmod.Wrapf(types.ErrTimeoutElapsed, "latest timestamp: %d, timeout timestamp: %d", latestTimestamp, timeoutTimestamp)
 	}
 
@@ -264,15 +267,18 @@ func (k *Keeper) timeoutPacket(
 		return errorsmod.Wrapf(clienttypes.ErrInvalidCounterparty, "counterparty id (%s) does not match packet destination id (%s)", counterparty.ClientId, packet.DestinationClient)
 	}
 
-	// check that timeout height or timeout timestamp has passed on the other end
+	// check that timeout timestamp has passed on the other end
+	// client timestamps are in nanoseconds while packet timeouts are in seconds
+	// so we convert client timestamp to seconds in uint64 to be consistent
+	// with IBC V2 timeout behaviour
 	proofTimestamp, err := k.ClientKeeper.GetClientTimestampAtHeight(ctx, packet.SourceClient, proofHeight)
 	if err != nil {
 		return err
 	}
+	proofTimestampSecs := uint64(time.Unix(0, int64(proofTimestamp)).Unix())
 
-	timeoutTimestamp := types.TimeoutTimestampToNanos(packet.TimeoutTimestamp)
-	if proofTimestamp < timeoutTimestamp {
-		return errorsmod.Wrapf(types.ErrTimeoutNotReached, "proof timestamp: %d, timeout timestamp: %d", proofTimestamp, timeoutTimestamp)
+	if proofTimestampSecs < packet.TimeoutTimestamp {
+		return errorsmod.Wrapf(types.ErrTimeoutNotReached, "proof timestamp: %d, timeout timestamp: %d", proofTimestamp, packet.TimeoutTimestamp)
 	}
 
 	// check that the commitment has not been cleared and that it matches the packet sent by relayer

--- a/modules/core/04-channel/v2/keeper/packet.go
+++ b/modules/core/04-channel/v2/keeper/packet.go
@@ -57,15 +57,14 @@ func (k *Keeper) sendPacket(
 	// client timestamps are in nanoseconds while packet timeouts are in seconds
 	// thus to compare them, we convert the client timestamp to seconds in uint64
 	// to be consistent with IBC V2 specified timeout behaviour
-	latestTimestamp, err := k.ClientKeeper.GetClientTimestampAtHeight(ctx, sourceClient, latestHeight)
+	latestTimestampNano, err := k.ClientKeeper.GetClientTimestampAtHeight(ctx, sourceClient, latestHeight)
 	if err != nil {
 		return 0, "", err
 	}
-	latestTimestampSecs := uint64(time.Unix(0, int64(latestTimestamp)).Unix())
+	latestTimestamp := uint64(time.Unix(0, int64(latestTimestampNano)).Unix())
 
-	timeoutTimestamp = types.TimeoutTimestampToNanos(packet.TimeoutTimestamp)
-	if latestTimestampSecs >= packet.TimeoutTimestamp {
-		return 0, "", errorsmod.Wrapf(types.ErrTimeoutElapsed, "latest timestamp: %d, timeout timestamp: %d", latestTimestamp, timeoutTimestamp)
+	if latestTimestamp >= packet.TimeoutTimestamp {
+		return 0, "", errorsmod.Wrapf(types.ErrTimeoutElapsed, "latest timestamp: %d, timeout timestamp: %d", latestTimestamp, packet.TimeoutTimestamp)
 	}
 
 	commitment := types.CommitPacket(packet)
@@ -271,13 +270,13 @@ func (k *Keeper) timeoutPacket(
 	// client timestamps are in nanoseconds while packet timeouts are in seconds
 	// so we convert client timestamp to seconds in uint64 to be consistent
 	// with IBC V2 timeout behaviour
-	proofTimestamp, err := k.ClientKeeper.GetClientTimestampAtHeight(ctx, packet.SourceClient, proofHeight)
+	proofTimestampNano, err := k.ClientKeeper.GetClientTimestampAtHeight(ctx, packet.SourceClient, proofHeight)
 	if err != nil {
 		return err
 	}
-	proofTimestampSecs := uint64(time.Unix(0, int64(proofTimestamp)).Unix())
+	proofTimestamp := uint64(time.Unix(0, int64(proofTimestampNano)).Unix())
 
-	if proofTimestampSecs < packet.TimeoutTimestamp {
+	if proofTimestamp < packet.TimeoutTimestamp {
 		return errorsmod.Wrapf(types.ErrTimeoutNotReached, "proof timestamp: %d, timeout timestamp: %d", proofTimestamp, packet.TimeoutTimestamp)
 	}
 

--- a/modules/core/04-channel/v2/types/packet.go
+++ b/modules/core/04-channel/v2/types/packet.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"strings"
-	"time"
 
 	errorsmod "cosmossdk.io/errors"
 
@@ -78,9 +77,4 @@ func (p Payload) ValidateBasic() error {
 		return errorsmod.Wrap(ErrInvalidPayload, "payload value cannot be empty")
 	}
 	return nil
-}
-
-// TimeoutTimestampToNanos takes seconds as a uint64 and returns Unix nanoseconds as uint64.
-func TimeoutTimestampToNanos(seconds uint64) uint64 {
-	return uint64(time.Unix(int64(seconds), 0).UnixNano())
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #7512 

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
