### PR TITLE
chore(core/port): remove unused RouterV2 field from PortKeeper

### DIFF
--- a/modules/core/05-port/keeper/keeper.go
+++ b/modules/core/05-port/keeper/keeper.go
@@ -8,14 +8,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/ibc-go/v10/modules/core/05-port/types"
-	"github.com/cosmos/ibc-go/v10/modules/core/api"
 	"github.com/cosmos/ibc-go/v10/modules/core/exported"
 )
 
 // Keeper defines the IBC connection keeper
 type Keeper struct {
 	Router   *types.Router
-	RouterV2 *api.Router
 }
 
 // NewKeeper creates a new IBC connection Keeper instance


### PR DESCRIPTION
Remove the unused RouterV2 field from PortKeeper and its import to eliminate dead code. IBC v2 routing is intentionally performed via ChannelKeeperV2.Router, and PortKeeper.RouterV2 was never referenced in the codebase or docs. This simplifies the API and prevents confusion for integrators.