### PR TITLE
refactor: use pointer receivers consistently for 08-wasm keeper methods

### DIFF
--- a/modules/light-clients/08-wasm/keeper/export_test.go
+++ b/modules/light-clients/08-wasm/keeper/export_test.go
@@ -3,12 +3,12 @@ package keeper
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
 // MigrateContractCode is a wrapper around k.migrateContractCode to allow the method to be directly called in tests.
-func (k Keeper) MigrateContractCode(ctx sdk.Context, clientID string, newChecksum, migrateMsg []byte) error {
+func (k *Keeper) MigrateContractCode(ctx sdk.Context, clientID string, newChecksum, migrateMsg []byte) error {
 	return k.migrateContractCode(ctx, clientID, newChecksum, migrateMsg)
 }
 
 // GetQueryPlugins is a wrapper around k.getQueryPlugins to allow the method to be directly called in tests.
-func (k Keeper) GetQueryPlugins() QueryPlugins {
+func (k *Keeper) GetQueryPlugins() QueryPlugins {
 	return k.getQueryPlugins()
 }
 


### PR DESCRIPTION
## Description

This PR makes the receiver types consistent across keeper method definitions in the light-clients/08-wasm module. All methods now use pointer receivers instead of a mix of pointer and value receivers.

closes: #6165

## Changes
- Updated all Keeper methods in keeper.go to use pointer receivers
- Updated QueryPlugins methods in querier.go to use pointer receivers
- Updated test wrapper methods in export_test.go to use pointer receivers

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#pull-request-targeting)).
- [x] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://docs.cosmos.network/main/build/building-modules/intro) and [Go style guide](../docs/dev/go-style-guide.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package).
- [ ] Updated relevant documentation (`docs/`). (N/A - code refactoring only)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code). (N/A - no new functions)
- [x] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
- [ ] Include a descriptive changelog entry when appropriate. This may be left to the discretion of the PR reviewers. (e.g. chores should be omitted from changelog)
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.