### PR TITLE
docs: fix typos in ADR documents and update README

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -18,7 +18,7 @@ An ADR should provide:
 
 Note the distinction between an ADR and a spec. The ADR provides the context, intuition, reasoning, and
 justification for a change in architecture, or for the architecture of something
-new. The spec is much more compressed and streamlined summary of everything as
+new. The spec is a much more compressed and streamlined summary of everything as
 it is or should be.
 
 If recorded decisions turned out to be lacking, convene a discussion, record the new decisions here, and then modify the code to match.

--- a/docs/architecture/adr-001-coin-source-tracing.md
+++ b/docs/architecture/adr-001-coin-source-tracing.md
@@ -161,9 +161,9 @@ that a new `[]DenomTrace` `GenesisState` field state needs to be added to the mo
 // GetDenomTrace retrieves the full identifiers trace and base denomination from the store.
 func (k Keeper) GetDenomTrace(ctx Context, denomTraceHash []byte) (DenomTrace, bool) {
   store := ctx.KVStore(k.storeKey)
-  bz := store.Get(types.KeyDenomTrace(traceHash))
+  bz := store.Get(types.KeyDenomTrace(denomTraceHash))
   if bz == nil {
-    return &DenomTrace, false
+    return DenomTrace{}, false
   }
 
   var denomTrace DenomTrace

--- a/docs/architecture/adr-004-ics29-lock-fee-module.md
+++ b/docs/architecture/adr-004-ics29-lock-fee-module.md
@@ -24,7 +24,7 @@ Manual intervention will be needed to unlock the fee module.
 
 ### Sending side
 
-Special behaviour will have to be accounted for in `OnAcknowledgementPacket`. Since the counterparty will continue to send incentivized acknowledgements for fee enabled channels, the acknowledgement will still need to be unmarshalled into an incentivized acknowledgement before calling the underlying application `OnAcknowledgePacket` callback.
+Special behavior will have to be accounted for in `OnAcknowledgementPacket`. Since the counterparty will continue to send incentivized acknowledgements for fee enabled channels, the acknowledgement will still need to be unmarshalled into an incentivized acknowledgement before calling the underlying application `OnAcknowledgePacket` callback.
 
 When distributing fees, a cached context should be used. If the escrow account balance would become negative, the current state changes should be discarded and the fee module should be locked using the uncached context. This prevents fees from being partially distributed for a given packetID.
 


### PR DESCRIPTION
This pull request fixes a few minor spelling issues and textual inconsistencies in the ADR documents (adr-001-coin-source-tracing.md, adr-004-ics29-lock-fee-module.md), and updates the docs/architecture/README.md to improve clarity. These changes are purely editorial and do not introduce any logic or code flow modifications.

closes: #XXXX

	•	Correct spelling from “behaviour” to “behavior”
	•	Remove extraneous words and unify phrasing
	•	Update README for concise explanation of ADR usage

No functional changes are included.