### PR TITLE
imp(apps/27-gmp): add extra validation during unmarshals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (apps/27-gmp) [\#8945](https://github.com/cosmos/ibc-go/pull/8945) imp(apps/27-gmp): add extra validation during unmarshals
 * (apps/pfm) [\#8933](https://github.com/cosmos/ibc-go/pull/8933) Use `channeltypes.NewErrorAcknowledgement` instead of internal function
 * (apps/pfm) [\#8932](https://github.com/cosmos/ibc-go/pull/8932) imp(apps/pfm): use addressCodec in GetReceiver
 

--- a/modules/apps/27-gmp/types/ack.go
+++ b/modules/apps/27-gmp/types/ack.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -68,6 +69,14 @@ func UnmarshalAcknowledgement(bz []byte, ics27Version string, encoding string) (
 		}
 	default:
 		return nil, errorsmod.Wrapf(ErrInvalidEncoding, "invalid encoding provided, must be either empty or one of [%q, %q, %q], got %s", EncodingJSON, EncodingProtobuf, EncodingABI, encoding)
+	}
+
+	reserializedBz, err := MarshalAcknowledgement(data, ics27Version, encoding)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(reserializedBz, bz) {
+		return nil, errorsmod.Wrapf(ibcerrors.ErrInvalidType, "acknowledgement did not marshal to expected bytes: %X != %X", reserializedBz, bz)
 	}
 
 	return data, nil

--- a/modules/apps/27-gmp/types/ack_test.go
+++ b/modules/apps/27-gmp/types/ack_test.go
@@ -95,3 +95,21 @@ func TestMarshalAcknowledgement_EmptyResult(t *testing.T) {
 		})
 	}
 }
+
+func TestUnmarshalAcknowledgement_NonCanonicalJSON(t *testing.T) {
+	testCases := []struct {
+		name string
+		bz   []byte
+	}{
+		{"failure: duplicate key", []byte(`{"result":"AAEC","result":"/+7d"}`)},
+		{"failure: unknown field", []byte(`{"result":"AAEC","unknown_field":"x"}`)},
+		{"failure: case-insensitive field", []byte(`{"RESULT":"AAEC"}`)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := types.UnmarshalAcknowledgement(tc.bz, types.Version, types.EncodingJSON)
+			require.ErrorIs(t, err, ibcerrors.ErrInvalidType)
+		})
+	}
+}

--- a/modules/apps/27-gmp/types/ack_test.go
+++ b/modules/apps/27-gmp/types/ack_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"testing"
 
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/ibc-go/v11/modules/apps/27-gmp/types"
@@ -96,36 +97,97 @@ func TestMarshalAcknowledgement_EmptyResult(t *testing.T) {
 	}
 }
 
