### PR TITLE
chore: bump ci deps

### DIFF
--- a/.github/workflows/build-simd-image-from-tag.yml
+++ b/.github/workflows/build-simd-image-from-tag.yml
@@ -19,12 +19,12 @@ env:
 
 jobs:
     build-image-at-tag:
-      runs-on: depot-ubuntu-22.04-4
+      runs-on: depot-ubuntu-24.04-4
       permissions:
         packages: write
         contents: read
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@v5
            with:
             ref: "${{ env.GIT_TAG }}"
             fetch-depth: 0

--- a/.github/workflows/build-wasm-simd-image-from-tag.yml
+++ b/.github/workflows/build-wasm-simd-image-from-tag.yml
@@ -28,7 +28,7 @@ jobs:
             platform: linux/arm64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
          ref: "${{ env.GIT_TAG }}"
          fetch-depth: 0
@@ -76,7 +76,7 @@ jobs:
           retention-days: 1
 
   merge:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       actions: read
       contents: read
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - uses: technote-space/get-diff-action@v6.1.2
       with:
         PATTERNS: |

--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -12,10 +12,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - name: Check out PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.DEPENDABOT_PUSH_PAT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,13 +16,13 @@ env:
 
 jobs:
   docker-build:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       packages: write
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -10,9 +10,9 @@ on:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -25,9 +25,9 @@ jobs:
         run: cd docs && npm run build
 
   lint:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - uses: DavidAnson/markdownlint-cli2-action@v20

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,9 +14,9 @@ on:
 jobs:
   deploy:
     name: Deploy to GitHub Pages
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/e2e-compatibility-workflow-call.yaml
+++ b/.github/workflows/e2e-compatibility-workflow-call.yaml
@@ -19,9 +19,9 @@ jobs:
   load-test-matrix:
     outputs:
       test-matrix: ${{ steps.set-test-matrix.outputs.test-matrix }}
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -34,7 +34,7 @@ jobs:
         id: set-test-matrix
 
   e2e:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     needs: load-test-matrix
     # this job is skipped if the test-matrix generated is empty. i.e. if the file was not present.
     # this allows us to not have to handle special case versions which may not have certain tests run against them.
@@ -44,7 +44,7 @@ jobs:
       matrix: ${{ fromJSON(needs.load-test-matrix.outputs.test-matrix) }}
     steps:
       - name: Checkout the ibc-go repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: cosmos/ibc-go
       - uses: actions/setup-go@v5

--- a/.github/workflows/e2e-compatibility.yaml
+++ b/.github/workflows/e2e-compatibility.yaml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   determine-image-tag:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     outputs:
       release-version: ${{ steps.set-release-version.outputs.release-version }}
     steps:
@@ -46,7 +46,7 @@ jobs:
   # build-release-images builds all docker images that are relevant for the compatibility tests. If a single release
   # branch is specified, only that image will be built, e.g. release-v6.0.x.
   build-release-images:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       packages: write
       contents: read
@@ -59,7 +59,7 @@ jobs:
           - release/v10.3.x
           - main
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: env.RELEASE_BRANCH == matrix.release-branch
         with:
           ref: "${{ matrix.release-branch }}"

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   e2e-upgrade-tests:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       fail-fast: false
       matrix: 
@@ -54,7 +54,7 @@ jobs:
           },
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: cosmos/ibc-go
       - uses: actions/setup-go@v5

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,11 +15,11 @@ env:
 
 jobs:
   docker-build:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     outputs:
       simd-tag: ${{ steps.get-tag.outputs.simd-tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -56,11 +56,11 @@ jobs:
           path: simd-image.tar.gz
 
   build-test-matrix:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: cosmos/ibc-go
       - uses: actions/setup-go@v5
@@ -75,7 +75,7 @@ jobs:
           TEST_EXCLUSIONS: 'TestUpgradeTestSuite'
 
   e2e-tests:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     needs:
       - build-test-matrix
       - docker-build
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build-test-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: cosmos/ibc-go
       - uses: actions/setup-go@v5

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         working-directory: ['.', 'modules/light-clients/08-wasm', 'e2e']
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/proto-breaking-check.yml
+++ b/.github/workflows/proto-breaking-check.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
   proto-breaking-check:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run proto-breaking check
         run: make proto-check-breaking

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -13,9 +13,9 @@ on:
 
 jobs:
   push:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ concurrency:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         go-arch: ['amd64', 'arm64']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
@@ -49,7 +49,7 @@ jobs:
           done
 
   unit-tests:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         module: [
@@ -68,7 +68,7 @@ jobs:
           }
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'


### PR DESCRIPTION
Update GitHub Actions workflows to use depot ubuntu 24.04 and checkout v5.

To use the latest version of checkout, we also needed to update our runners, which was due anyway...