### PR TITLE
docs: fix spelling errors in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -199,8 +199,8 @@ Technically, there are four docs being maintained in this repo:
 
 1. Found in `docs/docs/` (this is the one displayed on the website in the "Documentation" tab)
 2. Found in `docs/architecture/` (this is the one displayed on the website in the "Architecture Decision Records" tab)
-3. Found in `docs/events/` (depreciated, this is not displayed on the website, but is hosted under `/events/` url)
-4. Found in `docs/params/` (depreciated, this is not displayed on the website, but is hosted under `/params/` url)
+3. Found in `docs/events/` (deprecated, this is not displayed on the website, but is hosted under `/events/` url)
+4. Found in `docs/params/` (deprecated, this is not displayed on the website, but is hosted under `/params/` url)
 
 When referencing a markdown file, you should use relative file paths if they are in the same docs directory from above. For example, if you are in `docs/docs/01-ibc` and want to link to `docs/docs/02-apps/01-transfer/01-overview.md`, you should use the relative link `../02-apps/01-transfer/01-overview.md`.
 

--- a/docs/dev/go-style-guide.md
+++ b/docs/dev/go-style-guide.md
@@ -272,7 +272,7 @@ r := csv.Reader{',', '#', 4, false, false, false, false}
 ---
 **Naming struct fields in tabular tests**
 
-If tabular test struct has more than two fields, consider explicitly naming them. If the test struct has one name and one error field, then we can allow upto three fields. If test struct has more fields, consider naming them when writing test cases.
+If tabular test struct has more than two fields, consider explicitly naming them. If the test struct has one name and one error field, then we can allow up to three fields. If test struct has more fields, consider naming them when writing test cases.
 
 ```go
 // Good

--- a/docs/docs/00-intro.md
+++ b/docs/docs/00-intro.md
@@ -12,14 +12,14 @@ The Inter-Blockchain Communication Protocol (IBC) is a protocol that allows bloc
 The protocol realizes this interoperability by specifying a set of data structures, abstractions, and semantics that can be implemented by any distributed ledger that satisfies a small set of requirements.
 
 :::note Notice
-Since ibc-go v10, there are two versions of the protocol in the same release: IBC classic and IBC v2. The protocols are seperate - a connection uses either IBC classic or IBC v2
+Since ibc-go v10, there are two versions of the protocol in the same release: IBC classic and IBC v2. The protocols are separate - a connection uses either IBC classic or IBC v2
 :::
 
 ## High-level overview of IBC v2
 
 For a high level overview of IBC v2, please refer to [this blog post.](https://ibcprotocol.dev/blog/ibc-v2-announcement) For a more detailed understanding of the IBC v2 protocol, please refer to the [IBC v2 protocol specification.](https://github.com/cosmos/ibc/tree/main/spec/IBC_V2)
 
-If you are interested in using the cannonical deployment of IBC v2, connecting Cosmos chains and Ethereum, take a look at the [IBC Eureka](https://docs.skip.build/go/eureka/eureka-overview) documentation to get started.
+If you are interested in using the canonical deployment of IBC v2, connecting Cosmos chains and Ethereum, take a look at the [IBC Eureka](https://docs.skip.build/go/eureka/eureka-overview) documentation to get started.
 
 ## High-level overview of IBC Classic
 

--- a/docs/versioned_docs/version-v10.4.x/00-intro.md
+++ b/docs/versioned_docs/version-v10.4.x/00-intro.md
@@ -12,7 +12,7 @@ The Inter-Blockchain Communication Protocol (IBC) is a protocol that allows bloc
 The protocol realizes this interoperability by specifying a set of data structures, abstractions, and semantics that can be implemented by any distributed ledger that satisfies a small set of requirements.
 
 :::note Notice
-Since ibc-go v10, there are two versions of the protocol in the same release: IBC classic and IBC v2. The protocols are seperate - a connection uses either IBC classic or IBC v2
+Since ibc-go v10, there are two versions of the protocol in the same release: IBC classic and IBC v2. The protocols are separate - a connection uses either IBC classic or IBC v2
 :::
 
 ## High-level overview of IBC v2


### PR DESCRIPTION
Fixed 4 spelling errors in the documentation files:

"seperate" → "separate" in:
        docs/docs/00-intro.md (line 15)
        docs/versioned_docs/version-v10.4.x/00-intro.md (line 15)
"cannonical" → "canonical" in:
       docs/docs/00-intro.md (line 22)
"depreciated" → "deprecated" in:
       docs/README.md (lines 202-203)
"upto" → "up to" in:
       docs/dev/go-style-guide.md (line 275)