### PR TITLE
feat(proto): add buf labels for ibc-go release tags

### DIFF
--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -1,12 +1,14 @@
 name: Buf-Push
 # Protobuf runs buf (https://buf.build/) push updated proto files to https://buf.build/cosmos/ibc
-# This workflow is only run when a .proto file has been changed
+# This workflow is only run when a .proto file has been changed or a tag is created
 on:
   push:
     branches:
       - main
     paths:
       - "proto/**"
+    tags:
+      - 'v*.*.*'
 
 jobs:
   push:
@@ -14,7 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1.50.0
-      - uses: bufbuild/buf-push-action@v1
+      - name: Push to buf.build registry with appropriate labels
+        uses: bufbuild/buf-push-action@v1
         with:
           input: "proto"
           buf_token: ${{ secrets.BUF_TOKEN }}
+          # Add tag labels when this workflow is triggered by a tag
+          tag: ${{ startsWith(github.ref, 'refs/tags/') && format('commit:{0},{1}', github.sha, github.ref_name) || '' }}

--- a/README.md
+++ b/README.md
@@ -39,9 +39,21 @@ The [Inter-Blockchain Communication protocol (IBC)](https://ibcprotocol.dev/) al
 
 This IBC implementation in Golang is built as a Cosmos SDK module. To understand more about how to use the `ibc-go` module as well as about the IBC protocol, please check out the Interchain Developer Academy [section on IBC](https://tutorials.cosmos.network/academy/3-ibc/), or [our docs](./docs/docs/01-ibc/01-overview.md).
 
+## Protobuf
+
+IBC-Go Protobuf definitions are hosted on the [Buf Schema Registry](https://buf.build/cosmos/ibc).
+
+[![buf.build](https://img.shields.io/badge/buf.build-cosmos%2Fibc-blue)](https://buf.build/cosmos/ibc)
+
+The registry includes tagged versions for all releases, allowing you to depend on specific versions of the API in your projects.
+
 ## Roadmap
 
-For an overview of upcoming changes to ibc-go take a look at the [roadmap project board](https://github.com/orgs/cosmos/projects/38/views/14).
+For an overview of upcoming changes to ibc-go take a look at the [roadmap](./docs/docs/01-ibc/10-roadmap.md).
+
+This roadmap is also available as a [project board](https://github.com/orgs/cosmos/projects/7/views/25).
+
+For the latest expected release timelines, please check [here](https://github.com/cosmos/ibc-go/wiki/Release-timeline).
 
 ## Releases
 
@@ -61,7 +73,9 @@ We have active, helpful communities on Discord and Telegram.
 
 For questions and support please use the `developers` channel in the [Cosmos Network Discord server](https://discord.com/channels/669268347736686612/1019978171367559208) or join the [Interchain Discord server](https://discord.com/invite/interchain). The issue list of this repo is exclusively for bug reports and feature requests.
 
-To receive announcements of new releases or other technical updates, please join the [Telegram group that Interchain Labs administers](https://t.me/cosmostechstack/1).
+To receive announcements of new releases or other technical updates, please join the [Telegram group that we administer](https://t.me/ibc_is_expansive).
+
+We run biweekly community calls to update the community with our current direction and gather feedback on what to work on next. The community calls are also a platform for you to update everyone else with what you're working on, ask questions and find opportunities to collaborate. Please join [this Google group](https://groups.google.com/g/ibc-community) to receive a calendar invitation for the meeting.
 
 ## Contributing
 

--- a/docs/dev/development-setup.md
+++ b/docs/dev/development-setup.md
@@ -34,6 +34,17 @@ For generating or updating the swagger file that documents the URLs of the RESTf
 
 It reads protobuf service definitions and generates a reverse-proxy server which translates a RESTful HTTP API into gRPC.
 
+### Buf Registry and Tags
+
+The IBC-Go protobuf definitions are published to the [Buf Schema Registry](https://buf.build/cosmos/ibc) on both the `main` branch and for all release tags. When a new tag is created, the protobuf definitions are automatically pushed to the Buf registry with appropriate commit labels that include the tag name. This allows consumers to depend on specific versions of the API.
+
+These tagged versions can be referenced in your `buf.yaml` files as dependencies, for example:
+
+```yaml
+deps:
+  - buf.build/cosmos/ibc:v7.2.0  # Specific version
+```
+
 ## Developing and testing
 
 - The latest state of development is on `main`.

--- a/docs/docs/01-ibc/08-proto-docs.md
+++ b/docs/docs/01-ibc/08-proto-docs.md
@@ -6,6 +6,32 @@ slug: /ibc/proto-docs
 ---
 
 
-# Protobuf documentation
+# Protobuf Documentation
 
-See [ibc-go Buf Protobuf documentation](https://buf.build/cosmos/ibc/docs/main).
+## Buf Schema Registry
+
+IBC-Go Protobuf definitions are hosted on the [Buf Schema Registry](https://buf.build/cosmos/ibc).
+
+The registry includes all IBC-Go Protobuf definitions and is updated:
+- When changes are made to Protobuf files on the `main` branch
+- When a new version of IBC-Go is released with a tag (e.g., `v7.3.0`)
+
+You can browse the Protobuf definitions directly on the Buf Schema Registry:
+- [Main branch](https://buf.build/cosmos/ibc/docs/main)
+- Tagged versions are available in the "Tags" section
+
+## Using Tagged Versions in Your Projects
+
+When depending on IBC-Go Protobuf definitions in your own projects, you can specify a particular tagged version to ensure API stability:
+
+```yaml
+# In your buf.yaml file
+deps:
+  - buf.build/cosmos/ibc:v7.3.0  # Replace with your desired version
+```
+
+This ensures your project always uses the same version of the API definitions, regardless of updates to the main branch.
+
+## Generated Documentation
+
+For a complete reference of all IBC Protobuf definitions, see the [generated Protobuf documentation](https://buf.build/cosmos/ibc/docs/main).


### PR DESCRIPTION
## Description

This PR adds support for publishing Protocol Buffer definitions to the Buf Schema Registry with appropriate labels whenever a new IBC-Go release tag is created. This allows consumers of our Protobuf API to depend on specific tagged versions, ensuring API stability in their projects.

Changes include:
- Updated GitHub workflow to trigger on tag creation with pattern 'v*.*.*'
- Added configuration to push buf schemas with labels that include the tag name
- Updated documentation to explain how to use tagged versions in dependencies
- Added information about the Buf Schema Registry to README

closes: #8070

https://github.com/cosmos/ibc-go/issues/8070

## Checklist

- [x] Targeted PR against the correct branch.
- [x] Linked to GitHub issue with discussion and accepted design.
- [x] Code follows the module structure standards and Go style guide.
- [x] Updated relevant documentation (`docs/`).
- [x] Added relevant `godoc` comments.
- [x] Provide a conventional commit message to follow the repository standards.
- [x] Include a descriptive changelog entry.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Review `SonarCloud Report` in the comment section below once CI passes.