### PR TITLE
fix: prevent delay period arithmetic overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (light-clients/07-tendermint) Prevent delay period overflows when verifying membership proofs.
 * (apps/rate-limiting) [\#8767](https://github.com/cosmos/ibc-go/pull/8767) Fix string conflict in rate-limiting prefix iterator
 
 ### Testing API

--- a/modules/core/03-connection/keeper/delay_overflow_test.go
+++ b/modules/core/03-connection/keeper/delay_overflow_test.go
@@ -1,0 +1,94 @@
+package keeper_test
+
+import (
+	connectiontypes "github.com/cosmos/ibc-go/v11/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v11/modules/core/04-channel/types"
+	commitmenttypes "github.com/cosmos/ibc-go/v11/modules/core/23-commitment/types"
+	host "github.com/cosmos/ibc-go/v11/modules/core/24-host"
+	ibctm "github.com/cosmos/ibc-go/v11/modules/light-clients/07-tendermint"
+	ibctesting "github.com/cosmos/ibc-go/v11/testing"
+)
+
+func (s *KeeperTestSuite) TestVerifyPacketCommitmentDelayPeriodOverflowFailsClosed() {
+	s.SetupTest()
+
+	path := ibctesting.NewPath(s.chainA, s.chainB)
+	path.Setup()
+
+	sequence, err := path.EndpointA.SendPacket(defaultTimeoutHeight, 0, ibctesting.MockPacketData)
+	s.Require().NoError(err)
+
+	packet := channeltypes.NewPacket(
+		ibctesting.MockPacketData,
+		sequence,
+		path.EndpointA.ChannelConfig.PortID,
+		path.EndpointA.ChannelID,
+		path.EndpointB.ChannelConfig.PortID,
+		path.EndpointB.ChannelID,
+		defaultTimeoutHeight,
+		0,
+	)
+
+	connection := path.EndpointB.GetConnection()
+	connection.DelayPeriod = ^uint64(0)
+
+	// Make the block-delay side evaluate to one block so this isolates the time-delay overflow.
+	s.chainB.App.GetIBCKeeper().ConnectionKeeper.SetParams(s.chainB.GetContext(), connectiontypes.NewParams(^uint64(0)))
+
+	commitmentKey := host.PacketCommitmentKey(packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+	proof, proofHeight := s.chainA.QueryProof(commitmentKey)
+	commitment := channeltypes.CommitPacket(packet)
+
+	err = s.chainB.App.GetIBCKeeper().ConnectionKeeper.VerifyPacketCommitment(
+		s.chainB.GetContext(),
+		connection,
+		proofHeight,
+		proof,
+		packet.GetSourcePort(),
+		packet.GetSourceChannel(),
+		packet.GetSequence(),
+		commitment,
+	)
+	s.Require().ErrorIs(err, ibctm.ErrDelayPeriodNotPassed)
+}
+
+func (s *KeeperTestSuite) TestVerifyMembershipDelayBlockPeriodOverflowFailsClosed() {
+	s.SetupTest()
+
+	path := ibctesting.NewPath(s.chainA, s.chainB)
+	path.Setup()
+
+	sequence, err := path.EndpointA.SendPacket(defaultTimeoutHeight, 0, ibctesting.MockPacketData)
+	s.Require().NoError(err)
+
+	packet := channeltypes.NewPacket(
+		ibctesting.MockPacketData,
+		sequence,
+		path.EndpointA.ChannelConfig.PortID,
+		path.EndpointA.ChannelID,
+		path.EndpointB.ChannelConfig.PortID,
+		path.EndpointB.ChannelID,
+		defaultTimeoutHeight,
+		0,
+	)
+
+	connection := path.EndpointB.GetConnection()
+	commitmentKey := host.PacketCommitmentKey(packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+	proof, proofHeight := s.chainA.QueryProof(commitmentKey)
+	commitment := channeltypes.CommitPacket(packet)
+	merklePath := commitmenttypes.NewMerklePath(commitmentKey)
+	merklePath, err = commitmenttypes.ApplyPrefix(connection.Counterparty.Prefix, merklePath)
+	s.Require().NoError(err)
+
+	err = s.chainB.App.GetIBCKeeper().ClientKeeper.VerifyMembership(
+		s.chainB.GetContext(),
+		connection.ClientId,
+		proofHeight,
+		0,
+		^uint64(0),
+		proof,
+		merklePath,
+		commitment,
+	)
+	s.Require().ErrorIs(err, ibctm.ErrDelayPeriodNotPassed)
+}

--- a/modules/core/03-connection/keeper/verify.go
+++ b/modules/core/03-connection/keeper/verify.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"math"
-
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -220,8 +218,13 @@ func (k *Keeper) getBlockDelay(ctx sdk.Context, connection types.ConnectionEnd) 
 	if expectedTimePerBlock == 0 {
 		return 0
 	}
-	// calculate minimum block delay by dividing time delay period
-	// by the expected time per block. Round up the block delay.
+	// Calculate the minimum block delay by dividing the time delay period
+	// by the expected time per block and rounding up.
 	timeDelay := connection.DelayPeriod
-	return uint64(math.Ceil(float64(timeDelay) / float64(expectedTimePerBlock)))
+	blockDelay := timeDelay / expectedTimePerBlock
+	if timeDelay%expectedTimePerBlock != 0 {
+		blockDelay++
+	}
+
+	return blockDelay
 }

--- a/modules/light-clients/07-tendermint/client_state.go
+++ b/modules/light-clients/07-tendermint/client_state.go
@@ -1,6 +1,7 @@
 package tendermint
 
 import (
+	"math/bits"
 	"strings"
 	"time"
 
@@ -296,7 +297,11 @@ func verifyDelayPeriodPassed(ctx sdk.Context, store storetypes.KVStore, proofHei
 		}
 
 		currentTimestamp := uint64(ctx.BlockTime().UnixNano())
-		validTime := processedTime + delayTimePeriod
+		validTime, carry := bits.Add64(processedTime, delayTimePeriod, 0)
+		if carry != 0 {
+			return errorsmod.Wrapf(ErrDelayPeriodNotPassed, "delay time period overflows: processed time: %d, delay time period: %d",
+				processedTime, delayTimePeriod)
+		}
 
 		// NOTE: delay time period is inclusive, so if currentTimestamp is validTime, then we return no error
 		if currentTimestamp < validTime {
@@ -313,7 +318,12 @@ func verifyDelayPeriodPassed(ctx sdk.Context, store storetypes.KVStore, proofHei
 		}
 
 		currentHeight := clienttypes.GetSelfHeight(ctx)
-		validHeight := clienttypes.NewHeight(processedHeight.GetRevisionNumber(), processedHeight.GetRevisionHeight()+delayBlockPeriod)
+		validRevisionHeight, carry := bits.Add64(processedHeight.GetRevisionHeight(), delayBlockPeriod, 0)
+		if carry != 0 {
+			return errorsmod.Wrapf(ErrDelayPeriodNotPassed, "delay block period overflows: processed height: %s, delay block period: %d",
+				processedHeight, delayBlockPeriod)
+		}
+		validHeight := clienttypes.NewHeight(processedHeight.GetRevisionNumber(), validRevisionHeight)
 
 		// NOTE: delay block period is inclusive, so if currentHeight is validHeight, then we return no error
 		if currentHeight.LT(validHeight) {


### PR DESCRIPTION
## Description

This PR hardens packet delay-period verification against unchecked `uint64` arithmetic overflow.

The Tendermint light client delay checks add the requested time/block delay to the processed time/height for the proof height. If either addition overflows, the wrapped value can be lower than the current time/height and the delay check may incorrectly pass. This PR makes those additions fail closed with `ErrDelayPeriodNotPassed` when overflow is detected.

It also changes connection block-delay calculation from `float64`/`math.Ceil` to integer ceil division, avoiding precision loss for large `uint64` delay values.

Critical files:

- `modules/light-clients/07-tendermint/client_state.go`
- `modules/core/03-connection/keeper/verify.go`
- `modules/core/03-connection/keeper/delay_overflow_test.go`

closes: N/A — small hardening bug fix, no existing issue.

## Testing

```bash
go test ./modules/core/03-connection/keeper ./modules/light-clients/07-tendermint -count=1
```

## Commit message

```text
fix: prevent delay period arithmetic overflow
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work. N/A: small defensive bug fix; no issue opened.
- [x] Include changelog entry when appropriate (e.g. chores should be omitted from changelog).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package) if relevant.
- [ ] Updated documentation (`docs/`) if anything is changed. N/A: no user-facing docs changed.
- [ ] Added `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code) if relevant. N/A: no exported API added.
- [x] Self-reviewed `Files changed` in the GitHub PR explorer.
- [x] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
