### PR TITLE
fix typos and improve clarity in IBC v2 documentation

### DIFF
--- a/docs/versioned_docs/version-v10.1.x/02-apps/01-transfer/10-IBCv2-transfer.md
+++ b/docs/versioned_docs/version-v10.1.x/02-apps/01-transfer/10-IBCv2-transfer.md
@@ -7,7 +7,7 @@ slug: /apps/transfer/ics20-v1/ibcv2transfer
 
 # IBC v2 Transfer
 
-Much of the core business logic of sending and recieving tokens between chains is unchanged between IBC Classic and IBC v2. Some of the key differences to pay attention to are detailed below. 
+Much of the core business logic of sending and receiving tokens between chains is unchanged between IBC Classic and IBC v2. Some of the key differences to pay attention to are detailed below. 
 
 ## No Channel Handshakes, New Packet Format and Encoding Support
 
@@ -23,7 +23,7 @@ The code snippet shows the `Payload` struct.
 type Payload struct {
 	// specifies the source port of the packet, e.g. transfer
 	SourcePort string `protobuf:"bytes,1,opt,name=source_port,json=sourcePort,proto3" json:"source_port,omitempty"`
-	// specifies the destination port of the packet, e.g. trasnfer
+	// specifies the destination port of the packet, e.g. transfer
 	DestinationPort string `protobuf:"bytes,2,opt,name=destination_port,json=destinationPort,proto3" json:"destination_port,omitempty"`
 	// version of the specified application
 	Version string `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
@@ -56,9 +56,9 @@ type FungibleTokenPacketData struct {
 
 ## Base Denoms cannot contain slashes
 
-With the new [`Denom`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/types/token.pb.go#L81-L87) struct, the base denom, i.e. uatom, is seperated from the trace - the path the token has travelled. The trace is presented as an array of [`Hop`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/types/token.pb.go#L136-L140)s. 
+With the new [`Denom`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/types/token.pb.go#L81-L87) struct, the base denom, i.e. uatom, is separated from the trace - the path the token has travelled. The trace is presented as an array of [`Hop`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/types/token.pb.go#L136-L140)s. 
 
-Because IBC v2 no longer uses channels, it is no longer possible to rely on a fixed format for an identifier so using a base denom that contains a "/" is dissallowed. 
+Because IBC v2 no longer uses channels, it is no longer possible to rely on a fixed format for an identifier so using a base denom that contains a "/" is disallowed. 
 
 ## Changes to the application module interface
 

--- a/docs/versioned_docs/version-v10.1.x/04-middleware/01-callbacks/07-callbacks-IBCv2.md
+++ b/docs/versioned_docs/version-v10.1.x/04-middleware/01-callbacks/07-callbacks-IBCv2.md
@@ -15,14 +15,14 @@ Some of the interface differences are:
 
 - The callbacks middleware for IBC v2 requires the [`Underlying Application`](../01-callbacks/01-overview.md) to implement the new [`CallbacksCompatibleModuleV2`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/types/callbacks.go#L53-L58) interface. 
 - `channeltypesv2.Payload` is now used instead of `channeltypes.Packet`
-- With IBC classic, the `OnRecvPacket` callback returns the `ack`, whereas v2 returns the `recvResult` which is the [status of the packet](https://github.com/cosmos/ibc-go/blob/main/modules/core/04-channel/v2/types/packet.pb.go#L26-L38): unspecified, success, failue or asynchronous
+- With IBC classic, the `OnRecvPacket` callback returns the `ack`, whereas v2 returns the `recvResult` which is the [status of the packet](https://github.com/cosmos/ibc-go/blob/main/modules/core/04-channel/v2/types/packet.pb.go#L26-L38): unspecified, success, failure or asynchronous
 - `api.WriteAcknowledgementWrapper` is used instead of `ICS4Wrapper.WriteAcknowledgement`. It is only needed if the lower level application is going to write an asynchronous acknowledgement.
 
 ## Contract Developers
 
 The wasmd contract keeper enables cosmwasm developers to use the callbacks middleware. The [cosmwasm documentation](https://cosmwasm.cosmos.network/ibc/extensions/callbacks) provides information for contract developers. The IBC v2 callbacks implementation uses a `Payload` but reconstructs an IBC classic `Packet` to preserve the cosmwasm contract keeper interface. Additionally contracts must now handle the IBC v2 `ErrorAcknowledgement` sentinel value in the case of a failure.
 
-The callbacks middleware can be used for transfer + action workflows, for example a transfer and swap on recieve. These workflows require knowledge of the ibc denom that has been recieved. To assist with parsing the ics20 packet, [helper functions](https://github.com/cosmos/solidity-ibc-eureka/blob/a8870b023e58622fb7b3f733572c684851f8e5ee/packages/cosmwasm/ibc-callbacks-helpers/src/ics20.rs#L7-L41) can be found in the solidity-ibc-eureka repository. 
+The callbacks middleware can be used for transfer + action workflows, for example a transfer and swap on receive. These workflows require knowledge of the ibc denom that has been received. To assist with parsing the ics20 packet, [helper functions](https://github.com/cosmos/solidity-ibc-eureka/blob/a8870b023e58622fb7b3f733572c684851f8e5ee/packages/cosmwasm/ibc-callbacks-helpers/src/ics20.rs#L7-L41) can be found in the solidity-ibc-eureka repository. 
 
 ## Integration
 


### PR DESCRIPTION


---

**Description:**  
This pull request corrects several typographical errors (such as `recieve` → `receive` and `dissalowed` → `disallowed`) and improves the clarity of explanations in the IBC v2 documentation.  
No functional changes to code or logic were made; this is a documentation-only update.

---