### PR TITLE
Fix premature removal of temp directory in tempDir function

### DIFF
--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -354,9 +354,7 @@ func appExport(
 var tempDir = func() string {
 	dir, err := os.MkdirTemp("", "simapp")
 	if err != nil {
-		dir = simapp.DefaultNodeHome
+		return simapp.DefaultNodeHome
 	}
-	defer os.RemoveAll(dir)
-
 	return dir
 }


### PR DESCRIPTION
Previously, the tempDir function used `defer os.RemoveAll(dir)`, which caused the temporary directory to be deleted immediately after the function returned. This resulted in returning a path to a directory that no longer existed, potentially causing errors when the directory was used later in the application.

This commit removes the `defer os.RemoveAll(dir)` statement from the tempDir function. Now, the temporary directory will persist after the function returns, allowing it to be safely used by other parts of the application. If cleanup is required, it should be handled explicitly at the appropriate place in the codebase.