### PR TITLE
docs: clean up grammar in ADR documentation

### DIFF
--- a/docs/architecture/adr-006-02-client-refactor.md
+++ b/docs/architecture/adr-006-02-client-refactor.md
@@ -105,7 +105,7 @@ The IBC specification states:
 
 The initial version of the IBC go SDK based module did not fulfill this requirement.
 Instead, the 02-client submodule required each light client to return the client and consensus state which should be updated in the client prefixed store.
-This decision lead to the issues "Solomachine doesn't set consensus states" and "New clients may want to do batch updates".
+This decision led to the issues "Solomachine doesn't set consensus states" and "New clients may want to do batch updates".
 
 Each light client should be required to set its own client and consensus states on any update necessary.
 The go implementation should be changed to match the specification requirements.

--- a/docs/architecture/adr-008-app-caller-cbs.md
+++ b/docs/architecture/adr-008-app-caller-cbs.md
@@ -18,7 +18,7 @@ This setup worked well for off-chain users interacting with IBC applications.
 
 We are now seeing the desire for secondary applications (e.g. smart contracts, modules) to call into IBC apps as part of their state machine logic and then do some actions on the basis of the packet result. Or to receive a packet from IBC and do some logic upon receipt.
 
-Example Usecases:
+Example Use cases:
 
 - Send an ICS-20 packet, and if it is successful, then send an ICA-packet to swap tokens on LP and return funds to sender
 - Execute some logic upon receipt of token transfer to a smart contract address

--- a/docs/architecture/adr-010-light-clients-as-sdk-modules.md
+++ b/docs/architecture/adr-010-light-clients-as-sdk-modules.md
@@ -79,7 +79,7 @@ type ClientState interface {
 
 For the most part, any functions which require access to the client store should likely not be an interface function of the `ClientState`.
 
-`ExportMetadata` should eventually be replaced by a light client's ability to import/export it's own genesis information.
+`ExportMetadata` should eventually be replaced by a light client's ability to import/export its own genesis information.
 
 ### Intermodule communication
 

--- a/docs/architecture/adr-015-ibc-packet-receiver.md
+++ b/docs/architecture/adr-015-ibc-packet-receiver.md
@@ -22,7 +22,7 @@ verification code.
 
 For atomic multi-message transaction, we want to keep the IBC related
 state modification to be preserved even the application side state change
-reverts. One of the example might be IBC token sending message following with
+reverts. One example might be IBC token sending message following with
 stake delegation which uses the tokens received by the previous packet message.
 If the token receiving fails for any reason, we might not want to keep
 executing the transaction, but we also don't want to abort the transaction

--- a/docs/architecture/adr-015-ibc-packet-receiver.md
+++ b/docs/architecture/adr-015-ibc-packet-receiver.md
@@ -202,13 +202,13 @@ type AppModule struct {}
 // CheckChannel will be provided to the ChannelKeeper as ChannelKeeper.Port(module.CheckChannel)
 func (module AppModule) CheckChannel(portID, channelID string, channel Channel) error {
   if channel.Ordering != UNORDERED {
-    return ErrUncompatibleOrdering()
+    return ErrIncompatibleOrdering()
   }
   if channel.CounterpartyPort != "bank" {
-    return ErrUncompatiblePort()
+    return ErrIncompatiblePort()
   }
   if channel.Version != "" {
-    return ErrUncompatibleVersion()
+    return ErrIncompatibleVersion()
   }
   return nil
 }


### PR DESCRIPTION
Сleans up small grammar and spelling issues across several ADR files, specifically adr-006-02-client-refactor.md, adr-008-app-caller-cbs.md, adr-010-light-clients-as-sdk-modules.md, and adr-015-ibc-packet-receiver.md. Changes include correcting:
	•	“lead” → “led”
	•	“Usecases” → “Use cases”
	•	“it’s” → “its”
	•	“ErrUncompatible…” → “ErrIncompatible…”

No functionality or logic is changed. The edits are documentation-only to improve clarity.