-func TestUnmarshalAcknowledgement_NonCanonicalJSON(t *testing.T) {
+func TestUnmarshalAcknowledgement_NonCanonical(t *testing.T) {
+	ack := &types.Acknowledgement{Result: []byte("result")}
+
 	testCases := []struct {
-		name string
-		bz   []byte
+		name     string
+		encoding string
+		malleate func(t *testing.T) []byte
 	}{
-		{"failure: duplicate key", []byte(`{"result":"AAEC","result":"/+7d"}`)},
-		{"failure: unknown field", []byte(`{"result":"AAEC","unknown_field":"x"}`)},
-		{"failure: case-insensitive field", []byte(`{"RESULT":"AAEC"}`)},
+		{
+			"failure: JSON duplicate key",
+			types.EncodingJSON,
+			func(t *testing.T) []byte {
+				return []byte(`{"result":"AAEC","result":"/+7d"}`)
+			},
+		},
+		{
+			"failure: JSON unknown field",
+			types.EncodingJSON,
+			func(t *testing.T) []byte {
+				return []byte(`{"result":"AAEC","unknown_field":"x"}`)
+			},
+		},
+		{
+			"failure: JSON case-insensitive field",
+			types.EncodingJSON,
+			func(t *testing.T) []byte {
+				return []byte(`{"RESULT":"AAEC"}`)
+			},
+		},
+		{
+			"failure: ABI trailing data",
+			types.EncodingABI,
+			func(t *testing.T) []byte {
+				bz, err := types.MarshalAcknowledgement(ack, types.Version, types.EncodingABI)
+				require.NoError(t, err)
+				bz = append(bz, make([]byte, 32)...)
+
+				decoded, err := types.DecodeABIAcknowledgement(bz)
+				require.NoError(t, err)
+				require.Equal(t, ack.Result, decoded.Result)
+
+				return bz
+			},
+		},
+		{
+			"failure: ABI non-zero padding",
+			types.EncodingABI,
+			func(t *testing.T) []byte {
+				bz, err := types.MarshalAcknowledgement(ack, types.Version, types.EncodingABI)
+				require.NoError(t, err)
+				bz[len(bz)-1] = 1
+
+				decoded, err := types.DecodeABIAcknowledgement(bz)
+				require.NoError(t, err)
+				require.Equal(t, ack.Result, decoded.Result)
+
+				return bz
+			},
+		},
+		{
+			"failure: protobuf duplicate field",
+			types.EncodingProtobuf,
+			func(t *testing.T) []byte {
+				bz := []byte{0x0A, 0x03, 0x00, 0x01, 0x02, 0x0A, 0x03, 0xFF, 0xEE, 0xDD}
+				decoded := &types.Acknowledgement{}
+				require.NoError(t, proto.Unmarshal(bz, decoded))
+				require.Equal(t, []byte{0xFF, 0xEE, 0xDD}, decoded.Result)
+
+				return bz
+			},
+		},
+		{
+			"failure: protobuf explicit empty result",
+			types.EncodingProtobuf,
+			func(t *testing.T) []byte {
+				bz := []byte{0x0A, 0x00}
+				decoded := &types.Acknowledgement{}
+				require.NoError(t, proto.Unmarshal(bz, decoded))
+				require.Empty(t, decoded.Result)
+
+				return bz
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := types.UnmarshalAcknowledgement(tc.bz, types.Version, types.EncodingJSON)
+			bz := tc.malleate(t)
+
+			_, err := types.UnmarshalAcknowledgement(bz, types.Version, tc.encoding)
 			require.ErrorIs(t, err, ibcerrors.ErrInvalidType)
 		})
 	}
-}
-
-func TestUnmarshalAcknowledgement_NonCanonicalABI(t *testing.T) {
-	ack := &types.Acknowledgement{Result: []byte("result")}
-	bz, err := types.MarshalAcknowledgement(ack, types.Version, types.EncodingABI)
-	require.NoError(t, err)
-
-	// Solidity ABI does not encode field names, so trailing data is the ABI analogue of an unknown field.
-	bz = append(bz, make([]byte, 32)...)
-
-	decoded, err := types.DecodeABIAcknowledgement(bz)
-	require.NoError(t, err)
-	require.Equal(t, ack.Result, decoded.Result)
-
-	_, err = types.UnmarshalAcknowledgement(bz, types.Version, types.EncodingABI)
-	require.ErrorIs(t, err, ibcerrors.ErrInvalidType)
 }

--- a/modules/apps/27-gmp/types/ack_test.go
+++ b/modules/apps/27-gmp/types/ack_test.go
@@ -113,3 +113,19 @@ func TestUnmarshalAcknowledgement_NonCanonicalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestUnmarshalAcknowledgement_NonCanonicalABI(t *testing.T) {
+	ack := &types.Acknowledgement{Result: []byte("result")}
+	bz, err := types.MarshalAcknowledgement(ack, types.Version, types.EncodingABI)
+	require.NoError(t, err)
+
+	// Solidity ABI does not encode field names, so trailing data is the ABI analogue of an unknown field.
+	bz = append(bz, make([]byte, 32)...)
+
+	decoded, err := types.DecodeABIAcknowledgement(bz)
+	require.NoError(t, err)
+	require.Equal(t, ack.Result, decoded.Result)
+
+	_, err = types.UnmarshalAcknowledgement(bz, types.Version, types.EncodingABI)
+	require.ErrorIs(t, err, ibcerrors.ErrInvalidType)
+}

--- a/modules/apps/27-gmp/types/packet.go
+++ b/modules/apps/27-gmp/types/packet.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 
@@ -110,6 +111,14 @@ func UnmarshalPacketData(bz []byte, ics27Version string, encoding string) (*GMPP
 		}
 	default:
 		return nil, errorsmod.Wrapf(ErrInvalidEncoding, "invalid encoding provided, must be either empty or one of [%q, %q, %q], got %s", EncodingJSON, EncodingProtobuf, EncodingABI, encoding)
+	}
+
+	reserializedBz, err := MarshalPacketData(data, ics27Version, encoding)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(reserializedBz, bz) {
+		return nil, errorsmod.Wrapf(ibcerrors.ErrInvalidType, "packet data did not marshal to expected bytes: %X != %X", reserializedBz, bz)
 	}
 
 	return data, nil

