### PR TITLE
Update gRPC Query Path for Total Escrow by Denom

### DIFF
--- a/docs/architecture/adr-011-transfer-total-escrow-state-entry.md
+++ b/docs/architecture/adr-011-transfer-total-escrow-state-entry.md
@@ -99,7 +99,7 @@ A gRPC query endpoint is added so that it is possible to retrieve the total amou
 ```proto
 // TotalEscrowForDenom returns the total amount of tokens in escrow based on the denom.
 rpc TotalEscrowForDenom(QueryTotalEscrowForDenomRequest) returns (QueryTotalEscrowForDenomResponse) {
-  option (google.api.http).get = "/ibc/apps/transfer/v1/denoms/{denom=**}/total_escrow";
+  option (google.api.http).get = "/ibc/apps/transfer/v1/total_escrow/{denom=**}";
 }
 
 // QueryTotalEscrowForDenomRequest is the request type for TotalEscrowForDenom RPC method.


### PR DESCRIPTION


**Description:**  
This PR updates the gRPC query endpoint path in the ADR-011 documentation, changing it from `/ibc/apps/transfer/v1/denoms/{denom=*}/total_escrow` to `/ibc/apps/transfer/v1/total_escrow/{denom=*}` for improved clarity and consistency.