### PR TITLE
fix(04-channel): reject packets with an unreachable timeout height revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### State Machine Breaking
 
 * (apps/rate-limiting) [\#8937](https://github.com/cosmos/ibc-go/pull/8937) Increase pending send packet channel length key size from 16 to 64
+* (core/04-channel) [\#8983](https://github.com/cosmos/ibc-go/pull/8983) Reject in `SendPacket` a timeout height whose revision number exceeds the counterparty client's current revision number (an unreachable timeout). See [\#8653](https://github.com/cosmos/ibc-go/issues/8653).
 
 ### Improvements
 

--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -65,6 +65,23 @@ func (k *Keeper) SendPacket(
 		return 0, errorsmod.Wrapf(clienttypes.ErrInvalidHeight, "cannot send packet using client (%s) with zero height", connectionEnd.ClientId)
 	}
 
+	// A timeout height whose revision number is greater than the counterparty
+	// client's current revision number can never be reached (revision numbers
+	// only increase through a coordinated upgrade). Combined with a zero timeout
+	// timestamp this produces a packet that never times out. Reject it at send.
+	// The check is scoped to clients that use revision-numbered heights
+	// (revision number > 0, i.e. Tendermint); clients such as solomachine report
+	// revision 0 and legitimately use non-matching timeout-height revisions.
+	// See https://github.com/cosmos/ibc-go/issues/8653.
+	if !timeoutHeight.IsZero() && latestHeight.RevisionNumber > 0 &&
+		timeoutHeight.RevisionNumber > latestHeight.RevisionNumber {
+		return 0, errorsmod.Wrapf(
+			clienttypes.ErrInvalidHeight,
+			"packet timeout height revision number (%d) cannot exceed the counterparty client's current revision number (%d)",
+			timeoutHeight.RevisionNumber, latestHeight.RevisionNumber,
+		)
+	}
+
 	latestTimestamp, err := k.clientKeeper.GetClientTimestampAtHeight(ctx, connectionEnd.ClientId, latestHeight)
 	if err != nil {
 		return 0, err

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -151,6 +151,18 @@ func (s *KeeperTestSuite) TestSendPacket() {
 			timeoutHeight, ok = path.EndpointA.GetClientLatestHeight().(clienttypes.Height)
 			s.Require().True(ok)
 		}, types.ErrTimeoutElapsed},
+		{"timeout height has invalid revision number", func() {
+			path.Setup()
+			sourceChannel = path.EndpointA.ChannelID
+
+			// a timeout height on a revision number higher than the counterparty
+			// client's current revision can never be reached, which combined with a
+			// zero timeout timestamp yields a packet that never times out. it must
+			// be rejected at send. see https://github.com/cosmos/ibc-go/issues/8653.
+			latestHeight, ok := path.EndpointA.GetClientLatestHeight().(clienttypes.Height)
+			s.Require().True(ok)
+			timeoutHeight = clienttypes.NewHeight(latestHeight.RevisionNumber+1, 100)
+		}, clienttypes.ErrInvalidHeight},
 		{"timeout timestamp passed", func() {
 			path.Setup()
 			sourceChannel = path.EndpointA.ChannelID


### PR DESCRIPTION
## Description

Addresses #8653.

When a packet is sent with a timeout height whose **revision number is greater than the counterparty client's current revision number**, the height can never be reached — revision numbers only increase through a coordinated chain upgrade. `Height.Compare` orders by revision number first, so `heightElapsed` never returns true for such a height. Combined with a zero timeout timestamp (`--packet-timeout-timestamp 0`), this yields a packet that **never times out** (the reporter demonstrated this on a live chain via the CLI).

This PR rejects such timeouts in `SendPacket`, before the packet commitment is written:

```go
if !timeoutHeight.IsZero() && latestHeight.RevisionNumber > 0 &&
    timeoutHeight.RevisionNumber > latestHeight.RevisionNumber {
    return 0, errorsmod.Wrapf(clienttypes.ErrInvalidHeight,
        "packet timeout height revision number (%d) cannot exceed the counterparty client's current revision number (%d)",
        timeoutHeight.RevisionNumber, latestHeight.RevisionNumber)
}
```

### Design notes (worth a reviewer's eye)

- **Solomachine is intentionally exempt.** Solomachine clients report `RevisionNumber == 0` and legitimately send with timeout heights on a different revision. An unconditional revision-equality check breaks the existing `TestSendPacket` "success with solomachine" cases, so the check is scoped to `latestHeight.RevisionNumber > 0` (revision-numbered / Tendermint clients).
- **Only `>` is rejected, not `!=`.** A *lower* timeout-height revision is already handled by the existing `timeout.Elapsed` check (it returns `ErrTimeoutElapsed`); this PR only adds the unreachable *higher*-revision case, keeping the change minimal.
- **Known limitation:** a Tendermint chain whose counterparty revision number is `0` (a chain-id without a revision suffix) is not covered by the `> 0` guard. Fixing that generally, or hardening `heightElapsed` directly (issue's "Approach 2"), is a larger change with broader blast radius on consensus-critical timeout evaluation; happy to take it that direction if maintainers prefer.
- This is **state-machine-breaking** (a `SendPacket` that previously succeeded now errors), so it should target a minor/major release, not a patch.

## Testing

- Added `TestSendPacket` case "timeout height has invalid revision number".
- `go test ./modules/core/04-channel/keeper/` passes (full package), `go vet` clean.

## Author Checklist

- [x] Reviewed the [contributing guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/project-structure.md)
- [x] Added tests
- [x] Added a changelog entry
- [x] Targeted the correct branch (`main`)
