### PR TITLE
Fix typos in IBC v2 application documentation

### DIFF
--- a/docs/versioned_docs/version-v10.1.x/01-ibc/03-apps/00-ibcv2apps.md
+++ b/docs/versioned_docs/version-v10.1.x/01-ibc/03-apps/00-ibcv2apps.md
@@ -104,7 +104,7 @@ Modules may return to the IBC handler an acknowledgement which implements the `A
 The IBC handler will then commit this acknowledgement of the packet so that a relayer may relay the
 acknowledgement back to the sender module.
 
-The state changes that occurr during this callback could be:
+The state changes that occur during this callback could be:
 
 - the packet processing was successful as indicated by the `PacketStatus_Success` and an `Acknowledgement()` will be written
 - if the packet processing was unsuccessful as indicated by the `PacketStatus_Failure` and an `ackErr` will be written
@@ -307,7 +307,7 @@ payload := channeltypesv2.NewPayload(
 )
 ```
 
-It is also possible to define your own custom success acknowledgement which will be returned to the sender if the packet is successfully recieved and is returned in the `RecvPacketResult`. Note that if the packet processing fails, it is not possible to define a custom error acknowledgment, a constant ackErr is returned. 
+It is also possible to define your own custom success acknowledgement which will be returned to the sender if the packet is successfully received and is returned in the `RecvPacketResult`. Note that if the packet processing fails, it is not possible to define a custom error acknowledgment, a constant ackErr is returned. 
 
 ## Routing
 

--- a/docs/versioned_docs/version-v10.1.x/01-ibc/03-apps/01-apps.md
+++ b/docs/versioned_docs/version-v10.1.x/01-ibc/03-apps/01-apps.md
@@ -18,7 +18,7 @@ Communication Protocol (IBC) applications for custom use cases.
 
 Due to the modular design of the IBC protocol, IBC
 application developers do not need to concern themselves with the low-level details of clients,
-connections, and proof verification, however a brief explaination is given.  Then the document goes into detail on the abstraction layer most relevant for application
+connections, and proof verification, however a brief explanation is given.  Then the document goes into detail on the abstraction layer most relevant for application
 developers (channels and ports), and describes how to define your own custom packets, and
 `IBCModule` callbacks.
 

--- a/docs/versioned_docs/version-v10.1.x/02-apps/01-transfer/10-IBCv2-transfer.md
+++ b/docs/versioned_docs/version-v10.1.x/02-apps/01-transfer/10-IBCv2-transfer.md
@@ -7,7 +7,7 @@ slug: /apps/transfer/ics20-v1/ibcv2transfer
 
 # IBC v2 Transfer
 
-Much of the core business logic of sending and recieving tokens between chains is unchanged between IBC Classic and IBC v2. Some of the key differences to pay attention to are detailed below. 
+Much of the core business logic of sending and receiving tokens between chains is unchanged between IBC Classic and IBC v2. Some of the key differences to pay attention to are detailed below. 
 
 ## No Channel Handshakes, New Packet Format and Encoding Support
 
@@ -23,7 +23,7 @@ The code snippet shows the `Payload` struct.
 type Payload struct {
 	// specifies the source port of the packet, e.g. transfer
 	SourcePort string `protobuf:"bytes,1,opt,name=source_port,json=sourcePort,proto3" json:"source_port,omitempty"`
-	// specifies the destination port of the packet, e.g. trasnfer
+	// specifies the destination port of the packet, e.g. transfer
 	DestinationPort string `protobuf:"bytes,2,opt,name=destination_port,json=destinationPort,proto3" json:"destination_port,omitempty"`
 	// version of the specified application
 	Version string `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
@@ -56,9 +56,9 @@ type FungibleTokenPacketData struct {
 
 ## Base Denoms cannot contain slashes
 
-With the new [`Denom`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/types/token.pb.go#L81-L87) struct, the base denom, i.e. uatom, is seperated from the trace - the path the token has travelled. The trace is presented as an array of [`Hop`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/types/token.pb.go#L136-L140)s. 
+With the new [`Denom`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/types/token.pb.go#L81-L87) struct, the base denom, i.e. uatom, is separated from the trace - the path the token has travelled. The trace is presented as an array of [`Hop`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/types/token.pb.go#L136-L140)s. 
 
-Because IBC v2 no longer uses channels, it is no longer possible to rely on a fixed format for an identifier so using a base denom that contains a "/" is dissallowed. 
+Because IBC v2 no longer uses channels, it is no longer possible to rely on a fixed format for an identifier so using a base denom that contains a "/" is disallowed. 
 
 ## Changes to the application module interface
 


### PR DESCRIPTION


```markdown


## Description

This pull request addresses several typographical errors in the IBC v2 application documentation:

- Corrects common misspellings (e.g., "occur", "received", "explanation", "receiving", "separated", "disallowed")
- Improves overall clarity and readability


```