--- a/modules/apps/27-gmp/types/packet_test.go
+++ b/modules/apps/27-gmp/types/packet_test.go
@@ -145,6 +145,33 @@ func TestMarshalUnmarshalPacketData(t *testing.T) {
 	}
 }
 
+func TestUnmarshalPacketData_NonCanonicalJSON(t *testing.T) {
+	testCases := []struct {
+		name string
+		bz   []byte
+	}{
+		{
+			"failure: duplicate key",
+			[]byte(`{"sender":"cosmos1sender","sender":"cosmos1attacker","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo"}`),
+		},
+		{
+			"failure: unknown field",
+			[]byte(`{"sender":"cosmos1sender","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo","unknown_field":"x"}`),
+		},
+		{
+			"failure: case-insensitive field",
+			[]byte(`{"SENDER":"cosmos1sender","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo"}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := types.UnmarshalPacketData(tc.bz, types.Version, types.EncodingJSON)
+			require.ErrorIs(t, err, ibcerrors.ErrInvalidType)
+		})
+	}
+}
+
 func TestMsgSendCall_ValidateBasic(t *testing.T) {
 	validSender := "cosmos1qyqszqgpqyqszqgpqyqszqgpqyqszqgpjnp7du"
 

--- a/modules/apps/27-gmp/types/packet_test.go
+++ b/modules/apps/27-gmp/types/packet_test.go
@@ -172,6 +172,24 @@ func TestUnmarshalPacketData_NonCanonicalJSON(t *testing.T) {
 	}
 }
 
+func TestUnmarshalPacketData_NonCanonicalABI(t *testing.T) {
+	packetData := &types.GMPPacketData{
+		Sender:   "cosmos1sender",
+		Receiver: "cosmos1receiver",
+		Salt:     []byte("salt"),
+		Payload:  []byte("payload"),
+		Memo:     "memo",
+	}
+	bz, err := types.MarshalPacketData(packetData, types.Version, types.EncodingABI)
+	require.NoError(t, err)
+
+	// Solidity ABI does not encode field names, so trailing data is the ABI analogue of an unknown field.
+	bz = append(bz, make([]byte, 32)...)
+
+	_, err = types.UnmarshalPacketData(bz, types.Version, types.EncodingABI)
+	require.ErrorIs(t, err, ibcerrors.ErrInvalidType)
+}
+
 func TestMsgSendCall_ValidateBasic(t *testing.T) {
 	validSender := "cosmos1qyqszqgpqyqszqgpqyqszqgpqyqszqgpjnp7du"
 

--- a/modules/apps/27-gmp/types/packet_test.go
+++ b/modules/apps/27-gmp/types/packet_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/ibc-go/v11/modules/apps/27-gmp/types"
@@ -145,34 +146,7 @@ func TestMarshalUnmarshalPacketData(t *testing.T) {
 	}
 }
 
-func TestUnmarshalPacketData_NonCanonicalJSON(t *testing.T) {
-	testCases := []struct {
-		name string
-		bz   []byte
-	}{
-		{
-			"failure: duplicate key",
-			[]byte(`{"sender":"cosmos1sender","sender":"cosmos1attacker","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo"}`),
-		},
-		{
-			"failure: unknown field",
-			[]byte(`{"sender":"cosmos1sender","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo","unknown_field":"x"}`),
-		},
-		{
-			"failure: case-insensitive field",
-			[]byte(`{"SENDER":"cosmos1sender","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo"}`),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := types.UnmarshalPacketData(tc.bz, types.Version, types.EncodingJSON)
-			require.ErrorIs(t, err, ibcerrors.ErrInvalidType)
-		})
-	}
-}
-
-func TestUnmarshalPacketData_NonCanonicalABI(t *testing.T) {
+func TestUnmarshalPacketData_NonCanonical(t *testing.T) {
 	packetData := &types.GMPPacketData{
 		Sender:   "cosmos1sender",
 		Receiver: "cosmos1receiver",
@@ -180,14 +154,98 @@ func TestUnmarshalPacketData_NonCanonicalABI(t *testing.T) {
 		Payload:  []byte("payload"),
 		Memo:     "memo",
 	}
-	bz, err := types.MarshalPacketData(packetData, types.Version, types.EncodingABI)
-	require.NoError(t, err)
 
-	// Solidity ABI does not encode field names, so trailing data is the ABI analogue of an unknown field.
-	bz = append(bz, make([]byte, 32)...)
+	testCases := []struct {
+		name     string
+		encoding string
+		malleate func(t *testing.T) []byte
+	}{
+		{
+			"failure: JSON duplicate key",
+			types.EncodingJSON,
+			func(t *testing.T) []byte {
+				return []byte(`{"sender":"cosmos1sender","sender":"cosmos1attacker","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo"}`)
+			},
+		},
+		{
+			"failure: JSON unknown field",
+			types.EncodingJSON,
+			func(t *testing.T) []byte {
+				return []byte(`{"sender":"cosmos1sender","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo","unknown_field":"x"}`)
+			},
+		},
+		{
+			"failure: JSON case-insensitive field",
+			types.EncodingJSON,
+			func(t *testing.T) []byte {
+				return []byte(`{"SENDER":"cosmos1sender","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo"}`)
+			},
+		},
+		{
+			"failure: ABI trailing data",
+			types.EncodingABI,
+			func(t *testing.T) []byte {
+				bz, err := types.MarshalPacketData(packetData, types.Version, types.EncodingABI)
+				require.NoError(t, err)
+				bz = append(bz, make([]byte, 32)...)
 
-	_, err = types.UnmarshalPacketData(bz, types.Version, types.EncodingABI)
-	require.ErrorIs(t, err, ibcerrors.ErrInvalidType)
+				decoded, err := types.DecodeABIGMPPacketData(bz)
+				require.NoError(t, err)
+				require.Equal(t, packetData, decoded)
+
+				return bz
+			},
+		},
+		{
+			"failure: ABI non-zero padding",
+			types.EncodingABI,
+			func(t *testing.T) []byte {
+				bz, err := types.MarshalPacketData(packetData, types.Version, types.EncodingABI)
+				require.NoError(t, err)
+				bz[len(bz)-1] = 1
+
+				decoded, err := types.DecodeABIGMPPacketData(bz)
+				require.NoError(t, err)
+				require.Equal(t, packetData, decoded)
+
+				return bz
+			},
+		},
+		{
+			"failure: protobuf duplicate field",
+			types.EncodingProtobuf,
+			func(t *testing.T) []byte {
+				bz := []byte("\x0A\x0Dcosmos1sender\x0A\x0Fcosmos1attacker\x12\x0Fcosmos1receiver\x1A\x04salt\x22\x07payload\x2A\x04memo")
+				decoded := &types.GMPPacketData{}
+				require.NoError(t, proto.Unmarshal(bz, decoded))
+				require.Equal(t, "cosmos1attacker", decoded.Sender)
+				require.Equal(t, packetData.Receiver, decoded.Receiver)
+
+				return bz
+			},
+		},
+		{
+			"failure: protobuf reordered fields",
+			types.EncodingProtobuf,
+			func(t *testing.T) []byte {
+				bz := []byte("\x2A\x04memo\x22\x07payload\x1A\x04salt\x12\x0Fcosmos1receiver\x0A\x0Dcosmos1sender")
+				decoded := &types.GMPPacketData{}
+				require.NoError(t, proto.Unmarshal(bz, decoded))
+				require.Equal(t, packetData, decoded)
+
+				return bz
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bz := tc.malleate(t)
+
+			_, err := types.UnmarshalPacketData(bz, types.Version, tc.encoding)
+			require.ErrorIs(t, err, ibcerrors.ErrInvalidType)
+		})
+	}
 }
 
 func TestMsgSendCall_ValidateBasic(t *testing.T) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    Also: make sure that you are familiar with the contribution guidelines: (https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md
v    Failure to do this can result in your PR getting closed without further discussion (we receive a lot of PRs, and it takes a lot of time to respond to everyone who doesn't read this)
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Include changelog entry when appropriate (e.g. chores should be omitted from changelog).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package) if relevant.
- [ ] Updated documentation (`docs/`) if anything is changed.
- [ ] Added `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code) if relevant.
- [ ] Self-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
    <!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.
    This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
    Example commit messages:
    fix: skip emission of unpopulated memo field in ics20
    deps: updating sdk to v0.46.4
    chore: removed unused variables
    e2e: adding e2e upgrade test for ibc-go/v6
    docs: ics27 v6 documentation updates
    feat: add semantic version utilities for e2e tests
    feat(api)!: this is an api breaking feature
    fix(statemachine)!: this is a statemachine breaking fix
    -->
