### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/build-simd-image-from-tag.yml
+++ b/.github/workflows/build-simd-image-from-tag.yml
@@ -24,7 +24,7 @@ jobs:
         packages: write
         contents: read
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@v5
            with:
             ref: "${{ env.GIT_TAG }}"
             fetch-depth: 0

--- a/.github/workflows/build-wasm-simd-image-from-tag.yml
+++ b/.github/workflows/build-wasm-simd-image-from-tag.yml
@@ -28,7 +28,7 @@ jobs:
             platform: linux/arm64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
          ref: "${{ env.GIT_TAG }}"
          fetch-depth: 0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - uses: technote-space/get-diff-action@v6.1.2
       with:
         PATTERNS: |

--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.DEPENDABOT_PUSH_PAT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -27,7 +27,7 @@ jobs:
   lint:
     runs-on: depot-ubuntu-22.04-4
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - uses: DavidAnson/markdownlint-cli2-action@v20

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,7 +16,7 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/e2e-compatibility-workflow-call.yaml
+++ b/.github/workflows/e2e-compatibility-workflow-call.yaml
@@ -21,7 +21,7 @@ jobs:
       test-matrix: ${{ steps.set-test-matrix.outputs.test-matrix }}
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -44,7 +44,7 @@ jobs:
       matrix: ${{ fromJSON(needs.load-test-matrix.outputs.test-matrix) }}
     steps:
       - name: Checkout the ibc-go repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: cosmos/ibc-go
       - uses: actions/setup-go@v5

--- a/.github/workflows/e2e-compatibility.yaml
+++ b/.github/workflows/e2e-compatibility.yaml
@@ -59,7 +59,7 @@ jobs:
           - release/v10.3.x
           - main
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: env.RELEASE_BRANCH == matrix.release-branch
         with:
           ref: "${{ matrix.release-branch }}"

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -54,7 +54,7 @@ jobs:
           },
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: cosmos/ibc-go
       - uses: actions/setup-go@v5

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       simd-tag: ${{ steps.get-tag.outputs.simd-tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -60,7 +60,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: cosmos/ibc-go
       - uses: actions/setup-go@v5
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build-test-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: cosmos/ibc-go
       - uses: actions/setup-go@v5

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/proto-breaking-check.yml
+++ b/.github/workflows/proto-breaking-check.yml
@@ -11,6 +11,6 @@ jobs:
   proto-breaking-check:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run proto-breaking check
         run: make proto-check-breaking

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -15,7 +15,7 @@ jobs:
   push:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         go-arch: ['amd64', 'arm64']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
@@ -68,7 +68,7 @@ jobs:
           }
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0