### PR TITLE
fix(ibc): prevent incrementing zero IBC height

### DIFF
--- a/modules/core/02-client/types/height.go
+++ b/modules/core/02-client/types/height.go
@@ -113,7 +113,11 @@ func (h Height) Decrement() (exported.Height, bool) {
 // Increment will return a height with the same revision number but an
 // incremented revision height
 func (h Height) Increment() exported.Height {
-	return NewHeight(h.RevisionNumber, h.RevisionHeight+1)
+    if h.IsZero() {
+        panic("cannot increment zero IBC height")
+    }
+
+    return NewHeight(h.RevisionNumber, h.RevisionHeight+1)
 }
 
 // IsZero returns true if height revision and revision-height are both 0


### PR DESCRIPTION
Reject incrementing a zero-value IBC height to avoid creating an invalid state.


## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Include changelog entry when appropriate (e.g. chores should be omitted from changelog).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package) if relevant.
- [ ] Updated documentation (`docs/`) if anything is changed.
- [ ] Added `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code) if relevant.
- [ ] Self-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
    <!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.
    This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
    Example commit messages:
    fix: skip emission of unpopulated memo field in ics20
    deps: updating sdk to v0.46.4
    chore: removed unused variables
    e2e: adding e2e upgrade test for ibc-go/v6
    docs: ics27 v6 documentation updates
    feat: add semantic version utilities for e2e tests
    feat(api)!: this is an api breaking feature
    fix(statemachine)!: this is a statemachine breaking fix
    -->
