### PR TITLE
Fix Hermes config packet filter modification: correct TOML type asser…

### DIFF
--- a/e2e/relayer/relayer.go
+++ b/e2e/relayer/relayer.go
@@ -63,12 +63,16 @@ func ApplyPacketFilter(ctx context.Context, t *testing.T, r ibc.Relayer, chainID
 	}
 
 	return modifyHermesConfigFile(ctx, h, func(config map[string]any) error {
-		chains, ok := config["chains"].([]map[string]any)
+		chainsIface, ok := config["chains"].([]interface{})
 		if !ok {
 			return errors.New("failed to get chains from hermes config")
 		}
 		var chain map[string]any
-		for _, c := range chains {
+		for _, cIface := range chainsIface {
+			c, ok := cIface.(map[string]any)
+			if !ok {
+				continue
+			}
 			if c["id"] == chainID {
 				chain = c
 				break


### PR DESCRIPTION
## Description 

This commit updates the logic for modifying the Hermes relayer configuration in the ApplyPacketFilter function.
Previously, the code attempted to type assert the chains field of the parsed TOML config as []map[string]any. However, when unmarshaling TOML (or JSON) into a map[string]any in Go, arrays are represented as []interface{}, and each element must be individually type asserted to map[string]any. The previous approach could lead to type assertion failures and prevent correct modification of the Hermes config.

## What was changed:
- The code now asserts config["chains"] as []interface{} and iterates over each element, asserting each to map[string]any before processing.
- This ensures compatibility with the structure produced by toml.Unmarshal, allowing the function to reliably locate and modify the relevant chain's packet filter configuration.

## Why this was done:
- This change aligns the code with Go's standard practice for working with dynamically unmarshaled TOML/JSON data.
- It improves the robustness and reliability of Hermes relayer configuration updates during tests.

## How it was fixed:
- Replaced the direct type assertion to []map[string]any with a two-step process: first to []interface{}, then to map[string]any per element.

## Impact:
- The function now works as intended, enabling dynamic and reliable modification of Hermes relayer configuration files in e2e tests.
- This change helps prevent potential issues with type assertions and improves test reliability for scenarios involving Hermes packet filtering.