### PR TITLE
chore: replace Python script with bash script for libwasm version detection

### DIFF
--- a/.github/workflows/build-wasm-simd-image-from-tag.yml
+++ b/.github/workflows/build-wasm-simd-image-from-tag.yml
@@ -1,102 +1,16 @@
-name: Build Wasm Simd Image
-on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'The tag of the image to build'
-        required: true
-        type: string
+#!/bin/bash
 
-env:
-  REGISTRY: ghcr.io
-  ORG: cosmos
-  IMAGE_NAME: ibc-go-wasm-simd
-  GIT_TAG: "${{ inputs.tag }}"
+set -eou pipefail
 
-jobs:
-  build-image-at-tag:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            platform: linux/amd64
-          - os: ubuntu-24.04-arm
-            platform: linux/arm64
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-         ref: "${{ env.GIT_TAG }}"
-         fetch-depth: 0
+# build_wasm_image extracts the correct libwasm version and checksum
+# based on the go.mod and builds a docker image with the provided tag.
+function build_wasm_image(){
+  local version="$(scripts/get-libwasm-version.sh --get-version)"
+  local checksum="$(scripts/get-libwasm-version.sh --get-checksum)"
+  docker build . -t "${1}" -f modules/light-clients/08-wasm/Dockerfile --build-arg LIBWASM_VERSION=${version} --build-arg LIBWASM_CHECKSUM=${checksum}
+}
 
