### PR TITLE
imp(statemachine)!: use unambiguous rate-limit keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### State Machine Breaking
 
 * (apps/rate-limiting) [\#8937](https://github.com/cosmos/ibc-go/pull/8937) imp(ratelimit): use collections for pending markers.
-* (apps/rate-limiting) [\#9020](https://github.com/cosmos/ibc-go/pull/9020) Re-key rate-limit and address-whitelist entries with unambiguous length-prefixed keys. Includes the v2-to-v3 store migration for existing v11.2.0 and legacy cosmos/ibc-apps state.
+* (apps/rate-limiting) [\#9020](https://github.com/cosmos/ibc-go/pull/9020) Re-key rate-limit and address-whitelist entries with unambiguous length-prefixed keys. Includes the v2-to-v3 store migration for existing v11.2.0 and legacy cosmos/ibc-apps state, and bumps the module consensus version to 3.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### State Machine Breaking
 
 * (apps/rate-limiting) [\#8937](https://github.com/cosmos/ibc-go/pull/8937) imp(ratelimit): use collections for pending markers.
+* (apps/rate-limiting) [\#XXXX](https://github.com/cosmos/ibc-go/pull/XXXX) Re-key rate limits to a channel-first, length-prefixed layout (`uvarint(len(channelOrClientID)) || channelOrClientID || denom`) so distinct (denom, channel) pairs cannot collide (the channel-first layout also enables future range scans per channel or client, not yet used by queries), and re-key address whitelist entries to `uvarint(len(sender)) || sender || receiver` so distinct (sender, receiver) pairs cannot collide. Applies to all existing stores — v11.2.0 chains and legacy cosmos/ibc-apps chains alike — via a v3 store migration and a module consensus version bump to 3.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### State Machine Breaking
 
 * (apps/rate-limiting) [\#8937](https://github.com/cosmos/ibc-go/pull/8937) imp(ratelimit): use collections for pending markers.
-* (apps/rate-limiting) [\#XXXX](https://github.com/cosmos/ibc-go/pull/XXXX) Re-key rate-limit and address-whitelist entries with unambiguous length-prefixed keys. Includes the v2-to-v3 store migration for existing v11.2.0 and legacy cosmos/ibc-apps state.
+* (apps/rate-limiting) [\#9020](https://github.com/cosmos/ibc-go/pull/9020) Re-key rate-limit and address-whitelist entries with unambiguous length-prefixed keys. Includes the v2-to-v3 store migration for existing v11.2.0 and legacy cosmos/ibc-apps state.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### State Machine Breaking
 
 * (apps/rate-limiting) [\#8937](https://github.com/cosmos/ibc-go/pull/8937) imp(ratelimit): use collections for pending markers.
-* (apps/rate-limiting) [\#XXXX](https://github.com/cosmos/ibc-go/pull/XXXX) Re-key rate limits to a channel-first, length-prefixed layout (`uvarint(len(channelOrClientID)) || channelOrClientID || denom`) so distinct (denom, channel) pairs cannot collide (the channel-first layout also enables future range scans per channel or client, not yet used by queries), and re-key address whitelist entries to `uvarint(len(sender)) || sender || receiver` so distinct (sender, receiver) pairs cannot collide. Applies to all existing stores — v11.2.0 chains and legacy cosmos/ibc-apps chains alike — via a v3 store migration and a module consensus version bump to 3.
+* (apps/rate-limiting) [\#XXXX](https://github.com/cosmos/ibc-go/pull/XXXX) Re-key rate-limit and address-whitelist entries with unambiguous length-prefixed keys. Includes the v2-to-v3 store migration for existing v11.2.0 and legacy cosmos/ibc-apps state.
 
 ### Improvements
 

--- a/modules/apps/rate-limiting/keeper/migrator.go
+++ b/modules/apps/rate-limiting/keeper/migrator.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/migrations/v2"
+	"github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/migrations/v3"
 )
 
 // Migrator is a struct for handling in-place store migrations.
@@ -22,4 +23,11 @@ func NewMigrator(k *Keeper) Migrator {
 // reset because the legacy markers do not include denoms.
 func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 	return v2.Migrate(ctx, m.keeper.storeService)
+}
+
+// Migrate2to3 re-keys rate limits to the channel-first, length-prefixed key
+// layout so that rate limits are unambiguous and range scannable per channel or
+// client.
+func (m Migrator) Migrate2to3(ctx sdk.Context) error {
+	return v3.Migrate(ctx, m.keeper.storeService, m.keeper.cdc)
 }

--- a/modules/apps/rate-limiting/keeper/migrator_test.go
+++ b/modules/apps/rate-limiting/keeper/migrator_test.go
@@ -77,9 +77,10 @@ func (s *KeeperTestSuite) TestMigrate1to2() {
 	s.Require().True(found, "collections pending receive packet should be preserved")
 }
 
-// TestMigrate2to3 pins the Migrator wiring: Migrate2to3 must reach the v3
-// migration through the keeper's own store service and codec, and the module's
-// consensus version must match the highest registered migration target.
+// TestMigrate2to3 pins the Migrator wiring: a rate limit stored under the
+// legacy key layout must be readable through the keeper after Migrate2to3, and
+// the module's consensus version must match the highest registered migration
+// target.
 func (s *KeeperTestSuite) TestMigrate2to3() {
 	s.SetupTest()
 

--- a/modules/apps/rate-limiting/keeper/migrator_test.go
+++ b/modules/apps/rate-limiting/keeper/migrator_test.go
@@ -3,10 +3,13 @@ package keeper_test
 import (
 	"encoding/binary"
 
+	sdkmath "cosmossdk.io/math"
+
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/store/v2/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	ratelimiting "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting"
 	"github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/keeper"
 	ratelimittypes "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
 )
@@ -74,4 +77,44 @@ func (s *KeeperTestSuite) TestMigrate1to2() {
 	found, err = rlKeeper.CheckPacketReceivedDuringCurrentQuota(ctx, "channel-3", 1, "denom-a")
 	s.Require().NoError(err)
 	s.Require().True(found, "collections pending receive packet should be preserved")
+}
+
+// TestMigrate2to3 pins the Migrator wiring: Migrate2to3 must reach the v3
+// migration through the keeper's own store service and codec, and the module's
+// consensus version must match the highest registered migration target.
+func (s *KeeperTestSuite) TestMigrate2to3() {
+	s.SetupTest()
+
+	ctx := s.chainA.GetContext()
+	rlKeeper := s.chainA.GetSimApp().RateLimitKeeper
+	migrator := keeper.NewMigrator(rlKeeper)
+
+	rateLimit := ratelimittypes.RateLimit{
+		Path: &ratelimittypes.Path{Denom: "uatom", ChannelOrClientId: "channel-1"},
+		Quota: &ratelimittypes.Quota{
+			MaxPercentSend: sdkmath.NewInt(10),
+			MaxPercentRecv: sdkmath.NewInt(20),
+			DurationHours:  24,
+		},
+		Flow: &ratelimittypes.Flow{
+			Inflow:       sdkmath.NewInt(1),
+			Outflow:      sdkmath.NewInt(2),
+			ChannelValue: sdkmath.NewInt(100),
+		},
+	}
+
+	storeService := runtime.NewKVStoreService(s.chainA.GetSimApp().GetKey(ratelimittypes.StoreKey))
+	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(adapter, ratelimittypes.RateLimitKeyPrefix)
+
+	legacyKey := append([]byte(rateLimit.Path.Denom), rateLimit.Path.ChannelOrClientId...)
+	store.Set(legacyKey, s.chainA.GetSimApp().AppCodec().MustMarshal(&rateLimit))
+
+	s.Require().NoError(migrator.Migrate2to3(ctx))
+
+	migrated, found := rlKeeper.GetRateLimit(ctx, "uatom", "channel-1")
+	s.Require().True(found, "rate limit not readable through the keeper after Migrate2to3")
+	s.Require().Equal(rateLimit, migrated)
+
+	s.Require().Equal(uint64(3), ratelimiting.AppModule{}.ConsensusVersion())
 }

--- a/modules/apps/rate-limiting/keeper/migrator_test.go
+++ b/modules/apps/rate-limiting/keeper/migrator_test.go
@@ -3,8 +3,6 @@ package keeper_test
 import (
 	"encoding/binary"
 
-	sdkmath "cosmossdk.io/math"
-
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/store/v2/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -91,16 +89,6 @@ func (s *KeeperTestSuite) TestMigrate2to3() {
 
 	rateLimit := ratelimittypes.RateLimit{
 		Path: &ratelimittypes.Path{Denom: "uatom", ChannelOrClientId: "channel-1"},
-		Quota: &ratelimittypes.Quota{
-			MaxPercentSend: sdkmath.NewInt(10),
-			MaxPercentRecv: sdkmath.NewInt(20),
-			DurationHours:  24,
-		},
-		Flow: &ratelimittypes.Flow{
-			Inflow:       sdkmath.NewInt(1),
-			Outflow:      sdkmath.NewInt(2),
-			ChannelValue: sdkmath.NewInt(100),
-		},
 	}
 
 	storeService := runtime.NewKVStoreService(s.chainA.GetSimApp().GetKey(ratelimittypes.StoreKey))

--- a/modules/apps/rate-limiting/keeper/rate_limit.go
+++ b/modules/apps/rate-limiting/keeper/rate_limit.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	sdkmath "cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -68,7 +70,7 @@ func (k *Keeper) GetAllRateLimits(ctx sdk.Context) []types.RateLimit {
 		rateLimit := types.RateLimit{}
 		if err := k.cdc.Unmarshal(iterator.Value(), &rateLimit); err != nil {
 			// Log the error and skip this entry if unmarshalling fails
-			k.Logger(ctx).Error("failed to unmarshal rate limit", "key", string(iterator.Key()), "error", err)
+			k.Logger(ctx).Error("failed to unmarshal rate limit", "key", fmt.Sprintf("%X", iterator.Key()), "error", err)
 			continue
 		}
 		allRateLimits = append(allRateLimits, rateLimit)

--- a/modules/apps/rate-limiting/keeper/whitelist.go
+++ b/modules/apps/rate-limiting/keeper/whitelist.go
@@ -32,10 +32,7 @@ func (k *Keeper) IsAddressPairWhitelisted(ctx sdk.Context, sender, receiver stri
 	store := prefix.NewStore(adapter, types.AddressWhitelistKeyPrefix)
 
 	key := types.AddressWhitelistKey(sender, receiver)
-	value := store.Get(key)
-	found := len(value) != 0
-
-	return found
+	return store.Has(key)
 }
 
 // Get all the whitelisted addresses

--- a/modules/apps/rate-limiting/keeper/whitelist_test.go
+++ b/modules/apps/rate-limiting/keeper/whitelist_test.go
@@ -52,3 +52,11 @@ func (s *KeeperTestSuite) TestAddressWhitelist() {
 			addressPair.Sender, addressPair.Receiver)
 	}
 }
+
+func (s *KeeperTestSuite) TestEmptyAddressWhitelistPair() {
+	keeper := s.chainA.GetSimApp().RateLimitKeeper
+	ctx := s.chainA.GetContext()
+
+	keeper.SetWhitelistedAddressPair(ctx, types.WhitelistedAddressPair{})
+	s.Require().True(keeper.IsAddressPairWhitelisted(ctx, "", ""))
+}

--- a/modules/apps/rate-limiting/migrations/v3/migrate.go
+++ b/modules/apps/rate-limiting/migrations/v3/migrate.go
@@ -1,0 +1,98 @@
+package v3
+
+import (
+	"errors"
+	"fmt"
+
+	corestore "cosmossdk.io/core/store"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/store/v2/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
+)
+
+// Migrate re-keys every rate limit from the legacy denom||channelOrClientID
+// layout to the channel-first, length-prefixed layout of
+// types.RateLimitItemKey, and every whitelisted address pair from the legacy
+// sender||receiver layout to the length-prefixed layout of
+// types.AddressWhitelistKey.
+//
+// The legacy keys have no separator and are therefore ambiguous, so the new
+// keys are derived from the stored values rather than parsed out of the old
+// keys.
+func Migrate(ctx sdk.Context, storeService corestore.KVStoreService, cdc codec.BinaryCodec) error {
+	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+
+	err := rekey(prefix.NewStore(adapter, types.RateLimitKeyPrefix), func(value []byte) ([]byte, error) {
+		var rateLimit types.RateLimit
+		if err := cdc.Unmarshal(value, &rateLimit); err != nil {
+			return nil, fmt.Errorf("unmarshalling rate limit: %w", err)
+		}
+		if rateLimit.Path == nil {
+			return nil, errors.New("rate limit has no path")
+		}
+		return types.RateLimitItemKey(rateLimit.Path.Denom, rateLimit.Path.ChannelOrClientId), nil
+	})
+	if err != nil {
+		return fmt.Errorf("re-keying rate limits: %w", err)
+	}
+
+	err = rekey(prefix.NewStore(adapter, types.AddressWhitelistKeyPrefix), func(value []byte) ([]byte, error) {
+		var pair types.WhitelistedAddressPair
+		if err := cdc.Unmarshal(value, &pair); err != nil {
+			return nil, fmt.Errorf("unmarshalling whitelisted address pair: %w", err)
+		}
+		return types.AddressWhitelistKey(pair.Sender, pair.Receiver), nil
+	})
+	if err != nil {
+		return fmt.Errorf("re-keying address whitelist: %w", err)
+	}
+
+	return nil
+}
+
+// rekey rewrites every entry of store under newKey(value). All old keys are
+// deleted before any new key is written, since a new key may equal a
+// not-yet-migrated old key.
+func rekey(store prefix.Store, newKey func(value []byte) ([]byte, error)) error {
+	type entry struct {
+		oldKey, newKey, value []byte
+	}
+
+	iterator := store.Iterator(nil, nil)
+	entries := make([]entry, 0)
+	for ; iterator.Valid(); iterator.Next() {
+		// The buffers behind Key()/Value() may be reused by Next() or released
+		// by Close(), so copy up front: the copies are what is retained in
+		// entries and what the error path below formats after closing the
+		// iterator. The copies must stay non-nil even when zero-length
+		// (append to []byte{}, not to a nil slice): store.Set panics on a nil
+		// value, and a zero-value WhitelistedAddressPair marshals to zero
+		// bytes.
+		oldKey := append([]byte{}, iterator.Key()...)
+		value := append([]byte{}, iterator.Value()...)
+
+		key, err := newKey(value)
+		if err != nil {
+			iterator.Close()
+			return fmt.Errorf("entry at key %X: %w", oldKey, err)
+		}
+
+		entries = append(entries, entry{oldKey: oldKey, newKey: key, value: value})
+	}
+	if err := iterator.Close(); err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		store.Delete(e.oldKey)
+	}
+	for _, e := range entries {
+		store.Set(e.newKey, e.value)
+	}
+
+	return nil
+}

--- a/modules/apps/rate-limiting/migrations/v3/migrate.go
+++ b/modules/apps/rate-limiting/migrations/v3/migrate.go
@@ -14,15 +14,8 @@ import (
 	"github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
 )
 
-// Migrate re-keys every rate limit from the legacy denom||channelOrClientID
-// layout to the channel-first, length-prefixed layout of
-// types.RateLimitItemKey, and every whitelisted address pair from the legacy
-// sender||receiver layout to the length-prefixed layout of
-// types.AddressWhitelistKey.
-//
-// The legacy keys have no separator and are therefore ambiguous, so the new
-// keys are derived from the stored values rather than parsed out of the old
-// keys.
+// Migrate re-keys rate limits and whitelist entries. Legacy keys are ambiguous,
+// so new keys are derived from stored values.
 func Migrate(ctx sdk.Context, storeService corestore.KVStoreService, cdc codec.BinaryCodec) error {
 	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
 
@@ -65,13 +58,7 @@ func rekey(store prefix.Store, newKey func(value []byte) ([]byte, error)) error 
 	iterator := store.Iterator(nil, nil)
 	entries := make([]entry, 0)
 	for ; iterator.Valid(); iterator.Next() {
-		// The buffers behind Key()/Value() may be reused by Next() or released
-		// by Close(), so copy up front: the copies are what is retained in
-		// entries and what the error path below formats after closing the
-		// iterator. The copies must stay non-nil even when zero-length
-		// (append to []byte{}, not to a nil slice): store.Set panics on a nil
-		// value, and a zero-value WhitelistedAddressPair marshals to zero
-		// bytes.
+		// Copy iterator-owned buffers; keep empty values non-nil because Store.Set rejects nil.
 		oldKey := append([]byte{}, iterator.Key()...)
 		value := append([]byte{}, iterator.Value()...)
 

--- a/modules/apps/rate-limiting/migrations/v3/migrate_test.go
+++ b/modules/apps/rate-limiting/migrations/v3/migrate_test.go
@@ -69,31 +69,14 @@ func TestMigrateReKeysRateLimits(t *testing.T) {
 	for _, rl := range rateLimits {
 		store.Set(legacyRateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId), cdc.MustMarshal(&rl))
 	}
-	require.Len(t, collectKeys(t, store), len(rateLimits))
 
 	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
 
-	// Every entry is readable under its new key with its value intact, and no
-	// legacy key survives.
 	for _, rl := range rateLimits {
-		bz := store.Get(types.RateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId))
-		require.NotEmpty(t, bz, "rate limit %s/%s missing after migration", rl.Path.Denom, rl.Path.ChannelOrClientId)
-
-		var migrated types.RateLimit
-		require.NoError(t, cdc.Unmarshal(bz, &migrated))
-		require.Equal(t, rl, migrated)
-
+		require.Equal(t, cdc.MustMarshal(&rl), store.Get(types.RateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId)))
 		require.Empty(t, store.Get(legacyRateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId)),
 			"legacy key for %s/%s still set", rl.Path.Denom, rl.Path.ChannelOrClientId)
 	}
-	require.Len(t, collectKeys(t, store), len(rateLimits))
-
-	// Migrating an already-migrated store is a byte-for-byte no-op: the new
-	// keys are derived from stored values alone, so a second run maps every
-	// entry to the key it is already under.
-	before := snapshot(t, store)
-	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
-	require.Equal(t, before, snapshot(t, store))
 }
 
 // TestMigrateKeyCollision covers the case the two-pass delete-then-set design
@@ -118,7 +101,8 @@ func TestMigrateKeyCollision(t *testing.T) {
 	store := prefix.NewStore(adapter, types.RateLimitKeyPrefix)
 
 	colliding, victim := rateLimit("\x01gold", "channel-1"), rateLimit("\x09channel-1", "\x01gold")
-	require.Equal(t,
+	require.Equal(
+		t,
 		types.RateLimitItemKey(colliding.Path.Denom, colliding.Path.ChannelOrClientId),
 		legacyRateLimitItemKey(victim.Path.Denom, victim.Path.ChannelOrClientId),
 		"fixture does not reproduce the newKey(A) == legacyKey(B) collision",
@@ -128,20 +112,12 @@ func TestMigrateKeyCollision(t *testing.T) {
 	for _, rl := range rateLimits {
 		store.Set(legacyRateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId), cdc.MustMarshal(&rl))
 	}
-	require.Len(t, collectKeys(t, store), len(rateLimits))
 
 	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
 
-	// Every entry survives under its own new key with its own value.
 	for _, rl := range rateLimits {
-		bz := store.Get(types.RateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId))
-		require.NotEmpty(t, bz, "rate limit %q/%q lost to the key collision", rl.Path.Denom, rl.Path.ChannelOrClientId)
-
-		var migrated types.RateLimit
-		require.NoError(t, cdc.Unmarshal(bz, &migrated))
-		require.Equal(t, rl, migrated)
+		require.Equal(t, cdc.MustMarshal(&rl), store.Get(types.RateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId)))
 	}
-	require.Len(t, collectKeys(t, store), len(rateLimits))
 }
 
 func TestMigrateReKeysWhitelist(t *testing.T) {
@@ -157,74 +133,14 @@ func TestMigrateReKeysWhitelist(t *testing.T) {
 	for _, pair := range pairs {
 		store.Set(legacyAddressWhitelistKey(pair.Sender, pair.Receiver), cdc.MustMarshal(&pair))
 	}
-	require.Len(t, collectKeys(t, store), len(pairs))
 
 	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
 
-	// Every pair is readable under its new key with its value intact, and no
-	// legacy key survives.
 	for _, pair := range pairs {
-		bz := store.Get(types.AddressWhitelistKey(pair.Sender, pair.Receiver))
-		require.NotEmpty(t, bz, "whitelist pair %s/%s missing after migration", pair.Sender, pair.Receiver)
-
-		var migrated types.WhitelistedAddressPair
-		require.NoError(t, cdc.Unmarshal(bz, &migrated))
-		require.Equal(t, pair, migrated)
-
+		require.Equal(t, cdc.MustMarshal(&pair), store.Get(types.AddressWhitelistKey(pair.Sender, pair.Receiver)))
 		require.Empty(t, store.Get(legacyAddressWhitelistKey(pair.Sender, pair.Receiver)),
 			"legacy key for %s/%s still set", pair.Sender, pair.Receiver)
 	}
-	require.Len(t, collectKeys(t, store), len(pairs))
-
-	// Same no-op property as the rate limit store: a second run derives the
-	// same keys from the same values.
-	before := snapshot(t, store)
-	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
-	require.Equal(t, before, snapshot(t, store))
-}
-
-// TestMigrateWhitelistKeyCollision pins the same newKey(A) == legacyKey(B)
-// hazard for the whitelist store:
-//
-//	newKey("\x01gold", "recv-1")        = 05 01 "gold" "recv-1"
-//	legacyKey("\x05\x01gold", "recv-1") = 05 01 "gold" "recv-1"
-//
-// As in TestMigrateKeyCollision, the pair pins the iteration order that
-// actually fails: the colliding entry's legacy key (01 "gold" "recv-1") sorts
-// before the victim's (05 01 "gold" "recv-1"), so a per-entry migration
-// reaches the colliding entry while the victim is still stored under the key
-// it is about to write.
-func TestMigrateWhitelistKeyCollision(t *testing.T) {
-	ctx, storeService, cdc := setupMigrationTest(t)
-	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
-	store := prefix.NewStore(adapter, types.AddressWhitelistKeyPrefix)
-
-	colliding := types.WhitelistedAddressPair{Sender: "\x01gold", Receiver: "recv-1"}
-	victim := types.WhitelistedAddressPair{Sender: "\x05\x01gold", Receiver: "recv-1"}
-	require.Equal(t,
-		types.AddressWhitelistKey(colliding.Sender, colliding.Receiver),
-		legacyAddressWhitelistKey(victim.Sender, victim.Receiver),
-		"fixture does not reproduce the newKey(A) == legacyKey(B) collision",
-	)
-
-	pairs := []types.WhitelistedAddressPair{colliding, victim}
-	for _, pair := range pairs {
-		store.Set(legacyAddressWhitelistKey(pair.Sender, pair.Receiver), cdc.MustMarshal(&pair))
-	}
-	require.Len(t, collectKeys(t, store), len(pairs))
-
-	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
-
-	// Every pair survives under its own new key with its own value.
-	for _, pair := range pairs {
-		bz := store.Get(types.AddressWhitelistKey(pair.Sender, pair.Receiver))
-		require.NotEmpty(t, bz, "whitelist pair %q/%q lost to the key collision", pair.Sender, pair.Receiver)
-
-		var migrated types.WhitelistedAddressPair
-		require.NoError(t, cdc.Unmarshal(bz, &migrated))
-		require.Equal(t, pair, migrated)
-	}
-	require.Len(t, collectKeys(t, store), len(pairs))
 }
 
 // TestMigrateZeroLengthValue seeds an entry whose stored value is zero bytes
@@ -258,20 +174,4 @@ func collectKeys(t *testing.T, store prefix.Store) [][]byte {
 	}
 
 	return keys
-}
-
-// snapshot returns the full key -> value contents of the store, so that a
-// re-run can be compared byte for byte rather than by entry count.
-func snapshot(t *testing.T, store prefix.Store) map[string][]byte {
-	t.Helper()
-
-	iterator := store.Iterator(nil, nil)
-	defer iterator.Close()
-
-	contents := map[string][]byte{}
-	for ; iterator.Valid(); iterator.Next() {
-		contents[string(iterator.Key())] = append([]byte(nil), iterator.Value()...)
-	}
-
-	return contents
 }

--- a/modules/apps/rate-limiting/migrations/v3/migrate_test.go
+++ b/modules/apps/rate-limiting/migrations/v3/migrate_test.go
@@ -1,0 +1,277 @@
+package v3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corestore "cosmossdk.io/core/store"
+	sdkmath "cosmossdk.io/math"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/store/v2/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/migrations/v3"
+	"github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
+	ibctesting "github.com/cosmos/ibc-go/v11/testing"
+)
+
+// legacyRateLimitItemKey is the pre-v3 key layout: denom first, no separator.
+func legacyRateLimitItemKey(denom, channelOrClientID string) []byte {
+	return append([]byte(denom), channelOrClientID...)
+}
+
+// legacyAddressWhitelistKey is the pre-v3 key layout: sender||receiver, no
+// separator.
+func legacyAddressWhitelistKey(sender, receiver string) []byte {
+	return append([]byte(sender), receiver...)
+}
+
+func rateLimit(denom, channelOrClientID string) types.RateLimit {
+	return types.RateLimit{
+		Path: &types.Path{Denom: denom, ChannelOrClientId: channelOrClientID},
+		Quota: &types.Quota{
+			MaxPercentSend: sdkmath.NewInt(10),
+			MaxPercentRecv: sdkmath.NewInt(20),
+			DurationHours:  24,
+		},
+		Flow: &types.Flow{
+			Inflow:       sdkmath.NewInt(1),
+			Outflow:      sdkmath.NewInt(2),
+			ChannelValue: sdkmath.NewInt(100),
+		},
+	}
+}
+
+func setupMigrationTest(t *testing.T) (sdk.Context, corestore.KVStoreService, codec.Codec) {
+	t.Helper()
+
+	coordinator := ibctesting.NewCoordinator(t, 1)
+	chain := coordinator.GetChain(ibctesting.GetChainID(1))
+
+	return chain.GetContext(), runtime.NewKVStoreService(chain.GetSimApp().GetKey(types.StoreKey)), chain.GetSimApp().AppCodec()
+}
+
+func TestMigrateReKeysRateLimits(t *testing.T) {
+	ctx, storeService, cdc := setupMigrationTest(t)
+	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(adapter, types.RateLimitKeyPrefix)
+
+	rateLimits := []types.RateLimit{
+		rateLimit("uatom", "channel-0"),
+		rateLimit("uatom", "channel-1"),
+		rateLimit("uosmo", "channel-1"),
+		rateLimit("uosmo", "07-tendermint-0"),
+	}
+
+	for _, rl := range rateLimits {
+		store.Set(legacyRateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId), cdc.MustMarshal(&rl))
+	}
+	require.Len(t, collectKeys(t, store), len(rateLimits))
+
+	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
+
+	// Every entry is readable under its new key with its value intact, and no
+	// legacy key survives.
+	for _, rl := range rateLimits {
+		bz := store.Get(types.RateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId))
+		require.NotEmpty(t, bz, "rate limit %s/%s missing after migration", rl.Path.Denom, rl.Path.ChannelOrClientId)
+
+		var migrated types.RateLimit
+		require.NoError(t, cdc.Unmarshal(bz, &migrated))
+		require.Equal(t, rl, migrated)
+
+		require.Empty(t, store.Get(legacyRateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId)),
+			"legacy key for %s/%s still set", rl.Path.Denom, rl.Path.ChannelOrClientId)
+	}
+	require.Len(t, collectKeys(t, store), len(rateLimits))
+
+	// Migrating an already-migrated store is a byte-for-byte no-op: the new
+	// keys are derived from stored values alone, so a second run maps every
+	// entry to the key it is already under.
+	before := snapshot(t, store)
+	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
+	require.Equal(t, before, snapshot(t, store))
+}
+
+// TestMigrateKeyCollision covers the case the two-pass delete-then-set design
+// exists for: the new key of one entry equals the legacy key of another, so a
+// migration that deletes and sets per entry overwrites an entry that has not
+// been migrated yet.
+//
+// Such a collision needs a legacy denom that starts with a length byte, e.g.
+//
+//	newKey("\x01gold", "channel-1")        = 09 "channel-1" 01 "gold"
+//	legacyKey("\x09channel-1", "\x01gold") = 09 "channel-1" 01 "gold"
+//
+// Iteration order matters, and this pair pins the order that actually fails:
+// the colliding entry's legacy key (01 "gold" "channel-1") sorts before the
+// victim's (09 "channel-1" 01 "gold"), so a per-entry migration reaches the
+// colliding entry while the victim is still stored under the key it is about
+// to write. With the entries the other way round the victim would already have
+// been moved, and the bug would pass by luck.
+func TestMigrateKeyCollision(t *testing.T) {
+	ctx, storeService, cdc := setupMigrationTest(t)
+	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(adapter, types.RateLimitKeyPrefix)
+
+	colliding, victim := rateLimit("\x01gold", "channel-1"), rateLimit("\x09channel-1", "\x01gold")
+	require.Equal(t,
+		types.RateLimitItemKey(colliding.Path.Denom, colliding.Path.ChannelOrClientId),
+		legacyRateLimitItemKey(victim.Path.Denom, victim.Path.ChannelOrClientId),
+		"fixture does not reproduce the newKey(A) == legacyKey(B) collision",
+	)
+
+	rateLimits := []types.RateLimit{colliding, victim}
+	for _, rl := range rateLimits {
+		store.Set(legacyRateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId), cdc.MustMarshal(&rl))
+	}
+	require.Len(t, collectKeys(t, store), len(rateLimits))
+
+	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
+
+	// Every entry survives under its own new key with its own value.
+	for _, rl := range rateLimits {
+		bz := store.Get(types.RateLimitItemKey(rl.Path.Denom, rl.Path.ChannelOrClientId))
+		require.NotEmpty(t, bz, "rate limit %q/%q lost to the key collision", rl.Path.Denom, rl.Path.ChannelOrClientId)
+
+		var migrated types.RateLimit
+		require.NoError(t, cdc.Unmarshal(bz, &migrated))
+		require.Equal(t, rl, migrated)
+	}
+	require.Len(t, collectKeys(t, store), len(rateLimits))
+}
+
+func TestMigrateReKeysWhitelist(t *testing.T) {
+	ctx, storeService, cdc := setupMigrationTest(t)
+	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(adapter, types.AddressWhitelistKeyPrefix)
+
+	pairs := []types.WhitelistedAddressPair{
+		{Sender: "cosmos1sender", Receiver: "cosmos1receiver"},
+		{Sender: "cosmos1abc", Receiver: "cosmos1def"},
+	}
+
+	for _, pair := range pairs {
+		store.Set(legacyAddressWhitelistKey(pair.Sender, pair.Receiver), cdc.MustMarshal(&pair))
+	}
+	require.Len(t, collectKeys(t, store), len(pairs))
+
+	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
+
+	// Every pair is readable under its new key with its value intact, and no
+	// legacy key survives.
+	for _, pair := range pairs {
+		bz := store.Get(types.AddressWhitelistKey(pair.Sender, pair.Receiver))
+		require.NotEmpty(t, bz, "whitelist pair %s/%s missing after migration", pair.Sender, pair.Receiver)
+
+		var migrated types.WhitelistedAddressPair
+		require.NoError(t, cdc.Unmarshal(bz, &migrated))
+		require.Equal(t, pair, migrated)
+
+		require.Empty(t, store.Get(legacyAddressWhitelistKey(pair.Sender, pair.Receiver)),
+			"legacy key for %s/%s still set", pair.Sender, pair.Receiver)
+	}
+	require.Len(t, collectKeys(t, store), len(pairs))
+
+	// Same no-op property as the rate limit store: a second run derives the
+	// same keys from the same values.
+	before := snapshot(t, store)
+	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
+	require.Equal(t, before, snapshot(t, store))
+}
+
+// TestMigrateWhitelistKeyCollision pins the same newKey(A) == legacyKey(B)
+// hazard for the whitelist store:
+//
+//	newKey("\x01gold", "recv-1")        = 05 01 "gold" "recv-1"
+//	legacyKey("\x05\x01gold", "recv-1") = 05 01 "gold" "recv-1"
+//
+// As in TestMigrateKeyCollision, the pair pins the iteration order that
+// actually fails: the colliding entry's legacy key (01 "gold" "recv-1") sorts
+// before the victim's (05 01 "gold" "recv-1"), so a per-entry migration
+// reaches the colliding entry while the victim is still stored under the key
+// it is about to write.
+func TestMigrateWhitelistKeyCollision(t *testing.T) {
+	ctx, storeService, cdc := setupMigrationTest(t)
+	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(adapter, types.AddressWhitelistKeyPrefix)
+
+	colliding := types.WhitelistedAddressPair{Sender: "\x01gold", Receiver: "recv-1"}
+	victim := types.WhitelistedAddressPair{Sender: "\x05\x01gold", Receiver: "recv-1"}
+	require.Equal(t,
+		types.AddressWhitelistKey(colliding.Sender, colliding.Receiver),
+		legacyAddressWhitelistKey(victim.Sender, victim.Receiver),
+		"fixture does not reproduce the newKey(A) == legacyKey(B) collision",
+	)
+
+	pairs := []types.WhitelistedAddressPair{colliding, victim}
+	for _, pair := range pairs {
+		store.Set(legacyAddressWhitelistKey(pair.Sender, pair.Receiver), cdc.MustMarshal(&pair))
+	}
+	require.Len(t, collectKeys(t, store), len(pairs))
+
+	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
+
+	// Every pair survives under its own new key with its own value.
+	for _, pair := range pairs {
+		bz := store.Get(types.AddressWhitelistKey(pair.Sender, pair.Receiver))
+		require.NotEmpty(t, bz, "whitelist pair %q/%q lost to the key collision", pair.Sender, pair.Receiver)
+
+		var migrated types.WhitelistedAddressPair
+		require.NoError(t, cdc.Unmarshal(bz, &migrated))
+		require.Equal(t, pair, migrated)
+	}
+	require.Len(t, collectKeys(t, store), len(pairs))
+}
+
+// TestMigrateZeroLengthValue seeds an entry whose stored value is zero bytes
+// (a zero-value WhitelistedAddressPair marshals to nothing): the migration's
+// value copy must stay non-nil empty, since store.Set panics on a nil value.
+func TestMigrateZeroLengthValue(t *testing.T) {
+	ctx, storeService, cdc := setupMigrationTest(t)
+	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(adapter, types.AddressWhitelistKeyPrefix)
+
+	value := cdc.MustMarshal(&types.WhitelistedAddressPair{})
+	require.Empty(t, value)
+	store.Set([]byte("legacy-key"), value)
+
+	require.NoError(t, v3.Migrate(ctx, storeService, cdc))
+
+	keys := collectKeys(t, store)
+	require.Len(t, keys, 1)
+	require.Equal(t, types.AddressWhitelistKey("", ""), keys[0])
+}
+
+func collectKeys(t *testing.T, store prefix.Store) [][]byte {
+	t.Helper()
+
+	iterator := store.Iterator(nil, nil)
+	defer iterator.Close()
+
+	var keys [][]byte
+	for ; iterator.Valid(); iterator.Next() {
+		keys = append(keys, append([]byte(nil), iterator.Key()...))
+	}
+
+	return keys
+}
+
+// snapshot returns the full key -> value contents of the store, so that a
+// re-run can be compared byte for byte rather than by entry count.
+func snapshot(t *testing.T, store prefix.Store) map[string][]byte {
+	t.Helper()
+
+	iterator := store.Iterator(nil, nil)
+	defer iterator.Close()
+
+	contents := map[string][]byte{}
+	for ; iterator.Valid(); iterator.Next() {
+		contents[string(iterator.Key())] = append([]byte(nil), iterator.Value()...)
+	}
+
+	return contents
+}

--- a/modules/apps/rate-limiting/module.go
+++ b/modules/apps/rate-limiting/module.go
@@ -113,6 +113,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	if err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2); err != nil {
 		panic(fmt.Sprintf("failed to migrate x/%s from version 1 to 2: %v", types.ModuleName, err))
 	}
+	if err := cfg.RegisterMigration(types.ModuleName, 2, m.Migrate2to3); err != nil {
+		panic(fmt.Sprintf("failed to migrate x/%s from version 2 to 3: %v", types.ModuleName, err))
+	}
 }
 
 // InitGenesis performs genesis initialization for the rate-limiting module. It returns
@@ -131,7 +134,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion defining the current version of rate-limiting.
-func (AppModule) ConsensusVersion() uint64 { return 2 }
+func (AppModule) ConsensusVersion() uint64 { return 3 }
 
 // BeginBlock implements the AppModule interface
 func (am AppModule) BeginBlock(ctx context.Context) error {

--- a/modules/apps/rate-limiting/types/keys.go
+++ b/modules/apps/rate-limiting/types/keys.go
@@ -43,23 +43,11 @@ var (
 	PendingSendPacketChannelLength = 64
 )
 
-// RateLimitItemKey returns the rate limit key for a (denom, channelOrClientID)
-// pair. The layout is:
+// RateLimitItemKey returns an unambiguous key for a (denom, channelOrClientID) pair:
 //
 //	uvarint(len(channelOrClientID)) || channelOrClientID || denom
 //
-// Channel/client first so that all rate limits for a channel or client are a
-// contiguous range (the same channel-then-denom field order as the pending
-// packet collections, though not the same byte order: the uvarint prefix
-// groups identifiers by length before comparing bytes, while
-// collections.StringKey sorts lexicographically), and length prefixed so that
-// distinct pairs can never concatenate to the same key.
-//
-// The uvarint is self-delimiting, so the encoding stays unambiguous for any
-// identifier length, with no ceiling to enforce. Nothing in this module bounds
-// identifier length (msgs only shape-check channel and client IDs, and genesis
-// does not validate them), but every length below 128 encodes to the same
-// single byte a fixed-width uint8 prefix would produce.
+// Channel-first ordering groups a channel or client's rate limits by prefix.
 func RateLimitItemKey(denom string, channelOrClientID string) []byte {
 	key := binary.AppendUvarint(make([]byte, 0, 1+len(channelOrClientID)+len(denom)), uint64(len(channelOrClientID)))
 	key = append(key, channelOrClientID...)
@@ -83,14 +71,9 @@ func PendingPacketKey(channelID string, sequenceNumber uint64) ([]byte, error) {
 	return append(channelIDBz, sequenceNumberBz...), nil
 }
 
-// AddressWhitelistKey returns the whitelist key for a (sender, receiver)
-// address pair. The layout is:
+// AddressWhitelistKey returns an unambiguous key for a (sender, receiver) pair:
 //
 //	uvarint(len(sender)) || sender || receiver
-//
-// Length prefixed so that distinct pairs can never concatenate to the same
-// key; the uvarint is self-delimiting, so the encoding stays unambiguous for
-// any address length.
 func AddressWhitelistKey(sender, receiver string) []byte {
 	key := binary.AppendUvarint(make([]byte, 0, 1+len(sender)+len(receiver)), uint64(len(sender)))
 	key = append(key, sender...)

--- a/modules/apps/rate-limiting/types/keys.go
+++ b/modules/apps/rate-limiting/types/keys.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/binary"
-	"math"
 
 	"cosmossdk.io/collections"
 )
@@ -77,21 +76,15 @@ func AddressWhitelistKey(sender, receiver string) []byte {
 	return lengthPrefixedKey(sender, receiver)
 }
 
+// lengthPrefixedKey returns uvarint(len(first)) || first || second.
+//
+// Grown by append rather than sized up front on purpose: a make() capacity
+// computed from the argument lengths trips CodeQL go/allocation-size-overflow,
+// and bounding that computation with a panic trips beginendblock-panic, since
+// BeginBlocker builds these keys and must never halt the chain. The extra
+// allocations are noise next to the store read that follows.
 func lengthPrefixedKey(first, second string) []byte {
-	var prefix [binary.MaxVarintLen64]byte
-	prefixLen := binary.PutUvarint(prefix[:], uint64(len(first)))
-
-	if len(first) > math.MaxInt-prefixLen {
-		panic("key length overflow")
-	}
-	keyLen := prefixLen + len(first)
-	if len(second) > math.MaxInt-keyLen {
-		panic("key length overflow")
-	}
-	keyLen += len(second)
-
-	key := make([]byte, 0, keyLen)
-	key = append(key, prefix[:prefixLen]...)
+	key := binary.AppendUvarint(nil, uint64(len(first)))
 	key = append(key, first...)
 	return append(key, second...)
 }

--- a/modules/apps/rate-limiting/types/keys.go
+++ b/modules/apps/rate-limiting/types/keys.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/binary"
+	"math"
 
 	"cosmossdk.io/collections"
 )
@@ -49,9 +50,7 @@ var (
 //
 // Channel-first ordering groups a channel or client's rate limits by prefix.
 func RateLimitItemKey(denom string, channelOrClientID string) []byte {
-	key := binary.AppendUvarint(make([]byte, 0, 1+len(channelOrClientID)+len(denom)), uint64(len(channelOrClientID)))
-	key = append(key, channelOrClientID...)
-	return append(key, denom...)
+	return lengthPrefixedKey(channelOrClientID, denom)
 }
 
 // Get the pending packet key from the channel ID and sequence number
@@ -75,7 +74,24 @@ func PendingPacketKey(channelID string, sequenceNumber uint64) ([]byte, error) {
 //
 //	uvarint(len(sender)) || sender || receiver
 func AddressWhitelistKey(sender, receiver string) []byte {
-	key := binary.AppendUvarint(make([]byte, 0, 1+len(sender)+len(receiver)), uint64(len(sender)))
-	key = append(key, sender...)
-	return append(key, receiver...)
+	return lengthPrefixedKey(sender, receiver)
+}
+
+func lengthPrefixedKey(first, second string) []byte {
+	var prefix [binary.MaxVarintLen64]byte
+	prefixLen := binary.PutUvarint(prefix[:], uint64(len(first)))
+
+	if len(first) > math.MaxInt-prefixLen {
+		panic("key length overflow")
+	}
+	keyLen := prefixLen + len(first)
+	if len(second) > math.MaxInt-keyLen {
+		panic("key length overflow")
+	}
+	keyLen += len(second)
+
+	key := make([]byte, 0, keyLen)
+	key = append(key, prefix[:prefixLen]...)
+	key = append(key, first...)
+	return append(key, second...)
 }

--- a/modules/apps/rate-limiting/types/keys.go
+++ b/modules/apps/rate-limiting/types/keys.go
@@ -43,9 +43,27 @@ var (
 	PendingSendPacketChannelLength = 64
 )
 
-// Get the rate limit byte key built from the denom and channelId
-func RateLimitItemKey(denom string, channelID string) []byte {
-	return append(bytes(denom), bytes(channelID)...)
+// RateLimitItemKey returns the rate limit key for a (denom, channelOrClientID)
+// pair. The layout is:
+//
+//	uvarint(len(channelOrClientID)) || channelOrClientID || denom
+//
+// Channel/client first so that all rate limits for a channel or client are a
+// contiguous range (the same channel-then-denom field order as the pending
+// packet collections, though not the same byte order: the uvarint prefix
+// groups identifiers by length before comparing bytes, while
+// collections.StringKey sorts lexicographically), and length prefixed so that
+// distinct pairs can never concatenate to the same key.
+//
+// The uvarint is self-delimiting, so the encoding stays unambiguous for any
+// identifier length, with no ceiling to enforce. Nothing in this module bounds
+// identifier length (msgs only shape-check channel and client IDs, and genesis
+// does not validate them), but every length below 128 encodes to the same
+// single byte a fixed-width uint8 prefix would produce.
+func RateLimitItemKey(denom string, channelOrClientID string) []byte {
+	key := binary.AppendUvarint(make([]byte, 0, 1+len(channelOrClientID)+len(denom)), uint64(len(channelOrClientID)))
+	key = append(key, channelOrClientID...)
+	return append(key, denom...)
 }
 
 // Get the pending packet key from the channel ID and sequence number
@@ -65,7 +83,16 @@ func PendingPacketKey(channelID string, sequenceNumber uint64) ([]byte, error) {
 	return append(channelIDBz, sequenceNumberBz...), nil
 }
 
-// Get the whitelist path key from a sender and receiver address
+// AddressWhitelistKey returns the whitelist key for a (sender, receiver)
+// address pair. The layout is:
+//
+//	uvarint(len(sender)) || sender || receiver
+//
+// Length prefixed so that distinct pairs can never concatenate to the same
+// key; the uvarint is self-delimiting, so the encoding stays unambiguous for
+// any address length.
 func AddressWhitelistKey(sender, receiver string) []byte {
-	return append(bytes(sender), bytes(receiver)...)
+	key := binary.AppendUvarint(make([]byte, 0, 1+len(sender)+len(receiver)), uint64(len(sender)))
+	key = append(key, sender...)
+	return append(key, receiver...)
 }

--- a/modules/apps/rate-limiting/types/keys_test.go
+++ b/modules/apps/rate-limiting/types/keys_test.go
@@ -1,0 +1,68 @@
+package types_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
+)
+
+// TestRateLimitItemKeyLayout pins the on-disk key bytes, which are state
+// machine breaking to change. The uvarint length prefix of "channel-1" (9
+// bytes) is the single byte 0x09: every length below 128 encodes to one byte.
+func TestRateLimitItemKeyLayout(t *testing.T) {
+	require.Equal(t, []byte("\x09channel-1uatom"), types.RateLimitItemKey("uatom", "channel-1"))
+}
+
+// TestRateLimitItemKeyTwoByteLength pins the layout at 128, the first
+// identifier length whose uvarint prefix is two bytes (0x80 0x01), so a
+// fixed-width single-byte length prefix cannot silently pass.
+func TestRateLimitItemKeyTwoByteLength(t *testing.T) {
+	longID := strings.Repeat("c", 128)
+	expected := append([]byte("\x80\x01"), longID...)
+	expected = append(expected, "uatom"...)
+	require.Equal(t, expected, types.RateLimitItemKey("uatom", longID))
+}
+
+// TestRateLimitItemKeyUnambiguous covers a pair that collided under the old
+// denom-first, separator-less layout, and a pair that would collide under a
+// channel-first layout without the length prefix.
+func TestRateLimitItemKeyUnambiguous(t *testing.T) {
+	require.NotEqual(
+		t,
+		types.RateLimitItemKey("uatom", "channel-1"),
+		types.RateLimitItemKey("uatomchannel", "-1"),
+	)
+	require.NotEqual(
+		t,
+		types.RateLimitItemKey("", "channel-10"),
+		types.RateLimitItemKey("0", "channel-1"),
+	)
+}
+
+func TestRateLimitItemKeyChannelFirst(t *testing.T) {
+	// All rate limits for a channel share the channel-scoped prefix.
+	prefix := types.RateLimitItemKey("", "channel-1")
+	require.True(t, bytes.HasPrefix(types.RateLimitItemKey("uatom", "channel-1"), prefix))
+	require.False(t, bytes.HasPrefix(types.RateLimitItemKey("uatom", "channel-10"), prefix))
+}
+
+// TestAddressWhitelistKeyLayout pins the on-disk key bytes, which are state
+// machine breaking to change. The uvarint length prefix of "sender" (6 bytes)
+// is the single byte 0x06.
+func TestAddressWhitelistKeyLayout(t *testing.T) {
+	require.Equal(t, []byte("\x06senderreceiver"), types.AddressWhitelistKey("sender", "receiver"))
+}
+
+// TestAddressWhitelistKeyUnambiguous covers a pair that collided under the old
+// sender||receiver separator-less layout.
+func TestAddressWhitelistKeyUnambiguous(t *testing.T) {
+	require.NotEqual(
+		t,
+		types.AddressWhitelistKey("cosmos1a", "bcosmos1c"),
+		types.AddressWhitelistKey("cosmos1ab", "cosmos1c"),
+	)
+}


### PR DESCRIPTION
## Description

The rate-limit module currently concatenates variable-length key components without a boundary:

- rate limits: `denom || channelOrClientID`
- address whitelist: `sender || receiver`

Distinct pairs can therefore resolve to identical store keys.

This PR:

- uses unambiguous length-prefixed encodings for both key types;
- places the channel/client identifier first so its rate limits share a prefix;
- adds a v2-to-v3 store migration that derives new keys from stored values;
- registers the migration and bumps the module consensus version to 3.

The migration deletes legacy keys before writing new keys so a new key cannot overwrite an entry that has not been migrated yet.

## Testing

- `make tidy-all`
- `make build`
- `make lint` — exited 0; reported existing repository-wide `goconst`/`govet` findings outside this diff
- `make test-unit`

---

- [x] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work. — No linked issue; this addresses ambiguous on-disk keys identified during review.
- [x] Include changelog entry when appropriate.
- [x] Wrote unit and integration tests if relevant.
- [x] Updated documentation (`docs/`) if anything is changed. — N/A: internal store encoding; changelog and GoDoc are updated.
- [x] Added GoDoc comments if relevant.
- [x] Self-reviewed `Files changed`.
- [x] Provide a conventional commit message to follow the repository standards.

Proposed squash commit:

```
imp(statemachine)!: use unambiguous rate-limit keys
```

Closes FOU-1197
