### PR TITLE
chore: remove deprecated testing helper functions

### DIFF
--- a/testing/coordinator.go
+++ b/testing/coordinator.go
@@ -83,37 +83,6 @@ func (c *Coordinator) UpdateTimeForChain(chain *TestChain) {
 	chain.ProposedHeader.Time = c.CurrentTime.UTC()
 }
 
-// Setup constructs a TM client, connection, and channel on both chains provided. It will
-// fail if any error occurs.
-// Deprecated: please use path.Setup(), this function will be removed in v10
-func (*Coordinator) Setup(path *Path) {
-	path.Setup()
-}
-
-// SetupClients is a helper function to create clients on both chains. It assumes the
-// caller does not anticipate any errors.
-// Deprecated: please use path.SetupClients(), this function will be removed in v10
-func (*Coordinator) SetupClients(path *Path) {
-	path.SetupClients()
-}
-
-// SetupConnections is a helper function to create clients and the appropriate
-// connections on both the source and counterparty chain. It assumes the caller does not
-// anticipate any errors.
-// Deprecated: please use path.SetupConnections(), this function will be removed in v10
-func (*Coordinator) SetupConnections(path *Path) {
-	path.SetupConnections()
-}
-
-// CreateConnections constructs and executes connection handshake messages in order to create
-// OPEN channels on chainA and chainB. The connection information of for chainA and chainB
-// are returned within a TestConnection struct. The function expects the connections to be
-// successfully opened otherwise testing will fail.
-// Deprecated: please use path.CreateConnections(), this function will be removed in v10
-func (*Coordinator) CreateConnections(path *Path) {
-	path.CreateConnections()
-}
-
 // CreateMockChannels constructs and executes channel handshake messages to create OPEN
 // channels that use a mock application module that returns nil on all callbacks. This
 // function is expects the channels to be successfully opened otherwise testing will

--- a/testing/endpoint.go
+++ b/testing/endpoint.go
@@ -595,19 +595,6 @@ func (ep *Endpoint) TimeoutOnClose(packet channeltypes.Packet) error {
 	return ep.Chain.sendMsgs(timeoutOnCloseMsg)
 }
 
-// Deprecated: usage of this function should be replaced by `UpdateChannel`
-// SetChannelState sets a channel state
-func (ep *Endpoint) SetChannelState(state channeltypes.State) error {
-	channel := ep.GetChannel()
-
-	channel.State = state
-	ep.Chain.App.GetIBCKeeper().ChannelKeeper.SetChannel(ep.Chain.GetContext(), ep.ChannelConfig.PortID, ep.ChannelID, channel)
-
-	ep.Chain.Coordinator.CommitBlock(ep.Chain)
-
-	return ep.Counterparty.UpdateClient()
-}
-
 // UpdateChannel updates the channel associated with the given ep. It accepts a
 // closure which takes a channel allowing the caller to modify its fields.
 func (ep *Endpoint) UpdateChannel(updater func(channel *channeltypes.Channel)) {

--- a/testing/events.go
+++ b/testing/events.go
@@ -338,32 +338,3 @@ func attributeByKey(attributes []abci.EventAttribute, key string) (abci.EventAtt
 	}
 	return attributes[idx], true
 }
-
-// ParsePacketFromEvents parses events emitted from a send packet and returns
-// the first EventTypeSendPacket packet found.
-// Returns an error if no packet is found.
-//
-// Deprecated: This function will be removed in the next major release. Use
-// ParseV1PacketFromEvents instead
-func ParsePacketFromEvents(events []abci.Event) (channeltypes.Packet, error) {
-	return ParseV1PacketFromEvents(events)
-}
-
-// ParseRecvPacketFromEvents parses events emitted from a MsgRecvPacket and returns
-// the first EventTypeRecvPacket packet found.
-// Returns an error if no packet is found.
-//
-// Deprecated: This function will be removed in the next major release. Use
-// ParseRecvV1PacketFromEvents instead
-func ParseRecvPacketFromEvents(events []abci.Event) (channeltypes.Packet, error) {
-	return ParseRecvV1PacketFromEvents(events)
-}
-
-// ParsePacketsFromEvents parses events emitted from a MsgRecvPacket and returns
-// all the packets found.
-// Returns an error if no packet is found.
-//
-// Deprecated: This function will be removed in the next major release. Use ParseIBCV1Packets instead.
-func ParsePacketsFromEvents(eventType string, events []abci.Event) ([]channeltypes.Packet, error) {
-	return ParseIBCV1Packets(eventType, events)
-}


### PR DESCRIPTION
Remove deprecated testing helper functions with modern replacements available

Changes:
- Remove ParsePacketFromEvents, ParseRecvPacketFromEvents, ParsePacketsFromEvents (use V1 versions)
- Remove Setup, SetupClients, SetupConnections, CreateConnections (use path methods)  
- Remove SetChannelState (use UpdateChannel)