-      # TODO: #7885 Get rid of this script, it is super unecessary and can probably be done in the Dockerfile or a bash script
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      - name: Install dependencies
-        run: make python-install-deps
-      - name: Get arguments
-        run: echo "LIBWASM_VERSION=$(scripts/get-libwasm-version.py --get-version)" >> $GITHUB_ENV
+# default to latest if no tag is specified.
+TAG="${1:-ibc-go-wasm-simd:latest}"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
-        with:
-           registry: ${{ env.REGISTRY }}
-           username: ${{ github.actor }}
-           password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Build and push
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          platforms: ${{ matrix.platform }}
-          file: modules/light-clients/08-wasm/Dockerfile
-          build-args: LIBWASM_VERSION=${{ env.LIBWASM_VERSION }}
-          outputs: type=image,"name=${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ matrix.os }} # If we end up running more builds on the same OS, we need to differentiate more here
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: depot-ubuntu-22.04-4
-    needs:
-      - build-image-at-tag
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Get docker tag
-         # remove all `/` or `+` characters from the docker tag and replace them with a -.
-         # this ensures the docker tag is valid.
-        run: echo "DOCKER_TAG=$(echo $GIT_TAG | sed 's/[^a-zA-Z0-9\.]/-/g')" >> $GITHUB_ENV
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
-        with:
-           registry: ${{ env.REGISTRY }}
-           username: ${{ github.actor }}
-           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
-        run: |
-          docker buildx imagetools create --tag ${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }} $(printf '${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+build_wasm_image "${TAG}"

--- a/.github/workflows/build-wasm-simd-image-from-tag.yml
+++ b/.github/workflows/build-wasm-simd-image-from-tag.yml
@@ -1,16 +1,97 @@
-#!/bin/bash
+name: Build Wasm Simd Image
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag of the image to build'
+        required: true
+        type: string
 
-set -eou pipefail
+env:
+  REGISTRY: ghcr.io
+  ORG: cosmos
+  IMAGE_NAME: ibc-go-wasm-simd
+  GIT_TAG: "${{ inputs.tag }}"
 
-# build_wasm_image extracts the correct libwasm version and checksum
-# based on the go.mod and builds a docker image with the provided tag.
-function build_wasm_image(){
-  local version="$(scripts/get-libwasm-version.sh --get-version)"
-  local checksum="$(scripts/get-libwasm-version.sh --get-checksum)"
-  docker build . -t "${1}" -f modules/light-clients/08-wasm/Dockerfile --build-arg LIBWASM_VERSION=${version} --build-arg LIBWASM_CHECKSUM=${checksum}
-}
+jobs:
+  build-image-at-tag:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux/amd64
+          - os: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+         ref: "${{ env.GIT_TAG }}"
+         fetch-depth: 0
 
-# default to latest if no tag is specified.
-TAG="${1:-ibc-go-wasm-simd:latest}"
+      # Use bash script instead of Python script
+      - name: Get arguments
+        run: echo "LIBWASM_VERSION=$(bash scripts/get-libwasm-version.sh --get-version)" >> $GITHUB_ENV
 
-build_wasm_image "${TAG}"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+           registry: ${{ env.REGISTRY }}
+           username: ${{ github.actor }}
+           password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform }}
+          file: modules/light-clients/08-wasm/Dockerfile
+          build-args: LIBWASM_VERSION=${{ env.LIBWASM_VERSION }}
+          outputs: type=image,"name=${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.os }} # If we end up running more builds on the same OS, we need to differentiate more here
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: depot-ubuntu-22.04-4
+    needs:
+      - build-image-at-tag
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Get docker tag
+         # remove all `/` or `+` characters from the docker tag and replace them with a -.
+         # this ensures the docker tag is valid.
+        run: echo "DOCKER_TAG=$(echo $GIT_TAG | sed 's/[^a-zA-Z0-9\.]/-/g')" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+           registry: ${{ env.REGISTRY }}
+           username: ${{ github.actor }}
+           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create --tag ${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }} $(printf '${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)

--- a/.github/workflows/e2e-test-workflow-call.yml
+++ b/.github/workflows/e2e-test-workflow-call.yml
@@ -122,21 +122,16 @@ jobs:
       - uses: actions/checkout@v4
         if: ${{ inputs.build-and-push-docker-image-wasm }}
 
-      - uses: actions/setup-python@v5
+      - name: Set up Docker Buildx
         if: ${{ inputs.build-and-push-docker-image-wasm }}
-        with:
-          python-version: '3.10'
-
-      - name: Install dependencies
-        if: ${{ inputs.build-and-push-docker-image-wasm }}
-        run: make python-install-deps
+        uses: docker/setup-buildx-action@v3
 
       - name: Determine Build arguments
         if: ${{ inputs.build-and-push-docker-image-wasm }}
         id: build-args
         run: |
-          echo "version=$(scripts/get-libwasm-version.py --get-version)" >> $GITHUB_OUTPUT
-          echo "checksum=$(scripts/get-libwasm-version.py --get-checksum)" >> $GITHUB_OUTPUT
+          echo "version=$(scripts/get-libwasm-version.sh --get-version)" >> $GITHUB_OUTPUT
+          echo "checksum=$(scripts/get-libwasm-version.sh --get-checksum)" >> $GITHUB_OUTPUT
 
       - name: Log in to the Container registry
         if: ${{ inputs.build-and-push-docker-image-wasm }}

--- a/scripts/build-wasm-simapp-docker.sh
+++ b/scripts/build-wasm-simapp-docker.sh
@@ -5,8 +5,8 @@ set -eou pipefail
 # build_wasm_image extracts the correct libwasm version and checksum
 # based on the go.mod and builds a docker image with the provided tag.
 function build_wasm_image(){
-  local version="$(scripts/get-libwasm-version.py --get-version)"
-  local checksum="$(scripts/get-libwasm-version.py --get-checksum)"
+  local version="$(scripts/get-libwasm-version.sh --get-version)"
+  local checksum="$(scripts/get-libwasm-version.sh --get-checksum)"
   docker build . -t "${1}" -f modules/light-clients/08-wasm/Dockerfile --build-arg LIBWASM_VERSION=${version} --build-arg LIBWASM_CHECKSUM=${checksum}
 }
 


### PR DESCRIPTION
## Description

This PR replaces the Python script get-libwasm-version.py with a minimal bash script that performs the same functionality. The Python script was overkill for such a simple operation and required installing Python dependencies, which is unnecessary.
The bash script:
1. Extracts the version of CosmWasm/wasmvm/v2 from the go.mod file
2. Optionally gets the checksum of a specific library file for that version
Has the same command-line interface as the Python script
Additionally, this PR:
- Updates all references to the Python script in workflow files and build scripts
- Removes the Python dependencies installation step from workflows
- Removes the python-install-deps target from Makefile
- Removes the requirements.txt file
This change simplifies the build process and reduces dependencies.

closes: #7885


Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/11-structure.md) and [Go style guide](../docs/dev/go-style-guide.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
