### PR TITLE
test: set expError for fake acknowledgement test case

### DIFF
--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -699,6 +699,7 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 		{
 			"fake acknowledgement",
 			func() {
+				expError = types.ErrInvalidAcknowledgement
 				// setup uses an UNORDERED channel
 				suite.coordinator.Setup(path)
 


### PR DESCRIPTION
## Context

https://celestia-team.slack.com/archives/C01BZ4XNGFK/p1741950351888399

cc: @gjermundgaraba 

## Problem

[This PR](https://github.com/cosmos/ibc-go/commit/a5b5b929831859be62c5f7dc94970efa868cc84b) added a test case for the most recent security vulnerability but the test case doesn't verify that the error is of type `types.ErrInvalidAcknowledgement`