### PR TITLE
fix(lint): fix lint issues in rate-limiting and 27-gmp modules

### DIFF
--- a/modules/apps/27-gmp/types/ack_test.go
+++ b/modules/apps/27-gmp/types/ack_test.go
@@ -109,6 +109,7 @@ func TestUnmarshalAcknowledgement_NonCanonical(t *testing.T) {
 			"failure: JSON duplicate key",
 			types.EncodingJSON,
 			func(t *testing.T) []byte {
+				t.Helper()
 				return []byte(`{"result":"AAEC","result":"/+7d"}`)
 			},
 		},
@@ -116,6 +117,7 @@ func TestUnmarshalAcknowledgement_NonCanonical(t *testing.T) {
 			"failure: JSON unknown field",
 			types.EncodingJSON,
 			func(t *testing.T) []byte {
+				t.Helper()
 				return []byte(`{"result":"AAEC","unknown_field":"x"}`)
 			},
 		},
@@ -123,6 +125,7 @@ func TestUnmarshalAcknowledgement_NonCanonical(t *testing.T) {
 			"failure: JSON case-insensitive field",
 			types.EncodingJSON,
 			func(t *testing.T) []byte {
+				t.Helper()
 				return []byte(`{"RESULT":"AAEC"}`)
 			},
 		},
