### PR TITLE
fix(channel/v2): parse binary store keys in PacketCommitments and PacketAcknowledgements queries

### DIFF
--- a/modules/core/04-channel/v2/keeper/grpc_query.go
+++ b/modules/core/04-channel/v2/keeper/grpc_query.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -96,9 +95,9 @@ func (q *queryServer) PacketCommitments(goCtx context.Context, req *types.QueryP
 	store := prefix.NewStore(runtime.KVStoreAdapter(q.storeService.OpenKVStore(goCtx)), hostv2.PacketCommitmentPrefixKey(req.ClientId))
 
 	pageRes, err := query.Paginate(store, req.Pagination, func(key, value []byte) error {
-		keySplit := strings.Split(string(key), "/")
-
-		sequence := sdk.BigEndianToUint64([]byte(keySplit[len(keySplit)-1]))
+		// The prefix store has already stripped the channelID + base prefix,
+		// so the key here is the raw 8-byte big-endian sequence number.
+		sequence := sdk.BigEndianToUint64(key)
 		if sequence == 0 {
 			return types.ErrInvalidPacket
 		}
@@ -180,9 +179,9 @@ func (q *queryServer) PacketAcknowledgements(goCtx context.Context, req *types.Q
 	}
 
 	pageRes, err := query.Paginate(store, req.Pagination, func(key, value []byte) error {
-		keySplit := strings.Split(string(key), "/")
-
-		sequence := sdk.BigEndianToUint64([]byte(keySplit[len(keySplit)-1]))
+		// The prefix store has already stripped the channelID + base prefix,
+		// so the key here is the raw 8-byte big-endian sequence number.
+		sequence := sdk.BigEndianToUint64(key)
 		if sequence == 0 {
 			return types.ErrInvalidPacket
 		}

--- a/modules/core/04-channel/v2/keeper/grpc_query_test.go
+++ b/modules/core/04-channel/v2/keeper/grpc_query_test.go
@@ -247,15 +247,12 @@ func (s *KeeperTestSuite) TestQueryPacketCommitmentsWithSlashByteSequences() {
 	s.Require().NotNil(res)
 	s.Require().Len(res.Commitments, len(sequences))
 
-	// Verify each sequence was returned with correct data.
-	returnedSeqs := make(map[uint64][]byte)
-	for _, c := range res.Commitments {
-		returnedSeqs[c.Sequence] = c.Data
-	}
-	for _, seq := range sequences {
-		data, ok := returnedSeqs[seq]
-		s.Require().True(ok, "sequence %d must be present in results", seq)
-		s.Require().Equal(fmt.Appendf(nil, "hash_%d", seq), data, "sequence %d must have correct data", seq)
+	for i, ps := range res.Commitments {
+		s.Require().Equal(sequences[i], ps.Sequence, "sequence %d must be correct", ps.Sequence)
+		expCommitment := expCommitments[i]
+		s.Require().Equal(expCommitment.Sequence, ps.Sequence, "sequence %d must have correct sequence", ps.Sequence)
+		s.Require().Equal(expCommitment.ClientId, ps.ClientId, "sequence %d must have correct client ID", ps.Sequence)
+		s.Require().Equal(expCommitment.Data, ps.Data, "sequence %d must have correct data", ps.Sequence)
 	}
 }
 
@@ -291,14 +288,11 @@ func (s *KeeperTestSuite) TestQueryPacketAcknowledgementsWithSlashByteSequences(
 	s.Require().NotNil(res)
 	s.Require().Len(res.Acknowledgements, len(sequences))
 
-	returnedSeqs := make(map[uint64][]byte)
-	for _, a := range res.Acknowledgements {
-		returnedSeqs[a.Sequence] = a.Data
-	}
-	for _, seq := range sequences {
-		data, ok := returnedSeqs[seq]
-		s.Require().True(ok, "sequence %d must be present in results", seq)
-		s.Require().Equal(fmt.Appendf(nil, "ack_%d", seq), data, "sequence %d must have correct data", seq)
+	for i, ps := range res.Acknowledgements {
+		expAck := expAcks[i]
+		s.Require().Equal(expAck.Sequence, ps.Sequence, "sequence %d must have correct sequence", ps.Sequence)
+		s.Require().Equal(expAck.ClientId, ps.ClientId, "sequence %d must have correct client ID", ps.Sequence)
+		s.Require().Equal(expAck.Data, ps.Data, "sequence %d must have correct data", ps.Sequence)
 	}
 }
 


### PR DESCRIPTION
## Summary

The `PacketCommitments` and `PacketAcknowledgements` gRPC query handlers use `strings.Split(string(key), "/")` to extract packet sequence numbers from store keys during pagination. However, IBC v2 store keys are binary-encoded (`channelID + byte(1) + bigEndian(sequence)`), not slash-delimited strings.

When the 8-byte big-endian sequence number contains a `0x2F` byte (ASCII `/`), `strings.Split` incorrectly splits the key, producing a corrupted sequence number that parses to `0` and triggers `ErrInvalidPacket`. This permanently breaks the bulk query for **all** packets once any stored sequence contains `0x2F` in its encoding (e.g. sequence 47 = `0x000000000000002F`).

**Bug location:** [`modules/core/04-channel/v2/keeper/grpc_query.go` L99](https://github.com/cosmos/ibc-go/blob/main/modules/core/04-channel/v2/keeper/grpc_query.go#L99) and [L183](https://github.com/cosmos/ibc-go/blob/main/modules/core/04-channel/v2/keeper/grpc_query.go#L183)

**Key format** (from [`modules/core/24-host/v2/packet_keys.go` L24-25](https://github.com/cosmos/ibc-go/blob/main/modules/core/24-host/v2/packet_keys.go#L24-L25)):
```go
func PacketCommitmentKey(channelID string, sequence uint64) []byte {
    return append(PacketCommitmentPrefixKey(channelID), sdk.Uint64ToBigEndian(sequence)...)
}
```

Since the prefix store already strips `channelID + basePrefix`, the pagination callback key is just the raw 8-byte big-endian sequence. The fix reads it directly with `sdk.BigEndianToUint64(key)` instead of string-splitting.

## Impact

- **Severity**: Critical for IBC v2 relayers
- Any relayer calling `PacketCommitments` or `PacketAcknowledgements` will permanently fail once a problematic sequence is stored
- All packets become undiscoverable, halting IBC v2 relay entirely
- Discovered in production after ~100 packets accumulated on a channel

## Fix

Replace `strings.Split` with direct binary key parsing:

```go
// Before (broken):
keySplit := strings.Split(string(key), "/")
sequence := sdk.BigEndianToUint64([]byte(keySplit[len(keySplit)-1]))

// After (correct):
sequence := sdk.BigEndianToUint64(key)
```

## Test plan

- [x] Existing `TestQueryPacketCommitments` and `TestQueryPacketAcknowledgements` pass
- [ ] Verified fix resolves the issue in production (relay resumes after binary swap)