### PR TITLE
Update GitHub Actions: Bump actions/checkout to v5

### DIFF
--- a/.github/workflows/build-simd-image-from-tag.yml
+++ b/.github/workflows/build-simd-image-from-tag.yml
@@ -24,7 +24,7 @@ jobs:
         packages: write
         contents: read
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@v5
            with:
             ref: "${{ env.GIT_TAG }}"
             fetch-depth: 0

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         go-arch: ['amd64', 'arm64']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
@@ -68,7 +68,7 @@ jobs:
           }
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'


### PR DESCRIPTION


---


**Description:**  
This PR updates the GitHub Actions workflows to use actions/checkout@v5 instead of v4.  
- Updated in:  
  - build-simd-image-from-tag.yml  
  - golangci.yml  
  - test.yml  