@@ -130,6 +133,7 @@ func TestUnmarshalAcknowledgement_NonCanonical(t *testing.T) {
 			"failure: ABI trailing data",
 			types.EncodingABI,
 			func(t *testing.T) []byte {
+				t.Helper()
 				bz, err := types.MarshalAcknowledgement(ack, types.Version, types.EncodingABI)
 				require.NoError(t, err)
 				bz = append(bz, make([]byte, 32)...)
@@ -145,6 +149,7 @@ func TestUnmarshalAcknowledgement_NonCanonical(t *testing.T) {
 			"failure: ABI non-zero padding",
 			types.EncodingABI,
 			func(t *testing.T) []byte {
+				t.Helper()
 				bz, err := types.MarshalAcknowledgement(ack, types.Version, types.EncodingABI)
 				require.NoError(t, err)
 				bz[len(bz)-1] = 1
@@ -160,6 +165,7 @@ func TestUnmarshalAcknowledgement_NonCanonical(t *testing.T) {
 			"failure: protobuf duplicate field",
 			types.EncodingProtobuf,
 			func(t *testing.T) []byte {
+				t.Helper()
 				bz := []byte{0x0A, 0x03, 0x00, 0x01, 0x02, 0x0A, 0x03, 0xFF, 0xEE, 0xDD}
 				decoded := &types.Acknowledgement{}
 				require.NoError(t, proto.Unmarshal(bz, decoded))
@@ -172,6 +178,7 @@ func TestUnmarshalAcknowledgement_NonCanonical(t *testing.T) {
 			"failure: protobuf explicit empty result",
 			types.EncodingProtobuf,
 			func(t *testing.T) []byte {
+				t.Helper()
 				bz := []byte{0x0A, 0x00}
 				decoded := &types.Acknowledgement{}
 				require.NoError(t, proto.Unmarshal(bz, decoded))

--- a/modules/apps/27-gmp/types/packet_test.go
+++ b/modules/apps/27-gmp/types/packet_test.go
@@ -164,6 +164,7 @@ func TestUnmarshalPacketData_NonCanonical(t *testing.T) {
 			"failure: JSON duplicate key",
 			types.EncodingJSON,
 			func(t *testing.T) []byte {
+				t.Helper()
 				return []byte(`{"sender":"cosmos1sender","sender":"cosmos1attacker","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo"}`)
 			},
 		},
@@ -171,6 +172,7 @@ func TestUnmarshalPacketData_NonCanonical(t *testing.T) {
 			"failure: JSON unknown field",
 			types.EncodingJSON,
 			func(t *testing.T) []byte {
+				t.Helper()
 				return []byte(`{"sender":"cosmos1sender","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo","unknown_field":"x"}`)
 			},
 		},
@@ -178,6 +180,7 @@ func TestUnmarshalPacketData_NonCanonical(t *testing.T) {
 			"failure: JSON case-insensitive field",
 			types.EncodingJSON,
 			func(t *testing.T) []byte {
+				t.Helper()
 				return []byte(`{"SENDER":"cosmos1sender","receiver":"cosmos1receiver","salt":"c2FsdA==","payload":"cGF5bG9hZA==","memo":"memo"}`)
 			},
 		},
@@ -185,6 +188,7 @@ func TestUnmarshalPacketData_NonCanonical(t *testing.T) {
 			"failure: ABI trailing data",
 			types.EncodingABI,
 			func(t *testing.T) []byte {
+				t.Helper()
 				bz, err := types.MarshalPacketData(packetData, types.Version, types.EncodingABI)
 				require.NoError(t, err)
 				bz = append(bz, make([]byte, 32)...)
@@ -200,6 +204,7 @@ func TestUnmarshalPacketData_NonCanonical(t *testing.T) {
 			"failure: ABI non-zero padding",
 			types.EncodingABI,
 			func(t *testing.T) []byte {
+				t.Helper()
 				bz, err := types.MarshalPacketData(packetData, types.Version, types.EncodingABI)
 				require.NoError(t, err)
 				bz[len(bz)-1] = 1
@@ -215,6 +220,7 @@ func TestUnmarshalPacketData_NonCanonical(t *testing.T) {
 			"failure: protobuf duplicate field",
 			types.EncodingProtobuf,
 			func(t *testing.T) []byte {
+				t.Helper()
 				bz := []byte("\x0A\x0Dcosmos1sender\x0A\x0Fcosmos1attacker\x12\x0Fcosmos1receiver\x1A\x04salt\x22\x07payload\x2A\x04memo")
 				decoded := &types.GMPPacketData{}
 				require.NoError(t, proto.Unmarshal(bz, decoded))
@@ -228,6 +234,7 @@ func TestUnmarshalPacketData_NonCanonical(t *testing.T) {
 			"failure: protobuf reordered fields",
 			types.EncodingProtobuf,
 			func(t *testing.T) []byte {
+				t.Helper()
 				bz := []byte("\x2A\x04memo\x22\x07payload\x1A\x04salt\x12\x0Fcosmos1receiver\x0A\x0Dcosmos1sender")
 				decoded := &types.GMPPacketData{}
 				require.NoError(t, proto.Unmarshal(bz, decoded))

--- a/modules/apps/rate-limiting/keeper/pending_send.go
+++ b/modules/apps/rate-limiting/keeper/pending_send.go
@@ -79,7 +79,7 @@ func (k *Keeper) GetAllPendingSendPackets(ctx sdk.Context) ([]string, error) {
 
 // Remove all pending sequence numbers from the store
 // This is executed when the quota resets
-func (k *Keeper) RemoveAllChannelPendingSendPackets(ctx sdk.Context, channelID string) (err error) {
+func (k *Keeper) RemoveAllChannelPendingSendPackets(ctx sdk.Context, channelID string) error {
 	adapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(adapter, types.PendingSendPacketPrefix)
 
@@ -91,12 +91,8 @@ func (k *Keeper) RemoveAllChannelPendingSendPackets(ctx sdk.Context, channelID s
 	copy(channelIDBz, channelID)
 
 	iterator := storetypes.KVStorePrefixIterator(store, channelIDBz)
-	defer func() {
-		err = errors.Join(iterator.Close())
-	}()
-
 	for ; iterator.Valid(); iterator.Next() {
 		store.Delete(iterator.Key())
 	}
-	return nil
+	return iterator.Close()
 }

--- a/modules/apps/rate-limiting/keeper/pending_send.go
+++ b/modules/apps/rate-limiting/keeper/pending_send.go
@@ -2,11 +2,11 @@ package keeper
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
+
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/store/v2/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
@@ -56,16 +56,13 @@ func (k *Keeper) CheckPacketSentDuringCurrentQuota(ctx sdk.Context, channelID st
 }
 
 // Get all pending packet sequence numbers
-func (k *Keeper) GetAllPendingSendPackets(ctx sdk.Context) (pendingPackets []string, err error) {
+func (k *Keeper) GetAllPendingSendPackets(ctx sdk.Context) ([]string, error) {
 	adapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(adapter, types.PendingSendPacketPrefix)
 
 	iterator := store.Iterator(nil, nil)
-	defer func() {
-		err = errors.Join(err, iterator.Close())
-	}()
 
-	pendingPackets = make([]string, 0)
+	pendingPackets := make([]string, 0)
 	for ; iterator.Valid(); iterator.Next() {
 		key := iterator.Key()
 
@@ -77,7 +74,7 @@ func (k *Keeper) GetAllPendingSendPackets(ctx sdk.Context) (pendingPackets []str
 		pendingPackets = append(pendingPackets, packetID)
 	}
 
-	return pendingPackets, nil
+	return pendingPackets, iterator.Close()
 }
 
 // Remove all pending sequence numbers from the store

--- a/modules/apps/rate-limiting/keeper/pending_send_test.go
+++ b/modules/apps/rate-limiting/keeper/pending_send_test.go
@@ -30,7 +30,8 @@ func (s *KeeperTestSuite) TestPendingSendPacketPrefix() {
 
 	// Remove 0 sequence numbers and all sequence numbers from channel-0 + 07-tendermint-1005
 	for _, channelID := range channels {
-		s.chainA.GetSimApp().RateLimitKeeper.RemovePendingSendPacket(s.chainA.GetContext(), channelID, 0)
+		err = s.chainA.GetSimApp().RateLimitKeeper.RemovePendingSendPacket(s.chainA.GetContext(), channelID, 0)
+		s.Require().NoError(err, "unexpected error removing pending send packet - channel %s, sequence 0", channelID)
 	}
 	err = s.chainA.GetSimApp().RateLimitKeeper.RemoveAllChannelPendingSendPackets(s.chainA.GetContext(), "channel-1")
 	s.Require().NoError(err, "unexpected error removing all pending send packets - channel %s", "channel-1")

--- a/modules/apps/rate-limiting/migrations/v2/migrate.go
+++ b/modules/apps/rate-limiting/migrations/v2/migrate.go
@@ -131,7 +131,7 @@ func validateMigratedKey(newKey []byte, oldKey [oldKeyLen]byte) error {
 	// ensure after the oldPendingSendPacketChannelLength, we have 48 bytes of 0's
 	padding := newKey[oldPendingSendPacketChannelLength:newPendingSendPacketChannelLength]
 	if !bytes.Equal(padding, make([]byte, len(padding))) {
-		return fmt.Errorf("expected all zero values after channel identifier in migrated key")
+		return errors.New("expected all zero values after channel identifier in migrated key")
 	}
 
 	// validate sequence number in the newKey.
@@ -143,7 +143,7 @@ func validateMigratedKey(newKey []byte, oldKey [oldKeyLen]byte) error {
 
 	// ensure we have not modified the existing value
 	if !bytes.Equal(sequenceRaw, oldKey[oldPendingSendPacketChannelLength:]) {
-		return fmt.Errorf("mismatch in sequence number bytes between migrated key and existing key")
+		return errors.New("mismatch in sequence number bytes between migrated key and existing key")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Fixes pre-existing lint issues surfaced by the golangci-lint-action v9.2.1 upgrade (PR #8962). The linter action bump fixed `only-new-issues` comparison, exposing these issues in recently-added modules.

- `rate-limiting/keeper/pending_send.go`: fix gci import ordering (separate `cosmossdk.io` group from `cosmos-sdk`); remove named returns from `GetAllPendingSendPackets`, return `iterator.Close()` error directly
- `rate-limiting/keeper/pending_send_test.go`: handle error return from `RemovePendingSendPacket` (errcheck)
- `rate-limiting/migrations/v2/migrate.go`: replace `fmt.Errorf` with `errors.New` for non-formatted error strings (revive)
- `27-gmp/types/ack_test.go`, `packet_test.go`: add `t.Helper()` to all `func(t *testing.T) []byte` closures (thelper)