### PR TITLE
chore: make all keepers use address codecs

### DIFF
--- a/modules/apps/29-fee/ibc_middleware.go
+++ b/modules/apps/29-fee/ibc_middleware.go
@@ -283,7 +283,7 @@ func (im IBCMiddleware) OnAcknowledgementPacket(
 		payee = relayer.String()
 	}
 
-	payeeAddr, err := sdk.AccAddressFromBech32(payee)
+	payeeAddr, err := im.keeper.AddrCodec.StringToBytes(payee)
 	if err != nil {
 		return errorsmod.Wrapf(err, "failed to create sdk.Address from payee: %s", payee)
 	}
@@ -329,7 +329,7 @@ func (im IBCMiddleware) OnTimeoutPacket(
 		payee = relayer.String()
 	}
 
-	payeeAddr, err := sdk.AccAddressFromBech32(payee)
+	payeeAddr, err := im.keeper.AddrCodec.StringToBytes(payee)
 	if err != nil {
 		return errorsmod.Wrapf(err, "failed to create sdk.Address from payee: %s", payee)
 	}

--- a/modules/apps/29-fee/keeper/escrow.go
+++ b/modules/apps/29-fee/keeper/escrow.go
@@ -18,7 +18,7 @@ import (
 // escrowPacketFee sends the packet fee to the 29-fee module account to hold in escrow
 func (k Keeper) escrowPacketFee(ctx context.Context, packetID channeltypes.PacketId, packetFee types.PacketFee) error {
 	// check if the refund address is valid
-	refundAddr, err := sdk.AccAddressFromBech32(packetFee.RefundAddress)
+	refundAddr, err := k.AddrCodec.StringToBytes(packetFee.RefundAddress)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func (k Keeper) DistributePacketFeesOnAcknowledgement(ctx context.Context, forwa
 	// if the escrow account has insufficient balance then we want to avoid partially distributing fees
 	if err := k.BranchService.Execute(ctx, func(ctx context.Context) error {
 		// forward relayer address will be empty if conversion fails
-		forwardAddr, _ := sdk.AccAddressFromBech32(forwardRelayer)
+		forwardAddr, _ := k.AddrCodec.StringToBytes(forwardRelayer)
 
 		for _, packetFee := range packetFees {
 			if !k.EscrowAccountHasBalance(ctx, packetFee.Fee.Total()) {
@@ -61,7 +61,7 @@ func (k Keeper) DistributePacketFeesOnAcknowledgement(ctx context.Context, forwa
 			}
 
 			// check if refundAcc address works
-			refundAddr, err := sdk.AccAddressFromBech32(packetFee.RefundAddress)
+			refundAddr, err := k.AddrCodec.StringToBytes(packetFee.RefundAddress)
 			if err != nil {
 				panic(fmt.Errorf("could not parse refundAcc %s to sdk.AccAddress", packetFee.RefundAddress))
 			}
@@ -117,7 +117,7 @@ func (k Keeper) DistributePacketFeesOnTimeout(ctx context.Context, timeoutRelaye
 			}
 
 			// check if refundAcc address works
-			refundAddr, err := sdk.AccAddressFromBech32(packetFee.RefundAddress)
+			refundAddr, err := k.AddrCodec.StringToBytes(packetFee.RefundAddress)
 			if err != nil {
 				panic(fmt.Errorf("could not parse refundAcc %s to sdk.AccAddress", packetFee.RefundAddress))
 			}
@@ -206,7 +206,7 @@ func (k Keeper) RefundFeesOnChannelClosure(ctx context.Context, portID, channelI
 					return ibcerrors.ErrInsufficientFunds
 				}
 
-				refundAddr, err := sdk.AccAddressFromBech32(packetFee.RefundAddress)
+				refundAddr, err := k.AddrCodec.StringToBytes(packetFee.RefundAddress)
 				if err != nil {
 					unRefundedFees = append(unRefundedFees, packetFee)
 					continue

--- a/modules/apps/29-fee/keeper/keeper.go
+++ b/modules/apps/29-fee/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
 	storetypes "cosmossdk.io/store/types"
 
@@ -24,7 +25,8 @@ var _ types.ChannelKeeper = (*Keeper)(nil)
 type Keeper struct {
 	appmodule.Environment
 
-	cdc codec.BinaryCodec
+	cdc       codec.BinaryCodec
+	AddrCodec address.Codec
 
 	authKeeper    types.AuthKeeper
 	ics4Wrapper   porttypes.ICS4Wrapper
@@ -34,12 +36,13 @@ type Keeper struct {
 
 // NewKeeper creates a new 29-fee Keeper instance
 func NewKeeper(
-	cdc codec.BinaryCodec, env appmodule.Environment,
+	cdc codec.BinaryCodec, addrCdc address.Codec, env appmodule.Environment,
 	ics4Wrapper porttypes.ICS4Wrapper, channelKeeper types.ChannelKeeper,
 	authKeeper types.AuthKeeper, bankKeeper types.BankKeeper,
 ) Keeper {
 	return Keeper{
 		cdc:           cdc,
+		AddrCodec:     addrCdc,
 		Environment:   env,
 		ics4Wrapper:   ics4Wrapper,
 		channelKeeper: channelKeeper,

--- a/modules/apps/29-fee/keeper/keeper.go
+++ b/modules/apps/29-fee/keeper/keeper.go
@@ -223,17 +223,17 @@ func (k Keeper) GetAllPayees(ctx context.Context) []types.RegisteredPayee {
 
 // SetCounterpartyPayeeAddress maps the destination chain counterparty payee address to the source relayer address
 // The receiving chain must store the mapping from: address -> counterpartyPayeeAddress for the given channel
-func (k Keeper) SetCounterpartyPayeeAddress(ctx context.Context, address, counterpartyAddress, channelID string) {
+func (k Keeper) SetCounterpartyPayeeAddress(ctx context.Context, addr, counterpartyAddress, channelID string) {
 	store := k.KVStoreService.OpenKVStore(ctx)
-	if err := store.Set(types.KeyCounterpartyPayee(address, channelID), []byte(counterpartyAddress)); err != nil {
+	if err := store.Set(types.KeyCounterpartyPayee(addr, channelID), []byte(counterpartyAddress)); err != nil {
 		panic(err)
 	}
 }
 
 // GetCounterpartyPayeeAddress gets the counterparty payee address given a destination relayer address
-func (k Keeper) GetCounterpartyPayeeAddress(ctx context.Context, address, channelID string) (string, bool) {
+func (k Keeper) GetCounterpartyPayeeAddress(ctx context.Context, relayerAddr, channelID string) (string, bool) {
 	store := k.KVStoreService.OpenKVStore(ctx)
-	key := types.KeyCounterpartyPayee(address, channelID)
+	key := types.KeyCounterpartyPayee(relayerAddr, channelID)
 
 	addr, err := store.Get(key)
 	if err != nil {
@@ -272,9 +272,9 @@ func (k Keeper) GetAllCounterpartyPayees(ctx context.Context) []types.Registered
 }
 
 // SetRelayerAddressForAsyncAck sets the forward relayer address during OnRecvPacket in case of async acknowledgement
-func (k Keeper) SetRelayerAddressForAsyncAck(ctx context.Context, packetID channeltypes.PacketId, address string) {
+func (k Keeper) SetRelayerAddressForAsyncAck(ctx context.Context, packetID channeltypes.PacketId, addr string) {
 	store := k.KVStoreService.OpenKVStore(ctx)
-	if err := store.Set(types.KeyRelayerAddressForAsyncAck(packetID), []byte(address)); err != nil {
+	if err := store.Set(types.KeyRelayerAddressForAsyncAck(packetID), []byte(addr)); err != nil {
 		panic(err)
 	}
 }

--- a/modules/apps/29-fee/keeper/migrations.go
+++ b/modules/apps/29-fee/keeper/migrations.go
@@ -37,7 +37,7 @@ func (m Migrator) Migrate1to2(ctx context.Context) error {
 		for _, packetFee := range feesInEscrow.PacketFees {
 			refundCoins := legacyTotal(packetFee.Fee).Sub(packetFee.Fee.Total()...)
 
-			refundAddr, err := sdk.AccAddressFromBech32(packetFee.RefundAddress)
+			refundAddr, err := m.keeper.AddrCodec.StringToBytes(packetFee.RefundAddress)
 			if err != nil {
 				return err
 			}

--- a/modules/apps/29-fee/keeper/msg_server.go
+++ b/modules/apps/29-fee/keeper/msg_server.go
@@ -5,8 +5,6 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/ibc-go/v9/modules/apps/29-fee/types"
 	channeltypes "github.com/cosmos/ibc-go/v9/modules/core/04-channel/types"
 	ibcerrors "github.com/cosmos/ibc-go/v9/modules/core/errors"
@@ -20,7 +18,7 @@ var _ types.MsgServer = (*Keeper)(nil)
 // the source chain from which packets originate as this is where fee distribution takes place. This function may be
 // called more than once by a relayer, in which case, the latest payee is always used.
 func (k Keeper) RegisterPayee(ctx context.Context, msg *types.MsgRegisterPayee) (*types.MsgRegisterPayeeResponse, error) {
-	payee, err := sdk.AccAddressFromBech32(msg.Payee)
+	payee, err := k.AddrCodec.StringToBytes(msg.Payee)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +85,7 @@ func (k Keeper) PayPacketFee(ctx context.Context, msg *types.MsgPayPacketFee) (*
 		return nil, types.ErrFeeModuleLocked
 	}
 
-	refundAcc, err := sdk.AccAddressFromBech32(msg.Signer)
+	refundAcc, err := k.AddrCodec.StringToBytes(msg.Signer)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +128,7 @@ func (k Keeper) PayPacketFeeAsync(ctx context.Context, msg *types.MsgPayPacketFe
 		return nil, types.ErrFeeModuleLocked
 	}
 
-	refundAcc, err := sdk.AccAddressFromBech32(msg.PacketFee.RefundAddress)
+	refundAcc, err := k.AddrCodec.StringToBytes(msg.PacketFee.RefundAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/apps/callbacks/testing/simapp/app.go
+++ b/modules/apps/callbacks/testing/simapp/app.go
@@ -405,6 +405,7 @@ func NewSimApp(
 
 	app.IBCKeeper = ibckeeper.NewKeeper(
 		appCodec,
+		signingCtx.AddressCodec(),
 		runtime.NewEnvironment(runtime.NewKVStoreService(keys[ibcexported.StoreKey]), logger.With(log.ModuleKey, "x/ibc")),
 		app.GetSubspace(ibcexported.ModuleName),
 		app.UpgradeKeeper,
@@ -431,6 +432,7 @@ func NewSimApp(
 	// IBC Fee Module keeper
 	app.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
 		appCodec,
+		signingCtx.AddressCodec(),
 		runtime.NewEnvironment(runtime.NewKVStoreService(keys[ibcfeetypes.StoreKey]), logger.With(log.ModuleKey, fmt.Sprintf("x/%s-%s", ibcexported.ModuleName, ibcfeetypes.ModuleName))),
 		app.IBCKeeper.ChannelKeeper, // may be replaced with IBC middleware
 		app.IBCKeeper.ChannelKeeper,

--- a/modules/core/keeper/keeper.go
+++ b/modules/core/keeper/keeper.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -27,14 +28,15 @@ type Keeper struct {
 	ChannelKeeper    *channelkeeper.Keeper
 	PortKeeper       *portkeeper.Keeper
 
-	cdc codec.BinaryCodec
+	cdc     codec.BinaryCodec
+	AddrCdc address.Codec
 
 	authority string
 }
 
 // NewKeeper creates a new ibc Keeper
 func NewKeeper(
-	cdc codec.BinaryCodec, env appmodule.Environment, paramSpace types.ParamSubspace,
+	cdc codec.BinaryCodec, addrCdc address.Codec, env appmodule.Environment, paramSpace types.ParamSubspace,
 	upgradeKeeper clienttypes.UpgradeKeeper, authority string,
 ) *Keeper {
 	// panic if any of the keepers passed in is empty
@@ -54,6 +56,7 @@ func NewKeeper(
 	return &Keeper{
 		Environment:      env,
 		cdc:              cdc,
+		AddrCdc:          addrCdc,
 		ClientKeeper:     clientKeeper,
 		ConnectionKeeper: connectionKeeper,
 		ChannelKeeper:    channelKeeper,

--- a/modules/core/keeper/keeper_test.go
+++ b/modules/core/keeper/keeper_test.go
@@ -3,12 +3,12 @@ package keeper_test
 import (
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/codec/address"
 	testifysuite "github.com/stretchr/testify/suite"
 
 	"cosmossdk.io/log"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
 
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/runtime"
 
 	clienttypes "github.com/cosmos/ibc-go/v9/modules/core/02-client/types"

--- a/modules/core/keeper/keeper_test.go
+++ b/modules/core/keeper/keeper_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	testifysuite "github.com/stretchr/testify/suite"
 
 	"cosmossdk.io/log"
@@ -76,6 +77,7 @@ func (suite *KeeperTestSuite) TestNewKeeper() {
 				newIBCKeeperFn = func() {
 					ibckeeper.NewKeeper(
 						suite.chainA.GetSimApp().AppCodec(),
+						address.NewBech32Codec(suite.chainA.Bech32Prefix),
 						runtime.NewEnvironment(runtime.NewKVStoreService(suite.chainA.GetSimApp().GetKey(ibcexported.StoreKey)), log.NewNopLogger()),
 						suite.chainA.GetSimApp().GetSubspace(ibcexported.ModuleName),
 						upgradeKeeper,
@@ -96,6 +98,7 @@ func (suite *KeeperTestSuite) TestNewKeeper() {
 			newIBCKeeperFn = func() {
 				ibckeeper.NewKeeper(
 					suite.chainA.GetSimApp().AppCodec(),
+					address.NewBech32Codec(suite.chainA.Bech32Prefix),
 					runtime.NewEnvironment(runtime.NewKVStoreService(suite.chainA.GetSimApp().GetKey(ibcexported.StoreKey)), log.NewNopLogger()),
 					suite.chainA.GetSimApp().GetSubspace(ibcexported.ModuleName),
 					upgradeKeeper,

--- a/modules/core/keeper/msg_server.go
+++ b/modules/core/keeper/msg_server.go
@@ -361,7 +361,7 @@ func (k *Keeper) ChannelCloseConfirm(ctx context.Context, msg *channeltypes.MsgC
 func (k *Keeper) RecvPacket(goCtx context.Context, msg *channeltypes.MsgRecvPacket) (*channeltypes.MsgRecvPacketResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	relayer, err := sdk.AccAddressFromBech32(msg.Signer)
+	relayer, err := k.AddrCdc.StringToBytes(msg.Signer)
 	if err != nil {
 		k.Logger.Error("receive packet failed", "error", errorsmod.Wrap(err, "Invalid address for msg Signer"))
 		return nil, errorsmod.Wrap(err, "Invalid address for msg Signer")
@@ -424,7 +424,7 @@ func (k *Keeper) RecvPacket(goCtx context.Context, msg *channeltypes.MsgRecvPack
 
 // Timeout defines a rpc handler method for MsgTimeout.
 func (k *Keeper) Timeout(ctx context.Context, msg *channeltypes.MsgTimeout) (*channeltypes.MsgTimeoutResponse, error) {
-	relayer, err := sdk.AccAddressFromBech32(msg.Signer)
+	relayer, err := k.AddrCdc.StringToBytes(msg.Signer)
 	if err != nil {
 		k.Logger.Error("timeout failed", "error", errorsmod.Wrap(err, "Invalid address for msg Signer"))
 		return nil, errorsmod.Wrap(err, "Invalid address for msg Signer")
@@ -482,7 +482,7 @@ func (k *Keeper) Timeout(ctx context.Context, msg *channeltypes.MsgTimeout) (*ch
 
 // TimeoutOnClose defines a rpc handler method for MsgTimeoutOnClose.
 func (k *Keeper) TimeoutOnClose(ctx context.Context, msg *channeltypes.MsgTimeoutOnClose) (*channeltypes.MsgTimeoutOnCloseResponse, error) {
-	relayer, err := sdk.AccAddressFromBech32(msg.Signer)
+	relayer, err := k.AddrCdc.StringToBytes(msg.Signer)
 	if err != nil {
 		k.Logger.Error("timeout on close failed", "error", errorsmod.Wrap(err, "Invalid address for msg Signer"))
 		return nil, errorsmod.Wrap(err, "Invalid address for msg Signer")
@@ -541,7 +541,7 @@ func (k *Keeper) TimeoutOnClose(ctx context.Context, msg *channeltypes.MsgTimeou
 
 // Acknowledgement defines a rpc handler method for MsgAcknowledgement.
 func (k *Keeper) Acknowledgement(ctx context.Context, msg *channeltypes.MsgAcknowledgement) (*channeltypes.MsgAcknowledgementResponse, error) {
-	relayer, err := sdk.AccAddressFromBech32(msg.Signer)
+	relayer, err := k.AddrCdc.StringToBytes(msg.Signer)
 	if err != nil {
 		k.Logger.Error("acknowledgement failed", "error", errorsmod.Wrap(err, "Invalid address for msg Signer"))
 		return nil, errorsmod.Wrap(err, "Invalid address for msg Signer")

--- a/modules/light-clients/08-wasm/testing/simapp/app.go
+++ b/modules/light-clients/08-wasm/testing/simapp/app.go
@@ -471,6 +471,7 @@ func NewSimApp(
 
 	app.IBCKeeper = ibckeeper.NewKeeper(
 		appCodec,
+		signingCtx.AddressCodec(),
 		runtime.NewEnvironment(runtime.NewKVStoreService(keys[ibcexported.StoreKey]), logger.With(log.ModuleKey, "x/ibc")),
 		app.GetSubspace(ibcexported.ModuleName),
 		app.UpgradeKeeper,
@@ -559,6 +560,7 @@ func NewSimApp(
 	// IBC Fee Module keeper
 	app.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
 		appCodec,
+		signingCtx.AddressCodec(),
 		runtime.NewEnvironment(runtime.NewKVStoreService(keys[ibcfeetypes.StoreKey]), logger.With(log.ModuleKey, fmt.Sprintf("x/%s-%s", ibcexported.ModuleName, ibcfeetypes.ModuleName))),
 		app.IBCKeeper.ChannelKeeper, // may be replaced with IBC middleware
 		app.IBCKeeper.ChannelKeeper,

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -487,6 +487,7 @@ func NewSimApp(
 
 	app.IBCKeeper = ibckeeper.NewKeeper(
 		appCodec,
+		signingCtx.AddressCodec(),
 		runtime.NewEnvironment(runtime.NewKVStoreService(keys[ibcexported.StoreKey]), logger.With(log.ModuleKey, "x/ibc")),
 		app.GetSubspace(ibcexported.ModuleName),
 		app.UpgradeKeeper,
@@ -541,6 +542,7 @@ func NewSimApp(
 	// IBC Fee Module keeper
 	app.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
 		appCodec,
+		signingCtx.AddressCodec(),
 		runtime.NewEnvironment(runtime.NewKVStoreService(keys[ibcfeetypes.StoreKey]), logger.With(log.ModuleKey, fmt.Sprintf("x/%s-%s", ibcexported.ModuleName, ibcfeetypes.ModuleName))),
 		app.IBCKeeper.ChannelKeeper, // may be replaced with IBC middleware
 		app.IBCKeeper.ChannelKeeper,

--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -457,6 +457,7 @@ func NewSimApp(
 
 	app.IBCKeeper = ibckeeper.NewKeeper(
 		appCodec,
+		signingCtx.AddressCodec(),
 		runtime.NewEnvironment(runtime.NewKVStoreService(keys[ibcexported.StoreKey]), logger.With(log.ModuleKey, "x/ibc")),
 		app.GetSubspace(ibcexported.ModuleName),
 		app.UpgradeKeeper,
@@ -511,6 +512,7 @@ func NewSimApp(
 	// IBC Fee Module keeper
 	app.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
 		appCodec,
+		signingCtx.AddressCodec(),
 		runtime.NewEnvironment(runtime.NewKVStoreService(keys[ibcfeetypes.StoreKey]), logger.With(log.ModuleKey, fmt.Sprintf("x/%s-%s", ibcexported.ModuleName, ibcfeetypes.ModuleName))),
 		app.IBCKeeper.ChannelKeeper, // may be replaced with IBC middleware
 		app.IBCKeeper.ChannelKeeper,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

removes sdk.AccAddressFromBech32 where possible. all keepers have an address codec field now to avoid using the aforementioned function.

closes: #7835

<!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sdk to v0.46.4
chore: removed unused variables
e2e: adding e2e upgrade test for ibc-go/v6
docs: ics27 v6 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
