### PR TITLE
ci: upgrade to Node.js 24

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: docs/package-lock.json
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: docs/package-lock.json
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Node.js 24 instead of 20 .

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
No other changes were required. CI and lint checks run successfully under the new version.

Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)