### PR TITLE
fix(gmp): fix keeper initialization and packet unmarshaling

### DIFF
--- a/modules/apps/27-gmp/keeper/keeper.go
+++ b/modules/apps/27-gmp/keeper/keeper.go
@@ -46,9 +46,11 @@ func NewKeeper(
 
 	sb := collections.NewSchemaBuilder(storeService)
 	k := Keeper{
-		cdc:       cdc,
-		authority: authority,
-		Accounts:  collections.NewMap(sb, types.AccountsKey, "accounts", collections.TripleKeyCodec(collections.StringKey, collections.StringKey, collections.BytesKey), codec.CollValue[types.ICS27Account](cdc)),
+		cdc:           cdc,
+		msgRouter:     msgRouter,
+		accountKeeper: accountKeeper,
+		authority:     authority,
+		Accounts:      collections.NewMap(sb, types.AccountsKey, "accounts", collections.TripleKeyCodec(collections.StringKey, collections.StringKey, collections.BytesKey), codec.CollValue[types.ICS27Account](cdc)),
 	}
 
 	schema, err := sb.Build()

--- a/modules/apps/27-gmp/types/packet.go
+++ b/modules/apps/27-gmp/types/packet.go
@@ -79,10 +79,10 @@ func UnmarshalPacketData(bz []byte, ics27Version string, encoding string) (*GMPP
 		panic("unsupported ics27 version")
 	}
 
-	var data *GMPPacketData
+	data := &GMPPacketData{}
 	switch encoding {
 	case EncodingJSON:
-		if err := json.Unmarshal(bz, &data); err != nil {
+		if err := json.Unmarshal(bz, data); err != nil {
 			return nil, errorsmod.Wrapf(ibcerrors.ErrInvalidType, "failed to unmarshal json packet data: %s", err)
 		}
 	case EncodingProtobuf:


### PR DESCRIPTION
## Description

Fix two critical bugs in ICS27-GMP module:

  1. keeper: Initialize msgRouter and accountKeeper fields that were being passed to NewKeeper but not assigned to the keeper struct, causing nil pointer panics when routing messages

  2. packet: Fix UnmarshalPacketData to use correct Go unmarshal pattern by initializing pointer before passing to json.Unmarshal instead of passing pointer-to-pointer

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    Also: make sure that you are familiar with the contribution guidelines: (https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md
v    Failure to do this can result in your PR getting closed without further discussion (we receive a lot of PRs, and it takes a lot of time to respond to everyone who doesn't read this)
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->



<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->



---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Include changelog entry when appropriate (e.g. chores should be omitted from changelog).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package) if relevant.
- [ ] Updated documentation (`docs/`) if anything is changed.
- [ ] Added `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code) if relevant.
- [ ] Self-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
    <!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.
    This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
    Example commit messages:
    fix: skip emission of unpopulated memo field in ics20
    deps: updating sdk to v0.46.4
    chore: removed unused variables
    e2e: adding e2e upgrade test for ibc-go/v6
    docs: ics27 v6 documentation updates
    feat: add semantic version utilities for e2e tests
    feat(api)!: this is an api breaking feature
    fix(statemachine)!: this is a statemachine breaking fix
    -->
