### PR TITLE
chore: use bash array for package iteration

### DIFF
--- a/contrib/test_cover.sh
+++ b/contrib/test_cover.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-PKGS=$(go list ./... | grep -v '/simapp')
+mapfile -t PKGS < <(go list ./... | grep -v '/simapp')
 
-set -e
 echo "mode: atomic" > coverage.txt
-for pkg in ${PKGS[@]}; do
+for pkg in "${PKGS[@]}"; do
     go test -v -timeout 30m -race -coverprofile=profile.out -covermode=atomic -tags='ledger test_ledger_mock' "$pkg"
     if [ -f profile.out ]; then
         tail -n +2 profile.out >> coverage.txt;


### PR DESCRIPTION
Use a proper bash array for package iteration in coverage script. This avoids relying on implicit word splitting and makes ${PKGS[@]} usage semantically correct.