### PR TITLE
test: rename TestRandomizedGenState1 to TestRandomizedGenStateAbnormal

### DIFF
--- a/modules/apps/transfer/simulation/genesis_test.go
+++ b/modules/apps/transfer/simulation/genesis_test.go
@@ -51,7 +51,7 @@ func TestRandomizedGenState(t *testing.T) {
 }
 
 // TestRandomizedGenState tests abnormal scenarios of applying RandomizedGenState.
-func TestRandomizedGenState1(t *testing.T) {
+func TestRandomizedGenStateAbnormal(t *testing.T) {
 	interfaceRegistry := codectypes.NewInterfaceRegistry()
 	cdc := codec.NewProtoCodec(interfaceRegistry)
 


### PR DESCRIPTION
Renamed TestRandomizedGenState1 to TestRandomizedGenStateAbnormal to better reflect its purpose of testing abnormal scenarios. This improves code readability and follows Go testing conventions where test names should be descriptive of their functionality.