### PR TITLE
docs/codec link fix

### DIFF
--- a/docs/docs/01-ibc/03-apps/07-address-codec.md
+++ b/docs/docs/01-ibc/03-apps/07-address-codec.md
@@ -66,7 +66,7 @@ After initializing your transfer keeper, configure the codec using the `SetAddre
 app.TransferKeeper.SetAddressCodec(evmaddress.NewEvmCodec(sdk.GetConfig().GetBech32AccountAddrPrefix()))
 ```
 
-For a complete example showing the transfer keeper initialization and address codec configuration, see [evmd app.go](https://github.com/cosmos/evm/blob/vlad/erc20-address-codec/evmd/app.go#L483-L494).
+For a complete example showing the transfer keeper initialization and address codec configuration, see [evmd app.go](https://github.com/cosmos/evm/blob/720ba9cf908a20a29b7401b19a136caeb8c4092f/evmd/app.go#L483-L494).
 
 ## Usage
 
@@ -89,4 +89,4 @@ Both formats resolve to the same on-chain account when derived from the same pri
 The cosmos/evm repository provides a complete implementation in `utils/address_codec.go` with integration examples in the `evmd` reference chain:
 
 - [**Implementation PR**](https://github.com/cosmos/evm/pull/665)
-- [**Example integration**](https://github.com/cosmos/evm/tree/main/evmd)
+- [**Reference Chain "evmd"**](https://github.com/cosmos/evm/tree/main/evmd)

--- a/docs/versioned_docs/version-v10.4.x/01-ibc/03-apps/07-address-codec.md
+++ b/docs/versioned_docs/version-v10.4.x/01-ibc/03-apps/07-address-codec.md
@@ -66,7 +66,7 @@ After initializing your transfer keeper, configure the codec using the `SetAddre
 app.TransferKeeper.SetAddressCodec(evmaddress.NewEvmCodec(sdk.GetConfig().GetBech32AccountAddrPrefix()))
 ```
 
-For a complete example showing the transfer keeper initialization and address codec configuration, see [evmd app.go](https://github.com/cosmos/evm/blob/vlad/erc20-address-codec/evmd/app.go#L483-L494).
+For a complete example showing the transfer keeper initialization and address codec configuration, see [evmd app.go](https://github.com/cosmos/evm/blob/720ba9cf908a20a29b7401b19a136caeb8c4092f/evmd/app.go#L483-L494).
 
 ## Usage
 
@@ -89,4 +89,4 @@ Both formats resolve to the same on-chain account when derived from the same pri
 The cosmos/evm repository provides a complete implementation in `utils/address_codec.go` with integration examples in the `evmd` reference chain:
 
 - [**Implementation PR**](https://github.com/cosmos/evm/pull/665)
-- [**Example integration**](https://github.com/cosmos/evm/tree/main/evmd)
+- [**Reference Chain "evmd"**](https://github.com/cosmos/evm/tree/main/evmd)


### PR DESCRIPTION
## Description

Fixes reference to deleted branch of external repo.


---

## ALL N/A

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Include changelog entry when appropriate (e.g. chores should be omitted from changelog).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package) if relevant.
- [ ] Updated documentation (`docs/`) if anything is changed.
- [ ] Added `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code) if relevant.
- [ ] Self-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
    <!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.
    This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
    Example commit messages:
    fix: skip emission of unpopulated memo field in ics20
    deps: updating sdk to v0.46.4
    chore: removed unused variables
    e2e: adding e2e upgrade test for ibc-go/v6
    docs: ics27 v6 documentation updates
    feat: add semantic version utilities for e2e tests
    feat(api)!: this is an api breaking feature
    fix(statemachine)!: this is a statemachine breaking fix
    -->
