### PR TITLE
ci: bind simd image ibc-go-version via env before shell

### DIFF
--- a/.github/workflows/build-simd-image-from-tag.yml
+++ b/.github/workflows/build-simd-image-from-tag.yml
@@ -40,8 +40,10 @@ jobs:
               username: ${{ github.actor }}
               password: ${{ secrets.GITHUB_TOKEN }}
          - name: Build and push image
+           env:
+             IBC_GO_VERSION: ${{ inputs.ibc-go-version }}
            run: |
             # remove any `/` characters from the docker tag and replace them with a -
             docker_tag="$(echo $GIT_TAG | sed 's/[^a-zA-Z0-9\.]/-/g')"
-            docker build . -t "${REGISTRY}/${ORG}/${IMAGE_NAME}:${docker_tag}" --build-arg IBC_GO_VERSION=${{ inputs.ibc-go-version }}
+            docker build . -t "${REGISTRY}/${ORG}/${IMAGE_NAME}:${docker_tag}" --build-arg "IBC_GO_VERSION=${IBC_GO_VERSION}"
             docker push "${REGISTRY}/${ORG}/${IMAGE_NAME}:${docker_tag}"


### PR DESCRIPTION
## Summary
- Bind `inputs.ibc-go-version` through `env:` before the `docker build --build-arg` shell step in `build-simd-image-from-tag.yml`.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] simd image build still passes the configured IBC_GO_VERSION build-arg
- [ ] Image tag sanitization and push behavior unchanged


Made with [Cursor](https://cursor.com)